### PR TITLE
Change store status refresh action to a post

### DIFF
--- a/app/components/external_app_component.html.erb
+++ b/app/components/external_app_component.html.erb
@@ -5,7 +5,7 @@
   </div>
   <% if external_app %>
     <div class="text-left">
-      <%= decorated_button_to :neutral, refresh_external_app_path(app), method: :get do %>
+      <%= decorated_button_to :neutral, refresh_external_app_path(app), method: :post do %>
         <%= inline_svg('refresh.svg', classname: "inline-flex w-4") %>
       <% end %>
     </div>

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -69,6 +69,8 @@ class AppsController < SignedInApplicationController
 
   def refresh_external
     @app.create_external!
+
+    redirect_to app_path(@app), notice: "Store status was successfully refreshed."
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
 
     member do
       get :all_builds
-      get :refresh_external
+      post :refresh_external
     end
 
     resources :trains, only: %i[new create edit update show destroy] do


### PR DESCRIPTION
## Because

Refreshing store status creates a new store status on the backend.

## This addresses

This also fixes the ambiguity of redirecting after the action is completed. Earlier, the redirect was implicit.
