### PR TITLE
On the live release page, breadcrumb should be assumed version number and not the branch name

### DIFF
--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -23,7 +23,7 @@ crumb :step do |step|
 end
 
 crumb :release do |release|
-  link release.branch_name, app_train_releases_path(release.train.app, release.train)
+  link release.release_version, app_train_releases_path(release.train.app, release.train)
   parent :train, release.train
 end
 


### PR DESCRIPTION
Fixes #64
