### PR TITLE
Add view components for page and table

### DIFF
--- a/app/components/external_app_component.html.erb
+++ b/app/components/external_app_component.html.erb
@@ -1,58 +1,48 @@
-<div class="flex justify-between items-end w-3/4">
-  <div>
-    <h2 class="text-2xl text-slate-800 font-bold">Current Store Status</h2>
-    <span class="text-sm text-slate-400"><%= subtitle %></span>
-  </div>
-  <% if external_app %>
-    <div class="text-left">
-      <%= decorated_button_to :neutral, refresh_external_app_path(app), method: :post do %>
-        <%= inline_svg('refresh.svg', classname: "inline-flex w-4") %>
+<%= render TableComponent.new(columns: column_names) do |table| %>
+  <% table.with_header do %>
+    <div class="flex justify-between w-full items-center">
+      <div>
+        <h2 class="text-2xl text-slate-800 font-bold">Current Store Status</h2>
+        <span class="text-sm text-slate-400"><%= subtitle %></span>
+      </div>
+      <% if external_app %>
+        <div class="text-left">
+          <%= decorated_button_to :neutral, refresh_external_app_path(app), method: :get do %>
+            <%= inline_svg('refresh.svg', classname: "inline-flex w-4") %>
+          <% end %>
+        </div>
       <% end %>
     </div>
   <% end %>
-</div>
-<% if external_app.present? %>
-  <table class="table-auto w-3/4">
-    <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
-    <tr>
-      <th class="px-2 first:pl-5 last:pr-5 py-2 whitespace-nowrap">
-        <div class="font-semibold text-left">Channel Name</div>
-      </th>
-      <th class="px-2 first:pl-5 last:pr-5 py-2 whitespace-nowrap">
-        <div class="font-semibold text-left">Current Releases</div>
-      </th>
-    </tr>
-    </thead>
-    <tbody class="text-sm divide-y divide-slate-200">
-    <% channels.each do |channel| %>
-      <tr>
-        <td class="px-2 first:pl-5 last:pr-5 py-2 whitespace-nowrap">
-          <span><%= channel_name channel %></span>
-        </td>
-        <td class="px-2 first:pl-5 last:pr-5 py-2 whitespace-nowrap">
-          <% releases(channel).each do |release| %>
-            <div class="mx-2">
-              <div class="flex justify-between text-sm mb-2">
-                <div>
-                  <%= release_description(release) %>
-                  <%= release_status(release) %>
-                </div>
-                <% if release[:user_fraction] %>
-                  <div class="italic"><%= release_fraction_title(release) %></div>
-                <% end %>
+
+  <% channels.each do |channel| %>
+    <% table.with_row do |row| %>
+      <% row.with_cell do %>
+        <span><%= channel_name channel %></span>
+      <% end %>
+
+      <% row.with_cell do %>
+        <% releases(channel).each do |release| %>
+          <div class="mx-2">
+            <div class="flex justify-between text-sm mb-2">
+              <div>
+                <%= release_description(release) %>
+                <%= release_status(release) %>
               </div>
               <% if release[:user_fraction] %>
-                <div class="border-slate-200">
-                  <div class="relative w-full h-2 bg-slate-300">
-                    <div class="absolute inset-0 bg-emerald-500" aria-hidden="true" style="width: <%= release_fraction_width(release) %>"></div>
-                  </div>
-                </div>
+                <div class="italic"><%= release_fraction_title(release) %></div>
               <% end %>
             </div>
-          <% end %>
-        </td>
-      </tr>
+            <% if release[:user_fraction] %>
+              <div class="border-slate-200">
+                <div class="relative w-full h-2 bg-slate-300">
+                  <div class="absolute inset-0 bg-emerald-500" aria-hidden="true" style="width: <%= release_fraction_width(release) %>"></div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
     <% end %>
-    </tbody>
-  </table>
+  <% end %>
 <% end %>

--- a/app/components/external_app_component.html.erb
+++ b/app/components/external_app_component.html.erb
@@ -15,32 +15,34 @@
     </div>
   <% end %>
 
-  <% channels.each do |channel| %>
-    <% table.with_row do |row| %>
-      <% row.with_cell do %>
-        <span><%= channel_name channel %></span>
-      <% end %>
+  <% if external_app %>
+    <% channels.each do |channel| %>
+      <% table.with_row do |row| %>
+        <% row.with_cell do %>
+          <span><%= channel_name channel %></span>
+        <% end %>
 
-      <% row.with_cell do %>
-        <% releases(channel).each do |release| %>
-          <div class="mx-2">
-            <div class="flex justify-between text-sm mb-2">
-              <div>
-                <%= release_description(release) %>
-                <%= release_status(release) %>
+        <% row.with_cell do %>
+          <% releases(channel).each do |release| %>
+            <div class="mx-2">
+              <div class="flex justify-between text-sm mb-2">
+                <div>
+                  <%= release_description(release) %>
+                  <%= release_status(release) %>
+                </div>
+                <% if release[:user_fraction] %>
+                  <div class="italic"><%= release_fraction_title(release) %></div>
+                <% end %>
               </div>
               <% if release[:user_fraction] %>
-                <div class="italic"><%= release_fraction_title(release) %></div>
+                <div class="border-slate-200">
+                  <div class="relative w-full h-2 bg-slate-300">
+                    <div class="absolute inset-0 bg-emerald-500" aria-hidden="true" style="width: <%= release_fraction_width(release) %>"></div>
+                  </div>
+                </div>
               <% end %>
             </div>
-            <% if release[:user_fraction] %>
-              <div class="border-slate-200">
-                <div class="relative w-full h-2 bg-slate-300">
-                  <div class="absolute inset-0 bg-emerald-500" aria-hidden="true" style="width: <%= release_fraction_width(release) %>"></div>
-                </div>
-              </div>
-            <% end %>
-          </div>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/external_app_component.html.erb
+++ b/app/components/external_app_component.html.erb
@@ -1,5 +1,5 @@
 <%= render TableComponent.new(columns: column_names) do |table| %>
-  <% table.with_header do %>
+  <% table.with_heading do %>
     <div class="flex justify-between w-full items-center">
       <div>
         <h2 class="text-2xl text-slate-800 font-bold">Current Store Status</h2>

--- a/app/components/external_app_component.rb
+++ b/app/components/external_app_component.rb
@@ -12,6 +12,10 @@ class ExternalAppComponent < ViewComponent::Base
 
   private
 
+  def column_names
+    ["Channel Name", "Current Releases"]
+  end
+
   def subtitle
     return "Last changed #{ago_in_words external_app.fetched_at}" if external_app
     return "Fetching..." if app.has_store_integration?

--- a/app/components/page_component.html.erb
+++ b/app/components/page_component.html.erb
@@ -1,0 +1,17 @@
+<% breadcrumb %>
+
+<div class="sm:flex sm:justify-between sm:items-center border-b border-slate-200 pb-8 mb-8">
+  <!-- Left: Title -->
+  <h1 class="text-2xl md:text-3xl text-slate-800 font-bold"><%= page_title %></h1>
+
+  <!-- Left: Actions -->
+  <div class="grid grid-flow-col sm:auto-cols-max justify-start sm:justify-end gap-2">
+    <% actions.each do |action| %>
+      <%= action %>
+    <% end %>
+  </div>
+</div>
+
+<section>
+  <%= content %>
+</section>

--- a/app/components/page_component.rb
+++ b/app/components/page_component.rb
@@ -1,0 +1,10 @@
+class PageComponent < ViewComponent::Base
+  renders_many :actions
+
+  def initialize(breadcrumb: nil, title:)
+    @breadcrumb = breadcrumb
+    @page_title = title
+  end
+
+  attr_reader :breadcrumb, :page_title
+end

--- a/app/components/page_component.rb
+++ b/app/components/page_component.rb
@@ -1,7 +1,7 @@
 class PageComponent < ViewComponent::Base
   renders_many :actions
 
-  def initialize(breadcrumb: nil, title:)
+  def initialize(title:, breadcrumb: nil)
     @breadcrumb = breadcrumb
     @page_title = title
   end

--- a/app/components/table_component.html.erb
+++ b/app/components/table_component.html.erb
@@ -1,6 +1,6 @@
 <div>
   <header class="border-b border-slate-100 h-16">
-    <%= header %>
+    <%= heading %>
   </header>
   <div class="overflow-x-auto">
     <table class="table-auto w-full">

