### PR TITLE
Increase update external release job retries to go upto 10 days

### DIFF
--- a/app/jobs/concerns/backoffable.rb
+++ b/app/jobs/concerns/backoffable.rb
@@ -10,7 +10,7 @@ module Backoffable
 
   # goes roughly like: 10, 20, 40, 80, 160, 320, 640, 1280, 2560... for exponential
   # goes roughly like: 10, 15, 20, 25, 30, 35, 40, 45, 50, 55... for linear
-  def backoff_in(attempt: 1, period: :minutes, type: :exponential)
+  def backoff_in(attempt: 1, period: :minutes, type: :exponential, factor: LINEAR_BACKOFF_FACTOR)
     raise InvalidPeriod unless period.in?(ALLOWED_PERIODS)
     raise InvalidType unless type.in?(ALLOWED_TYPES)
     raise AttemptMustBeGreaterThanZero if attempt.zero?
@@ -21,7 +21,7 @@ module Backoffable
     when :exponential
       base_delay * 2**attempt
     when :linear
-      base_delay + (LINEAR_BACKOFF_FACTOR * attempt)
+      base_delay + (factor * attempt)
     end
 
     delay += rand(0..1000) / 1000.0 # add some jitter

--- a/app/jobs/deployments/app_store_connect/update_external_release_job.rb
+++ b/app/jobs/deployments/app_store_connect/update_external_release_job.rb
@@ -4,7 +4,7 @@ class Deployments::AppStoreConnect::UpdateExternalReleaseJob
   extend Backoffable
 
   queue_as :high
-  sidekiq_options retry: 14
+  sidekiq_options retry: 75
 
   sidekiq_retry_in do |count, ex|
     if ex.is_a?(Deployments::AppStoreConnect::Release::ExternalReleaseNotInTerminalState)

--- a/app/jobs/deployments/app_store_connect/update_external_release_job.rb
+++ b/app/jobs/deployments/app_store_connect/update_external_release_job.rb
@@ -4,11 +4,11 @@ class Deployments::AppStoreConnect::UpdateExternalReleaseJob
   extend Backoffable
 
   queue_as :high
-  sidekiq_options retry: 75
+  sidekiq_options retry: 21
 
   sidekiq_retry_in do |count, ex|
     if ex.is_a?(Deployments::AppStoreConnect::Release::ExternalReleaseNotInTerminalState)
-      backoff_in(attempt: count, period: :minutes, type: :linear).to_i
+      backoff_in(attempt: count, period: :minutes, type: :linear, factor: 60).to_i
     else
       elog(ex)
       :kill

--- a/app/libs/installations/google/play_developer/error.rb
+++ b/app/libs/installations/google/play_developer/error.rb
@@ -81,7 +81,7 @@ module Installations
       ERRORS.find do |known_error|
         known_error[:status].eql?(status) &&
           known_error[:code].eql?(code) &&
-          known_error[:message_matcher] =~ message
+          known_error[:message_matcher] =~ error_message
       end
     end
 
@@ -89,21 +89,21 @@ module Installations
       @parsed_body ||= api_error&.body&.safe_json_parse
     end
 
-    def error
+    def error_body
       return api_error.body if parsed_body.blank?
       parsed_body["error"]
     end
 
-    def message
-      error["message"]
+    def error_message
+      error_body["message"]
     end
 
     def code
-      error["code"]
+      error_body["code"]
     end
 
     def status
-      error["status"]
+      error_body["status"]
     end
 
     def log


### PR DESCRIPTION
This is to accommodate longer than average review periods in the app store. 

Also fixes: https://tramline.sentry.io/issues/4010387619/?project=4503923928727552&query=is%3Aunresolved&referrer=issue-stream 