### PR TITLE
Link people to marketing site if they try to open app on mobile browser 

### DIFF
--- a/app/views/layouts/unsupported_device.html.erb
+++ b/app/views/layouts/unsupported_device.html.erb
@@ -19,7 +19,7 @@
           </div>
 
           <div class="mb-6">
-            <a href="/" class="underline">Tramline</a> is currently only supported on desktop browsers.
+            <a href="https://tramline.app/" class="underline">Tramline</a> is only supported on desktop browsers at the moment.
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Because

If someone tries to open web app (tramline.dev) on their mobile browser, the link on "Tramline" just points to the same page and that's not very useful. More so if they had no idea what Tramline was in the first place. 

## This addresses

Changing the URL on the word "Tramline" to the marketing site (tramline.app) 