--- a/app/components/table_component.html.erb
+++ b/app/components/table_component.html.erb
@@ -1,7 +1,9 @@
 <div>
-  <header class="border-b border-slate-100 h-16">
-    <%= heading %>
-  </header>
+  <% if heading %>
+    <header class="border-b border-slate-100 h-16">
+      <%= heading %>
+    </header>
+  <% end %>
   <div class="overflow-x-auto">
     <table class="table-auto w-full">
       <thead class="text-xs uppercase text-slate-400 bg-slate-50 rounded-sm">

--- a/app/components/table_component.html.erb
+++ b/app/components/table_component.html.erb
@@ -1,0 +1,23 @@
+<div>
+  <header class="border-b border-slate-100 h-16">
+    <%= header %>
+  </header>
+  <div class="overflow-x-auto">
+    <table class="table-auto w-full">
+      <thead class="text-xs uppercase text-slate-400 bg-slate-50 rounded-sm">
+      <tr>
+        <% columns.each do |column| %>
+          <th class="p-2 whitespace-nowrap">
+            <div class="font-semibold text-left"><%= column %></div>
+          </th>
+        <% end %>
+      </tr>
+      </thead>
+      <tbody class="text-sm divide-y divide-slate-100">
+      <% rows.each do |row| %>
+        <%= row %>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/components/table_component.rb
+++ b/app/components/table_component.rb
@@ -1,0 +1,10 @@
+class TableComponent < ViewComponent::Base
+  renders_one :header
+  renders_many :rows, TableComponent::RowComponent
+
+  def initialize(columns:)
+    @columns = columns
+  end
+
+  attr_reader :columns
+end

--- a/app/components/table_component.rb
+++ b/app/components/table_component.rb
@@ -1,5 +1,5 @@
 class TableComponent < ViewComponent::Base
-  renders_one :header
+  renders_one :heading
   renders_many :rows, TableComponent::RowComponent
 
   def initialize(columns:)

--- a/app/components/table_component/row_component.html.erb
+++ b/app/components/table_component/row_component.html.erb
@@ -1,0 +1,5 @@
+<tr>
+  <% cells.each do |cell| %>
+    <%= cell %>
+  <% end %>
+</tr>

--- a/app/components/table_component/row_component.rb
+++ b/app/components/table_component/row_component.rb
@@ -1,0 +1,9 @@
+class TableComponent::RowComponent < ViewComponent::Base
+  renders_many :cells, "CellComponent"
+
+  class CellComponent < ViewComponent::Base
+    def call
+      content_tag :td, content, {class: "p-2.5 whitespace-nowrap"}
+    end
+  end
+end

--- a/app/views/accounts/invitations/new.html.erb
+++ b/app/views/accounts/invitations/new.html.erb
@@ -1,32 +1,30 @@
-<%= form_with(model: @invite,
-              url: accounts_organization_invitations_path(@invite.organization, @invite),
-              builder: ButtonHelper::AuthzForms,
-              html: { method: :post }) do |form| %>
-  <%= render "shared/errors", resource: @invite %>
+<%= render PageComponent.new(title: "Add a member to your team 📱") do %>
+  <%= form_with(model: @invite,
+                url: accounts_organization_invitations_path(@invite.organization, @invite),
+                builder: ButtonHelper::AuthzForms,
+                html: { method: :post }) do |form| %>
+    <%= render "shared/errors", resource: @invite %>
 
-  <div class="mb-8">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Add a member to your team 📱</h1>
-  </div>
+    <div class="space-y-4">
+      <%= form.hidden_field :organization_id, value: @invite.organization.id %>
 
-  <div class="space-y-4">
-    <%= form.hidden_field :organization_id, value: @invite.organization.id %>
+      <div>
+        <%= form.label :email, class: "block text-sm font-medium mb-1" %>
+        <%= form.email_field :email, autofocus: true, autocomplete: "email", class: "form-input w-full" %>
+      </div>
 
-    <div>
-      <%= form.label :email, class: "block text-sm font-medium mb-1" %>
-      <%= form.email_field :email, autofocus: true, autocomplete: "email", class: "form-input w-full" %>
+      <div>
+        <%= form.label :role, class: "block text-sm font-medium mb-1" %>
+        <%= form.select :role,
+                        options_for_select(Accounts::Membership.allowed_roles, "developer"),
+                        { required: true },
+                        { class: "form-input w-full mb-1" } %>
+      </div>
+
+      <div class="mt-5">
+        <!-- Start -->
+        <%= form.authz_submit :blue, "Create" %>
+      </div>
     </div>
-
-    <div>
-      <%= form.label :role, class: "block text-sm font-medium mb-1" %>
-      <%= form.select :role,
-                      options_for_select(Accounts::Membership.allowed_roles, "developer"),
-                      { required: true },
-                      { class: "form-input w-full mb-1" } %>
-    </div>
-
-    <div class="mt-5">
-      <!-- Start -->
-      <%= form.authz_submit :blue, "Create" %>
-    </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/accounts/organizations/index.html.erb
+++ b/app/views/accounts/organizations/index.html.erb
@@ -1,39 +1,18 @@
-<div class="sm:flex sm:justify-between sm:items-center mb-8">
-  <div class="mb-4 sm:mb-0">
+<%= render TableComponent.new(columns: ["Name", "Actions"]) do |table| %>
+  <% table.with_header do %>
     <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Memberships 🏢</h1>
-  </div>
-</div>
-
-<table class="table-auto w-full">
-  <!-- Table header -->
-  <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
-  <tr>
-    <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-      <div class="font-semibold text-left">Name</div>
-    </th>
-    <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-      <div class="font-semibold text-left">Actions</div>
-    </th>
-  </tr>
-  </thead>
-  <!-- Table body -->
-  <tbody class="text-sm divide-y divide-slate-200">
-  <!-- Row -->
-  <% @organizations.each do |org| %>
-    <tr>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="flex items-center">
-          <div class="font-medium text-slate-800">
-            <%= org.name %>
-          </div>
-        </div>
-      </td>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="text-left">
-          <%= decorated_button_to :neutral, "Switch", switch_accounts_organization_path(org), method: :get %>
-        </div>
-      </td>
-    </tr>
   <% end %>
-  </tbody>
-</table>
+
+  <% @organizations.each do |org| %>
+    <% table.with_row do |row| %>
+      <% row.with_cell do %>
+        <div class="font-medium text-slate-800">
+          <%= org.name %>
+        </div>
+      <% end %>
+      <% row.with_cell do %>
+        <%= decorated_button_to :neutral, "Switch", switch_accounts_organization_path(org), method: :get %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/accounts/organizations/index.html.erb
+++ b/app/views/accounts/organizations/index.html.erb
@@ -1,17 +1,15 @@
-<%= render TableComponent.new(columns: ["Name", "Actions"]) do |table| %>
-  <% table.with_heading do %>
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Memberships 🏢</h1>
-  <% end %>
-
-  <% @organizations.each do |org| %>
-    <% table.with_row do |row| %>
-      <% row.with_cell do %>
-        <div class="font-medium text-slate-800">
-          <%= org.name %>
-        </div>
-      <% end %>
-      <% row.with_cell do %>
-        <%= decorated_button_to :neutral, "Switch", switch_accounts_organization_path(org), method: :get %>
+<%= render PageComponent.new(title: "Memberships 🏢") do %>
+  <%= render TableComponent.new(columns: ["Name", "Actions"]) do |table| %>
+    <% @organizations.each do |org| %>
+      <% table.with_row do |row| %>
+        <% row.with_cell do %>
+          <div class="font-medium text-slate-800">
+            <%= org.name %>
+          </div>
+        <% end %>
+        <% row.with_cell do %>
+          <%= decorated_button_to :neutral, "Switch", switch_accounts_organization_path(org), method: :get %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/accounts/organizations/index.html.erb
+++ b/app/views/accounts/organizations/index.html.erb
@@ -1,5 +1,5 @@
 <%= render TableComponent.new(columns: ["Name", "Actions"]) do |table| %>
-  <% table.with_header do %>
+  <% table.with_heading do %>
     <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Memberships 🏢</h1>
   <% end %>
 

