### PR TITLE
Fix refresh button for current store status

### DIFF
--- a/app/components/external_app_component.html.erb
+++ b/app/components/external_app_component.html.erb
@@ -7,7 +7,7 @@
       </div>
       <% if external_app %>
         <div class="text-left">
-          <%= decorated_button_to :neutral, refresh_external_app_path(app), method: :get do %>
+          <%= decorated_button_to :neutral, refresh_external_app_path(app), method: :post do %>
             <%= inline_svg('refresh.svg', classname: "inline-flex w-4") %>
           <% end %>
         </div>


### PR DESCRIPTION
Fix the broken refresh button for `Current Store Status`

![Screenshot 2023-03-06 at 1 34 47 PM](https://user-images.githubusercontent.com/50663/223052270-47491a82-e510-44e7-9e7e-3c5618f3935e.png)
