### PR TITLE
Add transactions around work done in post-release steps

### DIFF
--- a/app/libs/services/post_release/almost_trunk.rb
+++ b/app/libs/services/post_release/almost_trunk.rb
@@ -1,5 +1,7 @@
 class Services::PostRelease
   class AlmostTrunk
+    delegate :transaction, to: ApplicationRecord
+
     def self.call(release)
       new(release).call
     end
@@ -10,8 +12,10 @@ class Services::PostRelease
     end
 
     def call
-      update_status
-      create_tag
+      transaction do
+        update_status
+        create_tag
+      end
     end
 
     private


### PR DESCRIPTION
So that API failures don't cause sanity issues against DB state.

Example:

* PR could not be created (for whatever reason)
* But status got updated in the DB under finalization

Eventually, proper error cases should be handled within this transaction.