--- a/app/views/accounts/teams/show.html.erb
+++ b/app/views/accounts/teams/show.html.erb
@@ -1,69 +1,62 @@
-<%= render TableComponent.new(columns: ["Email", "Status", "Preferred Name", "Full Name", "Role"]) do |table| %>
-  <% table.with_heading do %>
-    <div class="sm:flex sm:justify-between sm:items-center mb-8">
-      <!-- Left: Title -->
-      <div class="mb-4 sm:mb-0">
-        <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Team ‍👫</h1>
-      </div>
-
-      <div class="grid grid-flow-col sm:auto-cols-max justify-start sm:justify-end gap-2">
-        <%= authz_link_to :green, new_accounts_organization_invitation_path(current_organization) do %>
-          <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
-          <span class="hidden xs:block ml-2">
+<%= render PageComponent.new(title: "Team ‍👫") do |page| %>
+  <% page.with_action do %>
+    <%= authz_link_to :green, new_accounts_organization_invitation_path(current_organization) do %>
+      <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
+      <span class="hidden xs:block ml-2">
         Add team member
       </span>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
-
-  <% @team.each do |member| %>
-    <% table.with_row do |row| %>
-      <% row.with_cell do %>
-        <div class="font-medium text-slate-800">
-          <%= member.email %>
-        </div>
-      <% end %>
-      <% row.with_cell do %>
-        <div class="text-xs inline-flex font-medium bg-emerald-100 text-slate-500 rounded-full text-center px-2.5 py-1">
-          Active
-        </div>
-      <% end %>
-      <% row.with_cell do %>
-        <%= member.preferred_name %>
-      <% end %>
-      <% row.with_cell do %>
-        <%= member.full_name %>
-      <% end %>
-      <% row.with_cell do %>
-        <%= member.role_for(current_organization).titleize %>
-      <% end %>
     <% end %>
   <% end %>
-  <% @invited_team.each do |invite| %>
-    <% table.with_row do |row| %>
-      <% row.with_cell do %>
-        <div class="font-medium text-slate-800">
-          <%= invite.email %>
-        </div>
+
+  <%= render TableComponent.new(columns: ["Email", "Status", "Preferred Name", "Full Name", "Role"]) do |table| %>
+    <% @team.each do |member| %>
+      <% table.with_row do |row| %>
+        <% row.with_cell do %>
+          <div class="font-medium text-slate-800">
+            <%= member.email %>
+          </div>
+        <% end %>
+        <% row.with_cell do %>
+          <div class="text-xs inline-flex font-medium bg-emerald-100 text-slate-500 rounded-full text-center px-2.5 py-1">
+            Active
+          </div>
+        <% end %>
+        <% row.with_cell do %>
+          <%= member.preferred_name %>
+        <% end %>
+        <% row.with_cell do %>
+          <%= member.full_name %>
+        <% end %>
+        <% row.with_cell do %>
+          <%= member.role_for(current_organization).titleize %>
+        <% end %>
       <% end %>
-      <% row.with_cell do %>
-        <div class="text-xs inline-flex font-medium bg-slate-100 text-slate-500 rounded-full text-center px-2.5 py-1">
-          Invited
-        </div>
-      <% end %>
-      <% row.with_cell do %>
-        <div class="font-medium text-slate-800">
-          -
-        </div>
-      <% end %>
-      <% row.with_cell do %>
-        <div class="font-medium text-slate-800">
-          -
-        </div>
-      <% end %>
-      <% row.with_cell do %>
-        <%= invite.role.titleize %>
+    <% end %>
+    <% @invited_team.each do |invite| %>
+      <% table.with_row do |row| %>
+        <% row.with_cell do %>
+          <div class="font-medium text-slate-800">
+            <%= invite.email %>
+          </div>
+        <% end %>
+        <% row.with_cell do %>
+          <div class="text-xs inline-flex font-medium bg-slate-100 text-slate-500 rounded-full text-center px-2.5 py-1">
+            Invited
+          </div>
+        <% end %>
+        <% row.with_cell do %>
+          <div class="font-medium text-slate-800">
+            -
+          </div>
+        <% end %>
+        <% row.with_cell do %>
+          <div class="font-medium text-slate-800">
+            -
+          </div>
+        <% end %>
+        <% row.with_cell do %>
+          <%= invite.role.titleize %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/accounts/teams/show.html.erb
+++ b/app/views/accounts/teams/show.html.erb
@@ -1,118 +1,70 @@
-<div class="sm:flex sm:justify-between sm:items-center mb-8">
-  <!-- Left: Title -->
-  <div class="mb-4 sm:mb-0">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Team ‍👫</h1>
-  </div>
+<%= render TableComponent.new(columns: ["Email", "Status", "Preferred Name", "Full Name", "Role"]) do |table| %>
+  <% table.with_header do %>
+    <div class="sm:flex sm:justify-between sm:items-center mb-8">
+      <!-- Left: Title -->
+      <div class="mb-4 sm:mb-0">
+        <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Team ‍👫</h1>
+      </div>
 
-  <div class="grid grid-flow-col sm:auto-cols-max justify-start sm:justify-end gap-2">
-    <%= authz_link_to :green, new_accounts_organization_invitation_path(current_organization) do %>
-      <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
-      <span class="hidden xs:block ml-2">
+      <div class="grid grid-flow-col sm:auto-cols-max justify-start sm:justify-end gap-2">
+        <%= authz_link_to :green, new_accounts_organization_invitation_path(current_organization) do %>
+          <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
+          <span class="hidden xs:block ml-2">
         Add team member
       </span>
-    <% end %>
-  </div>
-</div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 
-<table class="table-auto w-full">
-  <!-- Table header -->
-  <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
-  <tr>
-    <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-      <div class="font-semibold text-left">Email</div>
-    </th>
-    <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-      <div class="font-semibold text-left">Status</div>
-    </th>
-    <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-      <div class="font-semibold text-left">Preferred Name</div>
-    </th>
-    <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-      <div class="font-semibold text-left">Full Name</div>
-    </th>
-    <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-      <div class="font-semibold text-left">Role</div>
-    </th>
-  </tr>
-  </thead>
-
-  <!-- Table body -->
-  <tbody class="text-sm divide-y divide-slate-200">
-  <!-- Row -->
   <% @team.each do |member| %>
-    <tr>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="flex items-center">
-          <div class="font-medium text-slate-800">
-            <%= member.email %>
-          </div>
+    <% table.with_row do |row| %>
+      <% row.with_cell do %>
+        <div class="font-medium text-slate-800">
+          <%= member.email %>
         </div>
-      </td>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="flex items-center">
-          <div class="font-medium text-slate-800">
-            <div class="text-xs ml-2 inline-flex font-medium bg-emerald-100 text-slate-500 rounded-full text-center px-2.5 py-1">
-              Active
-            </div>
-          </div>
+      <% end %>
+      <% row.with_cell do %>
+        <div class="text-xs inline-flex font-medium bg-emerald-100 text-slate-500 rounded-full text-center px-2.5 py-1">
+          Active
         </div>
-      </td>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="text-left">
-          <%= member.preferred_name %>
-        </div>
-      </td>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="text-left">
-          <%= member.full_name %>
-        </div>
-      </td>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="text-left">
-          <%= member.role_for(current_organization).titleize %>
-        </div>
-      </td>
-    </tr>
+      <% end %>
+      <% row.with_cell do %>
+        <%= member.preferred_name %>
+      <% end %>
+      <% row.with_cell do %>
+        <%= member.full_name %>
+      <% end %>
+      <% row.with_cell do %>
+        <%= member.role_for(current_organization).titleize %>
+      <% end %>
+    <% end %>
   <% end %>
-
   <% @invited_team.each do |invite| %>
-    <tr>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="flex items-center">
-          <div class="font-medium text-slate-800">
-            <%= invite.email %>
-          </div>
+    <% table.with_row do |row| %>
+      <% row.with_cell do %>
+        <div class="font-medium text-slate-800">
+          <%= invite.email %>
         </div>
-      </td>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="flex items-center">
-          <div class="font-medium text-slate-800">
-            <div class="text-xs ml-2 inline-flex font-medium bg-slate-100 text-slate-500 rounded-full text-center px-2.5 py-1">
-              Invited
-            </div>
-          </div>
+      <% end %>
+      <% row.with_cell do %>
+        <div class="text-xs inline-flex font-medium bg-slate-100 text-slate-500 rounded-full text-center px-2.5 py-1">
+          Invited
         </div>
