### PR TITLE
Fix step edit page crash

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -3,8 +3,8 @@ class StepsController < SignedInApplicationController
   using RefinedInteger
 
   before_action :require_write_access!, only: %i[new create edit update]
-  before_action :set_app, only: %i[new create]
-  before_action :set_train, only: %i[new create]
+  before_action :set_app, only: %i[new create edit update]
+  before_action :set_train, only: %i[new create edit update]
   before_action :set_ci_actions, only: %i[new create]
   before_action :integrations_are_ready?, only: %i[new create]
   around_action :set_time_zone

--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: 'shared/errors', locals: { resource: @step } %>
 
   <%= form_with(model: @step,
-                url: step_path(@step),
+                url: app_train_step_path(@app, @train, @step),
                 builder: ButtonHelper::AuthzForms,
                 method: :patch) do |form| %>
 

--- a/app/views/trains/_edit_step_button.html.erb
+++ b/app/views/trains/_edit_step_button.html.erb
@@ -1,7 +1,7 @@
 <% if editable %>
   <div class="p-1">
     <% if step.train.active_run.blank? %>
-      <%= authz_link_to :neutral, edit_step_path(step) do %>
+      <%= authz_link_to :neutral, edit_app_train_step_path(step.app, step.train, step) do %>
         <%= inline_svg("edit.svg", classname: "w-4") %>
       <% end %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,7 @@ Rails.application.routes.draw do
         patch :deactivate
       end
 
-      resources :steps, only: %i[new create edit update], shallow: true
+      resources :steps, only: %i[new create edit update]
 
       resources :releases, only: %i[show create destroy], shallow: true do
         resource :release_metadatum, only: %i[edit update], path: :metadata


### PR DESCRIPTION
Change step edit and update route to not be shallow, set app and train for the actions in the steps controller.