### PR TITLE
Disable intercom for admins

### DIFF
--- a/config/initializers/intercom.rb
+++ b/config/initializers/intercom.rb
@@ -45,7 +45,7 @@ IntercomRails.config do |config|
   # A Proc that given a user returns true if the user should be excluded
   # from imports and Javascript inclusion, false otherwise.
   #
-  # config.user.exclude_if = Proc.new { |user| user.deleted? }
+  config.user.exclude_if = Proc.new { |user| user.admin? }
 
   # == User Custom Data
   # A hash of additional data you wish to send about your users.

--- a/config/initializers/intercom.rb
+++ b/config/initializers/intercom.rb
@@ -45,7 +45,7 @@ IntercomRails.config do |config|
   # A Proc that given a user returns true if the user should be excluded
   # from imports and Javascript inclusion, false otherwise.
   #
-  config.user.exclude_if = Proc.new { |user| user.admin? }
+  config.user.exclude_if = proc { |user| user.admin? }
 
   # == User Custom Data
   # A hash of additional data you wish to send about your users.


### PR DESCRIPTION
No need for intercom for internal tramline admin users.