-      </td>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="flex items-center">
-          <div class="font-medium text-slate-800">
-            -
-          </div>
+      <% end %>
+      <% row.with_cell do %>
+        <div class="font-medium text-slate-800">
+          -
         </div>
-      </td>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="flex items-center">
-          <div class="font-medium text-slate-800">
-            -
-          </div>
+      <% end %>
+      <% row.with_cell do %>
+        <div class="font-medium text-slate-800">
+          -
         </div>
-      </td>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="flex items-center">
-          <%= invite.role.titleize %>
-        </div>
-      </td>
-    </tr>
+      <% end %>
+      <% row.with_cell do %>
+        <%= invite.role.titleize %>
+      <% end %>
+    <% end %>
   <% end %>
-  </tbody>
-</table>
+<% end %>

--- a/app/views/accounts/teams/show.html.erb
+++ b/app/views/accounts/teams/show.html.erb
@@ -1,5 +1,5 @@
 <%= render TableComponent.new(columns: ["Email", "Status", "Preferred Name", "Full Name", "Role"]) do |table| %>
-  <% table.with_header do %>
+  <% table.with_heading do %>
     <div class="sm:flex sm:justify-between sm:items-center mb-8">
       <!-- Left: Title -->
       <div class="mb-4 sm:mb-0">

--- a/app/views/app_configs/edit.html.erb
+++ b/app/views/app_configs/edit.html.erb
@@ -1,58 +1,55 @@
-<% breadcrumb :app_config, @config %>
-<%= form_with(model: [@app, @config],
-              url: app_app_config_path(@app, @config),
-              builder: ButtonHelper::AuthzForms,
-              method: :patch) do |form| %>
-  <div class="mb-8 pb-8 border-b">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Configure ⚙️</h1>
-  </div>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:app_config, @config), title: "Configure ⚙️") do %>
+  <%= form_with(model: [@app, @config],
+                url: app_app_config_path(@app, @config),
+                builder: ButtonHelper::AuthzForms,
+                method: :patch) do |form| %>
+    <div class="grid gap-5 md:grid-cols-2">
+      <div>
+        <%= form.label :code_repository, "Code Repository", class: "block text-sm font-medium mb-1" %>
+        <%= form.select :code_repository,
+                        options_for_select(
+                          display_channels(@code_repositories) { |chan| chan[:full_name] },
+                          @config.code_repository.to_json
+                        ),
+                        {},
+                        { class: "form-input w-full" } %>
+      </div>
 
-  <div class="grid gap-5 md:grid-cols-2">
-    <div>
-      <%= form.label :code_repository, "Code Repository", class: "block text-sm font-medium mb-1" %>
-      <%= form.select :code_repository,
-                      options_for_select(
-                        display_channels(@code_repositories) { |chan| chan[:full_name] },
-                        @config.code_repository.to_json
-                      ),
-                      {},
-                      { class: "form-input w-full" } %>
+      <% if @app.notifications_set_up? %>
+        <div>
+          <%= form.label :notification_channel, "Notification Channel", class: "block text-sm font-medium mb-1" %>
+          <%= form.select :notification_channel,
+                          options_for_select(
+                            display_channels(@notification_channels) { |chan| "#" + chan[:name] },
+                            @config.notification_channel.to_json
+                          ),
+                          {},
+                          { class: "form-input w-full", data: { controller: "input-select" } } %>
+
+          <div class="text-sm mt-1">
+            To receive notifications in <strong>private</strong> channels, <code>/invite @Tramline</code> into your
+            private channel and then select it from this list.
+          </div>
+        </div>
+      <% end %>
+
+      <% if @ci_cd_projects.present? %>
+        <div>
+          <%= form.label :project_id, "#{@ci_cd_provider_name} Project", class: "block text-sm font-medium mb-1" %>
+          <%= form.select :project_id,
+                          options_for_select(
+                            display_channels(@ci_cd_projects) { |app| "#{app[:name]} (#{app[:id]})" },
+                            @config.project_id.to_json
+                          ),
+                          {},
+                          { class: "form-input w-full", data: { controller: "input-select" } } %>
+        </div>
+      <% end %>
     </div>
 
-    <% if @app.notifications_set_up? %>
-      <div>
-        <%= form.label :notification_channel, "Notification Channel", class: "block text-sm font-medium mb-1" %>
-        <%= form.select :notification_channel,
-                        options_for_select(
-                          display_channels(@notification_channels) { |chan| "#" + chan[:name] },
-                          @config.notification_channel.to_json
-                        ),
-                        {},
-                        { class: "form-input w-full", data: { controller: "input-select" } } %>
-
-        <div class="text-sm mt-1">
-          To receive notifications in <strong>private</strong> channels, <code>/invite @Tramline</code> into your
-          private channel and then select it from this list.
-        </div>
-      </div>
-    <% end %>
-
-    <% if @ci_cd_projects.present? %>
-      <div>
-        <%= form.label :project_id, "#{@ci_cd_provider_name} Project", class: "block text-sm font-medium mb-1" %>
-        <%= form.select :project_id,
-                        options_for_select(
-                          display_channels(@ci_cd_projects) { |app| "#{app[:name]} (#{app[:id]})" },
-                          @config.project_id.to_json
-                        ),
-                        {},
-                        { class: "form-input w-full", data: { controller: "input-select" } } %>
-      </div>
-    <% end %>
-  </div>
-
-  <div class="mt-5">
-    <!-- Start -->
-    <%= form.authz_submit :blue, "Update" %>
-  </div>
+    <div class="mt-5">
+      <!-- Start -->
+      <%= form.authz_submit :blue, "Update" %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/apps/_ongoing_releases.html.erb
+++ b/app/views/apps/_ongoing_releases.html.erb
@@ -1,5 +1,5 @@
 <%= render TableComponent.new(columns: ["release", "current status"]) do |table| %>
-  <% table.with_header do %>
+  <% table.with_heading do %>
     <h2 class="text-2xl text-slate-800 font-bold">Ongoing Releases</h2>
   <% end %>
 

--- a/app/views/apps/_ongoing_releases.html.erb
+++ b/app/views/apps/_ongoing_releases.html.erb
@@ -1,36 +1,23 @@
-<h2 class="text-2xl text-slate-800 font-bold mb-6">Ongoing Releases</h2>
+<%= render TableComponent.new(columns: ["release", "current status"]) do |table| %>
+  <% table.with_header do %>
+    <h2 class="text-2xl text-slate-800 font-bold">Ongoing Releases</h2>
+  <% end %>
 
-<table class="table-auto w-full">
-  <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
-  <tr>
-    <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-      <div class="font-semibold text-left">release</div>
-    </th>
-    <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">current status</th>
-  </tr>
-  </thead>
-
-  <tbody class="text-sm divide-y divide-slate-200">
   <% app.active_runs.each do |run| %>
-    <tr>
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+    <% table.with_row do |row| %>
+      <% row.with_cell do %>
         <div class="flex items-center">
           <div class="font-medium text-slate-800">
             <%= link_to release_path(run.id) do %>
               <%= run.train.name %>&nbsp;&nbsp;•&nbsp;&nbsp;
               <span class="underline">
-                <% if run.completed_at %>
-                  <%= "#{run.release_version} released on #{run.completed_at.to_s(:short)}" %>
-                <% else %>
                   <%= version_in_progress(run.release_version) %>
-                <% end %>
               </span>
             <% end %>
           </div>
         </div>
-      </td>
-
-      <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+      <% end %>
+      <% row.with_cell do %>
         <div class="px-4">
           <div class="max-w-md mx-auto w-full">
             <div class="relative">
@@ -56,10 +43,7 @@
             </div>
           </div>
         </div>
-      </td>
-    </tr>
+      <% end %>
+    <% end %>
   <% end %>
-  </tbody>
-</table>
-
-
+<% end %>

--- a/app/views/apps/all_builds.html.erb
+++ b/app/views/apps/all_builds.html.erb
@@ -1,44 +1,34 @@
-<% breadcrumb :all_builds, @app %>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:all_builds, @app), title: "All Builds 🛠️") do %>
 
-<div class="sm:flex sm:justify-between sm:items-center mb-4">
-  <div class="mb-4 sm:mb-0">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">All Builds 🛠️</h1>
+  <div class="col-span-1">
+    <%= render SearchBarComponent.new(
+      path: all_builds_app_path(@app, *@all_builds_params),
+      placeholder: "Search by version code or name",
+      value: params[:search_pattern],
+      turbo_frame: "all_builds") %>
   </div>
