### PR TITLE
Add onboarding message and add getting support link to docs

### DIFF
--- a/app/views/apps/index.html.erb
+++ b/app/views/apps/index.html.erb
@@ -1,3 +1,8 @@
+<% content_for :sticky_page_message do %>
+  <%= render partial: "shared/sticky_topbar_message",
+             locals: { msg: "Contact us (using chat in the bottom right corner) and we'll help you get setup with your release process." } %>
+<% end %>
+
 <%= render PageComponent.new(breadcrumb: breadcrumb(:apps), title: "Apps 👩‍💻") do |page| %>
   <% page.with_action do %>
     <%= authz_link_to :green, new_app_path do %>

--- a/app/views/apps/index.html.erb
+++ b/app/views/apps/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :sticky_page_message do %>
   <%= render partial: "shared/sticky_topbar_message",
-             locals: { msg: "Contact us (using chat in the bottom right corner) and we'll help you get setup with your release process." } %>
+             locals: { msg: "Contact us via the chat in the bottom right corner and we'll help you get setup with your release process." } %>
 <% end %>
 
 <%= render PageComponent.new(breadcrumb: breadcrumb(:apps), title: "Apps 👩‍💻") do |page| %>

--- a/app/views/apps/show.html.erb
+++ b/app/views/apps/show.html.erb
@@ -1,5 +1,5 @@
 <% if @app.ready? && !@app.send_notifications? %>
-  <% content_for :missing_notification_integration do %>
+  <% content_for :sticky_page_message do %>
     <%= render partial: "shared/sticky_topbar_message",
                locals: { msg: "You haven't yet added the integration for notifications. Set it up to receive timely updates about your release!" } %>
   <% end %>

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -1,5 +1,5 @@
 <% if @release.finished? || @release.stopped? %>
-  <% content_for :locked_release do %>
+  <% content_for :sticky_page_message do %>
     <%= render partial: "shared/sticky_topbar_message",
                locals: { msg: "This release was completed and is now locked." } %>
   <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -56,6 +56,5 @@
     </div>
   </div>
 
-  <%= yield :locked_release %>
-  <%= yield :missing_notification_integration %>
+  <%= yield :sticky_page_message %>
 </header>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -52,9 +52,7 @@
   </div>
 
   <div class="text-slate-400 text-xs bottom-16 absolute">
-    For help and support,
-    <br/>→ Call Pratul at <a class="underline" href="tel:+919535520400">+91-95355-20400</a><br/>
-    → Email <a class="underline" href="mailto:support@tramline.app">Support</a>.
+    For help and support, see <%= link_to_external "Getting Support", "https://docs.tramline.app/getting-support", class: "underline"   %>
 
     <hr class="mt-4 border-slate-600 mb-2"/>
   </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -52,7 +52,7 @@
   </div>
 
   <div class="text-slate-400 text-xs bottom-16 absolute">
-    Need help, see <%= link_to_external "Getting Support", "https://docs.tramline.app/getting-support", class: "underline" %>
+    Need help? See <%= link_to_external "Getting Support", "https://docs.tramline.app/getting-support", class: "underline" %>
 
     <hr class="mt-4 border-slate-600 mb-2"/>
   </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -52,7 +52,7 @@
   </div>
 
   <div class="text-slate-400 text-xs bottom-16 absolute">
-    For help and support, see <%= link_to_external "Getting Support", "https://docs.tramline.app/getting-support", class: "underline"   %>
+    Need help, see <%= link_to_external "Getting Support", "https://docs.tramline.app/getting-support", class: "underline" %>
 
     <hr class="mt-4 border-slate-600 mb-2"/>
   </div>


### PR DESCRIPTION
Onboarding message:

<img width="1219" alt="Screenshot 2023-03-31 at 10 40 52 AM" src="https://user-images.githubusercontent.com/1309111/229030093-6929b334-931f-4c09-a43b-8b901d4b9d07.png">


Getting help and support:
<img width="224" alt="Screenshot 2023-03-31 at 11 35 12 AM" src="https://user-images.githubusercontent.com/1309111/229036952-90f8d30b-e310-43da-b9da-848d3aae2108.png">
