### PR TITLE
[hotfix] Fix data migration to deprecate upload failed status to not use a removed scope

### DIFF
--- a/db/data/20230314084413_deprecate_upload_failed_status.rb
+++ b/db/data/20230314084413_deprecate_upload_failed_status.rb
@@ -2,7 +2,7 @@ class DeprecateUploadFailedStatus < ActiveRecord::Migration[7.0]
   def up
     return unless defined?(DeploymentRun)
 
-    DeploymentRun.upload_failed.each do |run|
+    DeploymentRun.where(status: "upload_failed").each do |run|
       run.update(failure_reason: :unknown_failure, status: :failed)
     end
   end


### PR DESCRIPTION
Don't use the scope since we're removing it.