-</div>
 
-<div class="border-t border-slate-200">
-  <div class="grid grid-cols-1 mt-8">
-    <div class="col-span-1">
-      <%= render SearchBarComponent.new(
-        path: all_builds_app_path(@app, *@all_builds_params),
-        placeholder: "Search by version code or name",
-        value: params[:search_pattern],
-        turbo_frame: "all_builds") %>
+  <%= tag.turbo_frame id: "all_builds", target: "_top", data: { turbo_action: "advance" }, class: "col-span-full" do %>
+    <div class="col-span-1 my-4">
+      <%= render FilterButtonComponent.new(
+        name: "Completed",
+        on: @filters.dig(:release_status, :is_on),
+        path: all_builds_app_path(@app),
+        method: :get,
+        filter_params: get_query_filter(:release_status),
+        query_params: @all_builds_params) %>
     </div>
 
-    <%= tag.turbo_frame id: "all_builds", target: "_top", data: { turbo_action: "advance" }, class: "col-span-full" do %>
-      <div class="col-span-1 my-4">
-        <%= render FilterButtonComponent.new(
-          name: "Completed",
-          on: @filters.dig(:release_status, :is_on),
-          path: all_builds_app_path(@app),
-          method: :get,
-          filter_params: get_query_filter(:release_status),
-          query_params: @all_builds_params) %>
-      </div>
-
-      <% if @builds.present? %>
-        <%= render AllBuildsTableComponent.new(
-          builds: @builds,
-          paginator: @pagy,
-          query_params: @all_builds_params) %>
-        <footer>
-          <div class="text-sm text-slate-400">† All timestamps shown are in the timezone configured for the app.</div>
-        </footer>
-      <% else %>
-        <p class="text-lg text-slate-400 my-4">No builds found</p>
-      <% end %>
+    <% if @builds.present? %>
+      <%= render AllBuildsTableComponent.new(
+        builds: @builds,
+        paginator: @pagy,
+        query_params: @all_builds_params) %>
+      <footer>
+        <div class="text-sm text-slate-400">† All timestamps shown are in the timezone configured for the app.</div>
+      </footer>
+    <% else %>
+      <p class="text-lg text-slate-400 my-4">No builds found</p>
     <% end %>
-  </div>
-</div>
-
+  <% end %>
+<% end %>

--- a/app/views/apps/edit.html.erb
+++ b/app/views/apps/edit.html.erb
@@ -1,23 +1,17 @@
-<% breadcrumb :edit_app, @app %>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:edit_app, @app), title: "Settings: #{@app.name} ⚙️") do %>
+  <%= form_with(model: [@app],
+                url: app_path(@app),
+                builder: ButtonHelper::AuthzForms,
+                method: :patch) do |form| %>
 
-<%= form_with(model: [@app],
-              url: app_path(@app),
-              builder: ButtonHelper::AuthzForms,
-              method: :patch) do |form| %>
+    <%= render partial: "shared/errors", locals: { resource: @app } %>
 
-  <%= render partial: "shared/errors", locals: { resource: @app } %>
+    <div class="grid gap-5 md:grid-cols-2">
+      <%= render "form", form: form, app: @app %>
+    </div>
 
-  <div class="mb-8">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Settings: <%= @app.name %> ⚙️</h1>
-  </div>
-
-  <div class="border-t my-8"></div>
-
-  <div class="grid gap-5 md:grid-cols-2">
-    <%= render "form", form: form, app: @app %>
-  </div>
-
-  <div class="mt-5">
-    <%= form.authz_submit :blue, "Update" %>
-  </div>
+    <div class="mt-5">
+      <%= form.authz_submit :blue, "Update" %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/apps/index.html.erb
+++ b/app/views/apps/index.html.erb
@@ -1,47 +1,38 @@
-<% breadcrumb :apps %>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:apps), title: "Apps 👩‍💻") do |page| %>
+  <% page.with_action do %>
+    <%= authz_link_to :green, new_app_path do %>
+      <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
+      <span class="hidden xs:block ml-2">Add a new app</span>
+    <% end %>
+  <% end %>
 
-<% if @apps.any? %>
-  <div class="overflow-x-auto">
-    <%= render TableComponent.new(columns: ["Name", "Description", "Bundle Identifier"]) do |table| %>
-      <% table.with_heading do %>
-        <div class="sm:flex sm:justify-between sm:items-center mb-8">
-          <!-- Left: Title -->
-          <div class="mb-4 sm:mb-0">
-            <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Apps 👩‍💻</h1>
-          </div>
-
-          <div class="grid grid-flow-col sm:auto-cols-max justify-start sm:justify-end gap-2">
-            <%= authz_link_to :green, new_app_path do %>
-              <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
-              <span class="hidden xs:block ml-2">Add a new app</span>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-
-      <% @apps.each do |app| %>
-        <% table.with_row do |row| %>
-          <% row.with_cell do %>
-            <div class="flex items-center">
-              <%= image_tag("#{app.platform}.svg", width: 20, class: "inline-flex mr-3") %>
-              <div class="font-medium text-slate-800">
-                <%= link_to app.name, app_path(app) %>
+  <% if @apps.any? %>
+    <div class="overflow-x-auto">
+      <%= render TableComponent.new(columns: ["Name", "Description", "Bundle Identifier"]) do |table| %>
+        <% @apps.each do |app| %>
+          <% table.with_row do |row| %>
+            <% row.with_cell do %>
+              <div class="flex items-center">
+                <%= image_tag("#{app.platform}.svg", width: 20, class: "inline-flex mr-3") %>
+                <div class="font-medium text-slate-800">
+                  <%= link_to app.name, app_path(app) %>
+                </div>
               </div>
-            </div>
-          <% end %>
-          <% row.with_cell do %>
-            <div class="text-left"><%= simple_format app.description %></div>
-          <% end %>
-          <% row.with_cell do %>
-            <div class="text-left"><%= app.bundle_identifier %></div>
+            <% end %>
+            <% row.with_cell do %>
+              <div class="text-left"><%= simple_format app.description %></div>
+            <% end %>
+            <% row.with_cell do %>
+              <div class="text-left"><%= app.bundle_identifier %></div>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
-    <% end %>
-  </div>
-<% else %>
-  <p>Go to the
-    <%= link_to "new app page", new_app_path %>
-    to create an app and configure their integrations.
-  </p>
+    </div>
+  <% else %>
+    <p>Go to the
+      <%= link_to "new app page", new_app_path %>
+      to create an app and configure their integrations.
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/apps/index.html.erb
+++ b/app/views/apps/index.html.erb
@@ -3,7 +3,7 @@
 <% if @apps.any? %>
   <div class="overflow-x-auto">
     <%= render TableComponent.new(columns: ["Name", "Description", "Bundle Identifier"]) do |table| %>
-      <% table.with_header do %>
+      <% table.with_heading do %>
         <div class="sm:flex sm:justify-between sm:items-center mb-8">
           <!-- Left: Title -->
           <div class="mb-4 sm:mb-0">

--- a/app/views/apps/index.html.erb
+++ b/app/views/apps/index.html.erb
@@ -1,61 +1,43 @@
 <% breadcrumb :apps %>
 
-<div class="sm:flex sm:justify-between sm:items-center mb-8">
-  <!-- Left: Title -->
-  <div class="mb-4 sm:mb-0">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Apps 👩‍💻</h1>
-  </div>
-
-  <div class="grid grid-flow-col sm:auto-cols-max justify-start sm:justify-end gap-2">
-    <%= authz_link_to :green, new_app_path do %>
-      <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
-      <span class="hidden xs:block ml-2">
-        Add a new app
-      </span>
-    <% end %>
-  </div>
-</div>
-
 <% if @apps.any? %>
   <div class="overflow-x-auto">
-    <table class="table-auto w-full">
-      <!-- Table header -->
-      <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
-      <tr>
-        <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-          <div class="font-semibold text-left">Name</div>
-        </th>
-        <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-          <div class="font-semibold text-left">Description</div>
-        </th>
-        <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-          <div class="font-semibold text-left">Bundle Identifier</div>
-        </th>
-      </tr>
-      </thead>
-      <!-- Table body -->
-      <tbody class="text-sm divide-y divide-slate-200">
-      <!-- Row -->
+    <%= render TableComponent.new(columns: ["Name", "Description", "Bundle Identifier"]) do |table| %>
+      <% table.with_header do %>
+        <div class="sm:flex sm:justify-between sm:items-center mb-8">
+          <!-- Left: Title -->
+          <div class="mb-4 sm:mb-0">
+            <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Apps 👩‍💻</h1>
+          </div>
+
+          <div class="grid grid-flow-col sm:auto-cols-max justify-start sm:justify-end gap-2">
+            <%= authz_link_to :green, new_app_path do %>
+              <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
+              <span class="hidden xs:block ml-2">Add a new app</span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
       <% @apps.each do |app| %>
-        <tr>
-          <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+        <% table.with_row do |row| %>
+          <% row.with_cell do %>
             <div class="flex items-center">
               <%= image_tag("#{app.platform}.svg", width: 20, class: "inline-flex mr-3") %>
               <div class="font-medium text-slate-800">
                 <%= link_to app.name, app_path(app) %>
               </div>
             </div>
-          </td>
-          <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+          <% end %>
+          <% row.with_cell do %>
             <div class="text-left"><%= simple_format app.description %></div>
-          </td>
-          <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+          <% end %>
+          <% row.with_cell do %>
             <div class="text-left"><%= app.bundle_identifier %></div>
-          </td>
-        </tr>
+          <% end %>
+        <% end %>
       <% end %>
-      </tbody>
-    </table>
+    <% end %>
   </div>
 <% else %>
   <p>Go to the

--- a/app/views/apps/new.html.erb
+++ b/app/views/apps/new.html.erb
@@ -1,33 +1,27 @@
-<% breadcrumb :new_app %>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:new_app), title: "Add a new app 📱") do %>
+  <%= form_with(model: [@app], builder: ButtonHelper::AuthzForms) do |form| %>
+    <%= render partial: "shared/errors", locals: { resource: @app } %>
 
-<%= form_with(model: [@app], builder: ButtonHelper::AuthzForms) do |form| %>
-  <%= render partial: "shared/errors", locals: { resource: @app } %>
+    <div class="grid gap-5 md:grid-cols-2">
+      <%= render "form", form: form, app: @app %>
 
-  <div class="mb-8">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Add a new app 📱</h1>
-  </div>
+      <div>
+        <%= form.label :platform, class: "block text-sm font-medium mb-1" %>
+        <%= form.select :platform,
+                        options_for_select(App.allowed_platforms(current_user), "Android"),
+                        { required: true },
+                        { class: "form-input w-full mb-1" } %>
+      </div>
 
-  <div class="grid gap-5 md:grid-cols-2">
-    <%= render "form", form: form, app: @app %>
-
-    <div>
-      <%= form.label :platform, class: "block text-sm font-medium mb-1" %>
-      <%= form.select :platform,
-                      options_for_select(App.allowed_platforms(current_user), "Android"),
-                      { required: true },
-                      { class: "form-input w-full mb-1" } %>
+      <div>
+        <%= form.label :timezone, class: "block text-sm font-medium mb-1" %>
+        <%= form.time_zone_select(:timezone, @timezones, { model: ActiveSupport::TimeZone }, { :class => "form-select w-full" }) %>
+      </div>
     </div>
 
-    <div>
-      <%= form.label :timezone, class: "block text-sm font-medium mb-1" %>
-      <%= form.time_zone_select(:timezone, @timezones, { model: ActiveSupport::TimeZone }, { :class => "form-select w-full" }) %>
+    <div class="mt-5">
+      <!-- Start -->
+      <%= form.authz_submit :blue, "Create App" %>
     </div>
-  </div>
-
-  <div class="mt-5">
-    <!-- Start -->
-    <%= form.authz_submit :blue, "Create App" %>
-  </div>
+  <% end %>
 <% end %>
-
-

--- a/app/views/apps/show.html.erb
+++ b/app/views/apps/show.html.erb
@@ -65,60 +65,48 @@
       <%= render partial: "setup_progress", locals: { setup_instructions: @setup_instructions } %>
     <% end %>
 
-    <%= render(ExternalAppComponent.new(app: @app, external_app: @app.latest_external_app)) %>
+    <div class="w-3/4">
+      <%= render(ExternalAppComponent.new(app: @app, external_app: @app.latest_external_app)) %>
+    </div>
+
 
     <% if @app.trains.any? %>
       <% active_runs = @app.active_runs %>
       <% if active_runs.present? %>
         <%= render partial: "ongoing_releases", locals: { app: @app } %>
       <% end %>
-
-      <div class="flex justify-between items-end">
-        <h2 class="text-2xl text-slate-800 font-bold">Release Trains</h2>
-        <% if @app.trains.any? %>
-          <%= authz_link_to :green, new_app_train_path(@app) do %>
-            <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
-            <span class="hidden xs:block ml-2">Create another release train</span>
-          <% end %>
+      <%= render TableComponent.new(columns: ["Name", "Description", "Current Release"]) do |table| %>
+        <% table.with_header do %>
+          <div class="flex justify-between items-end mb-2">
+            <h2 class="text-2xl text-slate-800 font-bold">Release Trains</h2>
+            <% if @app.trains.any? %>
+              <%= authz_link_to :green, new_app_train_path(@app) do %>
+                <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
+                <span class="hidden xs:block ml-2">Create another release train</span>
+              <% end %>
+            <% end %>
+          </div>
         <% end %>
-      </div>
-
-      <table class="table-auto w-full">
-        <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
-        <tr>
-          <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-            <div class="font-semibold text-left">Name</div>
-          </th>
-          <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-            <div class="font-semibold text-left">Description</div>
-          </th>
-          <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-            <div class="font-semibold text-left">Current Release</div>
-          </th>
-        </tr>
-        </thead>
-        <tbody class="text-sm divide-y divide-slate-200">
         <% @app.trains.each do |train| %>
-          <tr>
-            <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+          <% table.with_row do |row| %>
+            <% row.with_cell do %>
               <div class="flex items-center">
                 <div class="font-medium text-slate-800">
                   <%= link_to train.name, app_train_path(@app, train) %>
                 </div>
               </div>
-            </td>
-            <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+            <% end %>
+            <% row.with_cell do %>
               <div class="text-left"><%= simple_format train.description %></div>
-            </td>
-            <td class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+            <% end %>
+            <% row.with_cell do %>
               <div class="text-left">
                 <%= "#{train.runs.any? ? train.version_current : train.version_seeded_with} • #{@app.build_number}" %>
               </div>
-            </td>
-          </tr>
+            <% end %>
+          <% end %>
         <% end %>
-        </tbody>
-      </table>
+      <% end %>
     <% end %>
   </div>
 
@@ -127,11 +115,9 @@
 
     <div class="mb-6 mt-8">
       <h2 class="text-2xl text-slate-800 font-bold">Release History</h2>
-      <p class="text-sm text-slate-500">Successful releases in the last <%= n %> months</p>
+      <span class="text-sm text-slate-400">Successful releases in the last <%= n %> months</span>
     </div>
 
     <%= line_chart [{ name: "Count", data: Reports::ReleaseHistory.call(app: @app, period: :month, last: n) }], ytitle: "Number of Releases", legend: "top left" %>
   <% end %>
 </div>
-
-

--- a/app/views/apps/show.html.erb
+++ b/app/views/apps/show.html.erb
@@ -76,7 +76,7 @@
         <%= render partial: "ongoing_releases", locals: { app: @app } %>
       <% end %>
       <%= render TableComponent.new(columns: ["Name", "Description", "Current Release"]) do |table| %>
-        <% table.with_header do %>
+        <% table.with_heading do %>
           <div class="flex justify-between items-end mb-2">
             <h2 class="text-2xl text-slate-800 font-bold">Release Trains</h2>
             <% if @app.trains.any? %>

--- a/app/views/apps/show.html.erb
+++ b/app/views/apps/show.html.erb
@@ -5,51 +5,50 @@
   <% end %>
 <% end %>
 
-<% breadcrumb @app %>
-
-<%= render partial: 'shared/errors', locals: { resource: @app } %>
-
-<div class="sm:flex sm:justify-between sm:items-center mb-8">
-  <div class="mb-4 sm:mb-0">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold"><%= @app.name %> 📱</h1>
-  </div>
-
-  <div class="grid grid-flow-col sm:auto-cols-max justify-start sm:justify-end gap-2">
-    <% if @app.ready? %>
-      <% if @app.runs.exists? %>
+<%= render PageComponent.new(breadcrumb: breadcrumb(@app), title: "#{@app.name} 📱") do |page| %>
+  <% if @app.ready? %>
+    <% if @app.runs.exists? %>
+      <% page.with_action do %>
         <%= authz_link_to :neutral, all_builds_app_path(@app) do %>
           <%= inline_svg("all_builds_icon.svg", classname: "w-4") %>
           <span class="ml-2">All Builds</span>
         <% end %>
       <% end %>
+    <% end %>
 
+    <% page.with_action do %>
       <%= authz_link_to :neutral, app_integrations_path(@app) do %>
         <%= inline_svg("link_icon.svg", classname: "w-4 fill-current shrink-0 text-slate-500") %>
 
         <span class="ml-2">Integrations</span>
       <% end %>
+    <% end %>
 
+    <% page.with_action do %>
       <%= authz_link_to :neutral, edit_app_app_config_path(@app) do %>
         <%= inline_svg("configure_icon.svg", classname: "w-4 fill-current shrink-0") %>
         <span class="ml-2">Configure</span>
       <% end %>
     <% end %>
+  <% end %>
 
+  <% page.with_action do %>
     <%= authz_link_to :neutral, edit_app_path(@app) do %>
       <%= inline_svg("edit.svg", classname: "w-4 fill-current text-slate-500 shrink-0") %>
       <span class="ml-2">Settings</span>
     <% end %>
+  <% end %>
 
-    <% if @app.runs.blank? %>
+  <% if @app.runs.blank? %>
+    <% page.with_action do %>
       <%= authz_link_to :red, app_path(@app), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } do %>
         <span>Delete</span>
       <% end %>
     <% end %>
-  </div>
-</div>
+  <% end %>
 
-<div class="border-t border-slate-200">
-  <div class="space-y-8 mt-8">
+  <%= render partial: 'shared/errors', locals: { resource: @app } %>
+  <div class="space-y-8">
     <% if @app.ready? %>
       <% unless @app.trains.any? %>
         <div class="grid grid-flow-col sm:auto-cols-max justify-start gap-2">
@@ -68,7 +67,6 @@
     <div class="w-3/4">
       <%= render(ExternalAppComponent.new(app: @app, external_app: @app.latest_external_app)) %>
     </div>
-
 
     <% if @app.trains.any? %>
       <% active_runs = @app.active_runs %>
@@ -109,15 +107,16 @@
       <% end %>
     <% end %>
   </div>
+  <div>
+    <% if @app.runs.size > 1 %>
+      <% n = 3 %>
 
-  <% if @app.runs.size > 1 %>
-    <% n = 3 %>
+      <div class="mb-6 mt-8">
+        <h2 class="text-2xl text-slate-800 font-bold">Release History</h2>
+        <span class="text-sm text-slate-400">Successful releases in the last <%= n %> months</span>
+      </div>
 
-    <div class="mb-6 mt-8">
-      <h2 class="text-2xl text-slate-800 font-bold">Release History</h2>
-      <span class="text-sm text-slate-400">Successful releases in the last <%= n %> months</span>
-    </div>
-
-    <%= line_chart [{ name: "Count", data: Reports::ReleaseHistory.call(app: @app, period: :month, last: n) }], ytitle: "Number of Releases", legend: "top left" %>
-  <% end %>
-</div>
+      <%= line_chart [{ name: "Count", data: Reports::ReleaseHistory.call(app: @app, period: :month, last: n) }], ytitle: "Number of Releases", legend: "top left" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/releases/timeline.html.erb
+++ b/app/views/releases/timeline.html.erb
@@ -1,10 +1,4 @@
-<% breadcrumb :timeline_release, @release %>
-
-<div class="sm:flex sm:justify-between sm:items-center pb-8 border-b border-slate-200">
-  <p class="text-2xl md:text-3xl text-slate-800 font-bold">Event Log</p>
-</div>
-
-<section>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:timeline_release, @release), title: "Event Log") do %>
   <ul class="mt-6">
     <% @events.each do |passport| %>
       <li class="flex px-2">
@@ -28,4 +22,4 @@
       </li>
     <% end %>
   </ul>
-</section>
+<% end %>

--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -1,30 +1,25 @@
-<% breadcrumb :step, @step %>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:step, @step), title: "Edit step 🪜") do %>
+  <%= render partial: 'shared/errors', locals: { resource: @step } %>
 
-<%= render partial: 'shared/errors', locals: { resource: @step } %>
+  <%= form_with(model: @step,
+                url: step_path(@step),
+                builder: ButtonHelper::AuthzForms,
+                method: :patch) do |form| %>
 
-<%= form_with(model: @step,
-              url: step_path(@step),
-              builder: ButtonHelper::AuthzForms,
-              method: :patch) do |form| %>
-  <div class="mb-8">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Edit step 🪜</h1>
-  </div>
+    <%= render 'form', form: form %>
 
-  <div class="border-t my-8"></div>
+    <div class="sm:flex sm:justify-between sm:items-center mt-8 mb-2 pb-5">
+      <p class="font-bold text-xl">
+        <%= Deployment.display.pluralize %>
+      </p>
+    </div>
 
-  <%= render 'form', form: form %>
+    <div class="mb-8">
+      <%= render partial: "shared/deployments", locals: { step: @step, show_deployment_status: false } %>
+    </div>
 
-  <div class="sm:flex sm:justify-between sm:items-center mt-8 mb-2 pb-5">
-    <p class="font-bold text-xl">
-      <%= Deployment.display.pluralize %>
-    </p>
-  </div>
-
-  <div class="mb-8">
-    <%= render partial: "shared/deployments", locals: { step: @step, show_deployment_status: false } %>
-  </div>
-
-  <div class="mt-5">
-    <%= form.authz_submit :blue, "Update" %>
-  </div>
+    <div class="mt-5">
+      <%= form.authz_submit :blue, "Update" %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -1,18 +1,12 @@
-<% breadcrumb :new_step, @train %>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:new_step, @train), title: "Create a new #{@step.kind} step 🪜") do %>
+  <%= render partial: 'shared/errors', locals: { resource: @step } %>
 
-<%= render partial: 'shared/errors', locals: { resource: @step } %>
+  <%= form_with(model: @step, url: app_train_steps_path(@app, @train), builder: ButtonHelper::AuthzForms) do |form| %>
+    <%= render "form", form: form %>
+    <%= render "new_deployments", form: form %>
 
-<%= form_with(model: @step, url: app_train_steps_path(@app, @train), builder: ButtonHelper::AuthzForms) do |form| %>
-  <div class="mb-8">
-    <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Create a new <%= @step.kind %> step 🪜</h1>
-  </div>
-
-  <div class="border-t my-8"></div>
-
-  <%= render "form", form: form %>
-  <%= render "new_deployments", form: form %>
-
-  <div class="mt-10">
-    <%= form.authz_submit :blue, "Create" %>
-  </div>
+    <div class="mt-10">
+      <%= form.authz_submit :blue, "Create" %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -3,15 +3,6 @@
 <%= form_with(model: [app, train],
               url: url,
               builder: ButtonHelper::AuthzForms) do |form| %>
-  <div class="mb-8">
-    <% if train.new_record? %>
-      <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Create a new train 🚦</h1>
-    <% else %>
-      <h1 class="text-2xl md:text-3xl text-slate-800 font-bold">Settings: <%= train.name %></h1>
-    <% end %>
-  </div>
-
-  <div class="border-t my-8"></div>
 
   <div class="grid gap-5 md:grid-cols-2">
     <div data-controller="domain--branch-name-help"

--- a/app/views/trains/edit.html.erb
+++ b/app/views/trains/edit.html.erb
@@ -1,3 +1,4 @@
-<% breadcrumb :edit_train, @train %>
-<%= render partial: 'shared/errors', locals: { resource: @train } %>
-<%= render 'form', app: @app, train: @train %>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:edit_train, @train), title: "Settings: #{@train.name}") do %>
+  <%= render partial: 'shared/errors', locals: { resource: @train } %>
+  <%= render 'form', app: @app, train: @train %>
+<% end %>

--- a/app/views/trains/new.html.erb
+++ b/app/views/trains/new.html.erb
@@ -1,3 +1,4 @@
-<% breadcrumb :new_train, @app %>
-<%= render partial: 'shared/errors', locals: { resource: @train } %>
-<%= render 'form', app: @app, train: @train %>
+<%= render PageComponent.new(breadcrumb: breadcrumb(:new_train, @app), title: "Create a new train 🚦") do %>
+  <%= render partial: 'shared/errors', locals: { resource: @train } %>
+  <%= render 'form', app: @app, train: @train %>
+<% end %>

--- a/app/views/trains/show.html.erb
+++ b/app/views/trains/show.html.erb
@@ -68,7 +68,7 @@
 
 <% if releases_count > 0 %>
   <%= render TableComponent.new(columns: ["•", "version", "release branch", "final deployment channel"]) do |table| %>
-    <% table.with_header do %>
+    <% table.with_heading do %>
       <h2 class="text-2xl font-bold mt-8 mb-4">Releases</h2>
     <% end %>
 

--- a/app/views/trains/show.html.erb
+++ b/app/views/trains/show.html.erb
@@ -63,48 +63,73 @@
 <% end %>
 
 <!--Releases-->
+<h2 class="text-2xl font-bold mt-8 mb-4">Releases</h2>
 
 <% releases_count = @train.runs.size %>
 
 <% if releases_count > 0 %>
-  <%= render TableComponent.new(columns: ["•", "version", "release branch", "final deployment channel"]) do |table| %>
-    <% table.with_heading do %>
-      <h2 class="text-2xl font-bold mt-8 mb-4">Releases</h2>
-    <% end %>
+  <table class="table-auto w-full">
+    <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
+    <tr>
+      <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+        <div class="font-semibold text-left">•</div>
+      </th>
+      <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+        <div class="font-semibold text-left">version</div>
+      </th>
+      <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+        <div class="font-semibold text-left">release branch</div>
+      </th>
+      <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
+        <div class="font-semibold text-left">final deployment channel</div>
+      </th>
+    </tr>
+    </thead>
 
+    <tbody class="text-sm divide-y divide-slate-200">
     <% @train.runs.order(scheduled_at: :desc).each_with_index do |run, index| %>
-      <% table.with_row do |row| %>
-        <% row.with_cell do %>
-          <%= releases_count - index %>
-        <% end %>
-        <% row.with_cell do %>
+      <tr>
+        <td class="px-2 first:pl-5 py-3 whitespace-nowrap">
+          <div>
+            <%= releases_count - index %>
+          </div>
+        </td>
+
+        <td class="px-2 py-3 whitespace-nowrap">
           <%= link_to release_path(run.id) do %>
-            <span class="underline">
-              <% if run.completed_at %>
-                <%= "#{run.release_version} released on #{run.completed_at.to_s(:short)}" %>
-              <% else %>
-                <%= version_in_progress(run.release_version) %>
-              <% end %>
-            </span>
+        <span class="underline">
+          <% if run.completed_at %>
+            <%= "#{run.release_version} released on #{run.completed_at.to_s(:short)}" %>
+          <% else %>
+            <%= version_in_progress(run.release_version) %>
+          <% end %>
+        </span>
             <% if @train.active_run == run %>
-              <span class="text-xs uppercase tracking-wider inline-flex font-medium bg-green-100 text-green-600 rounded-full text-center px-2 py-0.5 ml-2">
-                Ongoing
-              </span>
+            <span class="text-xs uppercase tracking-wider inline-flex font-medium bg-green-100 text-green-600 rounded-full text-center px-2 py-0.5 ml-2">
+              Ongoing
+            </span>
             <% end %>
           <% end %>
-        <% end %>
-        <% row.with_cell do %>
-          <%= run.branch_name %>
-        <% end %>
-        <% row.with_cell do %>
-          <%= @train.final_deployment_channel.display || "–" %>
-        <% end %>
-      <% end %>
+        </td>
+
+        <td class="px-2 py-3 whitespace-nowrap">
+          <div class="">
+            <%= run.branch_name %>
+          </div>
+        </td>
+
+        <td class="px-2 last:pr-5 py-3 whitespace-nowrap">
+          <div>
+            <%= @train.final_deployment_channel.display || "–" %>
+          </div>
+        </td>
+      </tr>
     <% end %>
-  <% end %>
+    </tbody>
+  </table>
 <% else %>
-  <h2 class="text-2xl font-bold mt-8 mb-4">Releases</h2>
   <p class="text-sm">
     No releases yet.
   </p>
 <% end %>
+

--- a/app/views/trains/show.html.erb
+++ b/app/views/trains/show.html.erb
@@ -63,73 +63,48 @@
 <% end %>
 
 <!--Releases-->
-<h2 class="text-2xl font-bold mt-8 mb-4">Releases</h2>
 
 <% releases_count = @train.runs.size %>
 
 <% if releases_count > 0 %>
-  <table class="table-auto w-full">
-    <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
-    <tr>
-      <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="font-semibold text-left">•</div>
-      </th>
-      <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="font-semibold text-left">version</div>
-      </th>
-      <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="font-semibold text-left">release branch</div>
-      </th>
-      <th class="px-2 first:pl-5 last:pr-5 py-3 whitespace-nowrap">
-        <div class="font-semibold text-left">final deployment channel</div>
-      </th>
-    </tr>
-    </thead>
+  <%= render TableComponent.new(columns: ["•", "version", "release branch", "final deployment channel"]) do |table| %>
+    <% table.with_header do %>
+      <h2 class="text-2xl font-bold mt-8 mb-4">Releases</h2>
+    <% end %>
 
-    <tbody class="text-sm divide-y divide-slate-200">
     <% @train.runs.order(scheduled_at: :desc).each_with_index do |run, index| %>
-      <tr>
-        <td class="px-2 first:pl-5 py-3 whitespace-nowrap">
-          <div>
-            <%= releases_count - index %>
-          </div>
-        </td>
-
-        <td class="px-2 py-3 whitespace-nowrap">
+      <% table.with_row do |row| %>
+        <% row.with_cell do %>
+          <%= releases_count - index %>
+        <% end %>
+        <% row.with_cell do %>
           <%= link_to release_path(run.id) do %>
-        <span class="underline">
-          <% if run.completed_at %>
-            <%= "#{run.release_version} released on #{run.completed_at.to_s(:short)}" %>
-          <% else %>
-            <%= version_in_progress(run.release_version) %>
-          <% end %>
-        </span>
-            <% if @train.active_run == run %>
-            <span class="text-xs uppercase tracking-wider inline-flex font-medium bg-green-100 text-green-600 rounded-full text-center px-2 py-0.5 ml-2">
-              Ongoing
+            <span class="underline">
+              <% if run.completed_at %>
+                <%= "#{run.release_version} released on #{run.completed_at.to_s(:short)}" %>
+              <% else %>
+                <%= version_in_progress(run.release_version) %>
+              <% end %>
             </span>
+            <% if @train.active_run == run %>
+              <span class="text-xs uppercase tracking-wider inline-flex font-medium bg-green-100 text-green-600 rounded-full text-center px-2 py-0.5 ml-2">
+                Ongoing
+              </span>
             <% end %>
           <% end %>
-        </td>
-
-        <td class="px-2 py-3 whitespace-nowrap">
-          <div class="">
-            <%= run.branch_name %>
-          </div>
-        </td>
-
-        <td class="px-2 last:pr-5 py-3 whitespace-nowrap">
-          <div>
-            <%= @train.final_deployment_channel.display || "–" %>
-          </div>
-        </td>
-      </tr>
+        <% end %>
+        <% row.with_cell do %>
+          <%= run.branch_name %>
+        <% end %>
+        <% row.with_cell do %>
+          <%= @train.final_deployment_channel.display || "–" %>
+        <% end %>
+      <% end %>
     <% end %>
-    </tbody>
-  </table>
+  <% end %>
 <% else %>
+  <h2 class="text-2xl font-bold mt-8 mb-4">Releases</h2>
   <p class="text-sm">
     No releases yet.
   </p>
 <% end %>
-


### PR DESCRIPTION
Add an overall page component and layout to stop repeating common tags.

Move tables throughout the views to use the table component for uniform style and lesser skeletal view code.

Tables not moved to table component:
- all builds table -- this has more complex sortable components which are not yet part of the basic table component
- builds table in live release -- this has an accordion view which is not handled by the basic table component
- staged rollout table in live release -- this is wip and will be modified in a separate PR
