### PR TITLE
Make the unauthenticated pages pop a bit

### DIFF
--- a/app/views/authentication/registrations/new.html.erb
+++ b/app/views/authentication/registrations/new.html.erb
@@ -29,7 +29,7 @@
       <% if @token.blank? %>
         <div>
           <%= f.fields_for :organizations, @organization do |m| %>
-            <%= m.label :name, "Organization Name", class: "block text-sm font-medium mb-1" %>
+            <%= m.label :name, "Organization name", class: "block text-sm font-medium mb-1" %>
             <%= m.text_field :name, required: true, autofocus: true, autocomplete: "organization-name",
                              placeholder: "Use your name for a personal account", class: "form-input w-full" %>
           <% end %>

--- a/app/views/authentication/registrations/new.html.erb
+++ b/app/views/authentication/registrations/new.html.erb
@@ -1,65 +1,64 @@
-<div class="max-w-sm mx-auto px-4 py-8">
-  <h1 class="text-3xl text-slate-800 font-bold mb-6">Create your account ✨</h1>
-  <!-- Form -->
-  <%= form_for(resource, as: resource_name, html: { 'data-turbo' => "false" }, url: registration_path(resource_name)) do |f| %>
-    <%= render partial: 'shared/errors' %>
-    <%= render partial: 'shared/flash' %>
+<div class="max-w-md mx-auto px-4 py-8">
+  <%= render partial: "authentication/shared/header", locals: { heading: "Create a new account ✨"} %>
 
+  <%= form_for(resource, as: resource_name, html: { 'data-turbo' => "false" },
+               url: registration_path(resource_name)) do |f| %>
     <% if @token.present? %>
       <%= hidden_field_tag :invite_token, @token %>
     <% end %>
 
-    <div class="space-y-4">
+    <div class="space-y-6">
       <div>
         <%= f.label :full_name, class: "block text-sm font-medium mb-1" %>
-        <%= f.text_field :full_name, required: true, autofocus: true, autocomplete: "full-name", class: "form-input w-full" %>
+        <%= f.text_field :full_name, required: true, autofocus: true, autocomplete: "full-name",
+                         class: "form-input w-full" %>
       </div>
 
       <div>
         <%= f.label :preferred_name, class: "block text-sm font-medium mb-1" %>
-        <%= f.text_field :preferred_name, autofocus: true, autocomplete: "preferred-name", placeholder: "What should we call you?", class: "form-input w-full" %>
+        <%= f.text_field :preferred_name, autofocus: true, autocomplete: "preferred-name",
+                         placeholder: "What should we call you?", class: "form-input w-full" %>
       </div>
 
       <div>
         <%= f.label :email, class: "block text-sm font-medium mb-1" %>
-        <%= f.email_field :email, required: true, autocomplete: "email", class: "form-input w-full", readonly: @invite.present? %>
+        <%= f.email_field :email, required: true, autocomplete: "email",
+                          class: "form-input w-full", readonly: @invite.present? %>
       </div>
 
       <% if @token.blank? %>
         <div>
           <%= f.fields_for :organizations, @organization do |m| %>
             <%= m.label :name, "Organization Name", class: "block text-sm font-medium mb-1" %>
-            <%= m.text_field :name, required: true, autofocus: true, autocomplete: "organization-name", class: "form-input w-full" %>
+            <%= m.text_field :name, required: true, autofocus: true, autocomplete: "organization-name",
+                             placeholder: "Use your name for a personal account", class: "form-input w-full" %>
           <% end %>
         </div>
       <% end %>
 
       <div class="field">
         <%= f.label :password, class: "block text-sm font-medium mb-1" %>
-        <%= f.password_field :password, required: true, autocomplete: "new-password", placeholder: "Minimum #{@minimum_password_length} characters", class: "form-input w-full" %>
+        <%= f.password_field :password, required: true, autocomplete: "new-password",
+                             placeholder: "Minimum #{@minimum_password_length} characters",
+                             class: "form-input w-full" %>
       </div>
 
       <div class="field">
         <%= f.label :password_confirmation, class: "block text-sm font-medium mb-1" %>
-        <%= f.password_field :password_confirmation, required: true, autocomplete: "new-password", class: "form-input w-full" %>
+        <%= f.password_field :password_confirmation, required: true,
+                             autocomplete: "new-password", class: "form-input w-full" %>
       </div>
 
-      <div class="flex items-center justify-between mt-6">
-        <div class="mr-1">
-          <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-            <%= link_to "Forgot your password?", new_password_path(resource_name), class: "text-sm underline hover:no-underline" %>
-          <% end %>
-        </div>
-        <%= f.submit "Sign up", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-3" %>
+      <div>
+        <%= f.submit "Sign up", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white w-full" %>
+      </div>
+
+      <div class="text-sm">
+        Have an account?
+        <%= link_to "Sign In", user_session_path, class: "font-medium text-indigo-500 hover:text-indigo-600" %>
       </div>
     </div>
   <% end %>
 
-  <!-- Footer -->
-  <div class="pt-5 mt-6 border-t border-slate-200">
-    <div class="text-sm">
-      Have an account?
-      <%= link_to "Sign In", user_session_path, class: "font-medium text-indigo-500 hover:text-indigo-600" %>
-    </div>
-  </div>
+  <%= render partial: "authentication/shared/footer" %>
 </div>

--- a/app/views/authentication/sessions/new.html.erb
+++ b/app/views/authentication/sessions/new.html.erb
@@ -1,11 +1,6 @@
-<div class="max-w-sm mx-auto px-4 py-8">
-  <div class="flex mb-8">
-    <%= inline_svg("tramline.svg") %>
-  </div>
+<div class="max-w-md mx-auto px-4 py-8">
+  <%= render partial: "authentication/shared/header", locals: { heading: "Sign in to your account ✨"} %>
 
-  <%= render partial: "shared/flash" %>
-
-  <!-- Form -->
   <%= form_for(resource, as: resource_name, html: { 'data-turbo' => "false" }, url: session_path(resource_name)) do |f| %>
     <div class="space-y-6">
       <div>
@@ -16,6 +11,13 @@
       <div>
         <%= f.label :password, class: "block text-sm font-medium mb-1" %>
         <%= f.password_field :password, autocomplete: "current-password", class: "form-input w-full" %>
+
+        <div class="text-sm mt-2">
+          <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+            <%= link_to "Forgot your password?", new_password_path(resource_name),
+                        class: "font-medium text-indigo-500 hover:text-indigo-600" %>
+          <% end %>
+        </div>
       </div>
 
       <% if devise_mapping.rememberable? %>
@@ -25,23 +27,17 @@
         </label>
       <% end %>
 
-      <div class="flex items-center justify-between">
-        <div class="mr-1">
-          <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-            <%= link_to "Forgot your password?", new_password_path(resource_name), class: "text-sm underline hover:no-underline" %>
-          <% end %>
+      <%= f.submit "Log in", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white w-full" %>
 
-          <div>
-            <%= link_to "Sign up", new_registration_path(resource_name), class: "text-sm underline hover:no-underline" %>
-          </div>
+      <div class="mr-1">
+        <div class="text-sm">
+          Don't have an account?
+          <%= link_to "Sign up", new_registration_path(resource_name),
+                      class: "font-medium text-indigo-500 hover:text-indigo-600" %>
         </div>
-        <%= f.submit "Log in", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-3" %>
       </div>
     </div>
   <% end %>
 
-  <!-- Footer -->
-  <div class="flex mt-8 pt-4 border-t border-slate-200 justify-center">
-    <span class="text-xs text-slate-400">Copyright <%= Date.current.year %>, Tramline Inc.</span>
-  </div>
+  <%= render partial: "authentication/shared/footer" %>
 </div>

--- a/app/views/authentication/sessions/new.html.erb
+++ b/app/views/authentication/sessions/new.html.erb
@@ -27,7 +27,7 @@
         </label>
       <% end %>
 
-      <%= f.submit "Log in", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white w-full" %>
+      <%= f.submit "Sign in", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white w-full" %>
 
       <div class="mr-1">
         <div class="text-sm">

--- a/app/views/authentication/shared/_footer.html.erb
+++ b/app/views/authentication/shared/_footer.html.erb
@@ -1,3 +1,4 @@
 <div class="flex mt-8 pt-4 border-t border-slate-200 justify-center">
-  <span class="text-xs text-slate-400">Copyright <%= Date.current.year %>, <a href="https://tramline.app" class="underline">Tramline Inc.</a></span>
+  <span class="text-xs text-slate-400">Copyright <%= Date.current.year %>,
+    <a href="https://tramline.app" target=_blank", rel="nofollow noopener" class="underline">Tramline Inc.</a></span>
 </div>

--- a/app/views/authentication/shared/_footer.html.erb
+++ b/app/views/authentication/shared/_footer.html.erb
@@ -1,0 +1,3 @@
+<div class="flex mt-8 pt-4 border-t border-slate-200 justify-center">
+  <span class="text-xs text-slate-400">Copyright <%= Date.current.year %>, <a href="https://tramline.app" class="underline">Tramline Inc.</a></span>
+</div>

--- a/app/views/authentication/shared/_header.html.erb
+++ b/app/views/authentication/shared/_header.html.erb
@@ -1,0 +1,5 @@
+<div class="flex mb-8"><%= inline_svg("tramline.svg") %></div>
+<h1 class="text-3xl text-slate-800 font-bold mb-6"><%= heading %></h1>
+
+<%= render partial: 'shared/errors' %>
+<%= render partial: "shared/flash" %>

--- a/app/views/authentication/shared/_header.html.erb
+++ b/app/views/authentication/shared/_header.html.erb
@@ -1,4 +1,7 @@
-<div class="flex mb-8"><%= inline_svg("tramline.svg") %></div>
+<a href="https://tramline.app" target=_blank", rel="nofollow noopener">
+  <div class="flex mb-8"><%= inline_svg("tramline.svg") %></div>
+</a>
+
 <h1 class="text-3xl text-slate-800 font-bold mb-6"><%= heading %></h1>
 
 <%= render partial: 'shared/errors' %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,41 +1,41 @@
-<div class="max-w-sm mx-auto px-4 py-8">
-  <div class="flex mb-8">
-    <%= inline_svg("tramline.svg") %>
-  </div>
+<div class="max-w-md mx-auto px-4 py-8">
+  <%= render partial: "authentication/shared/header", locals: { heading: "Reset password 🔏"} %>
 
-  <%= render "shared/errors" %>
-  <%= render "shared/flash" %>
-
-  <h1 class="text-3xl text-slate-800 font-bold mb-6">Reset password 🔏</h1>
-
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, 'data-turbo' => "false" }) do |f| %>
+  <%= form_for(resource, as: resource_name,
+               url: password_path(resource_name), html: { method: :put, 'data-turbo' => "false" }) do |f| %>
     <div class="space-y-6">
       <%= render "shared/flash", resource: resource %>
       <%= f.hidden_field :reset_password_token %>
 
       <div>
         <%= f.label :password, "New password", class: "block text-sm font-medium mb-1" %>
-        <%= f.password_field :password, required: true, autofocus: true, autocomplete: "new-password", class: "form-input w-full" %>
+        <%= f.password_field :password, required: true, autofocus: false, autocomplete: "new-password",
+                             placeholder: "Minimum #{@minimum_password_length} characters",
+                             class: "form-input w-full" %>
       </div>
 
       <div class="field">
         <%= f.label :password_confirmation, "Confirm new password", class: "block text-sm font-medium mb-1" %>
-        <%= f.password_field :password_confirmation, required: true, autocomplete: "new-password", class: "form-input w-full" %>
+        <%= f.password_field :password_confirmation, required: true,
+                             autocomplete: "new-password",
+                             class: "form-input w-full" %>
       </div>
 
       <div class="actions">
-        <%= f.submit "Reset", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white" %>
+        <%= f.submit "Reset", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white w-full" %>
+      </div>
+
+      <div class="text-sm">
+        Or
+        <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+          <%= link_to "Sign up", new_registration_path(resource_name),
+                      class: "font-medium text-indigo-500 hover:text-indigo-600" %>
+        <% end %>
+        or,
+        <%= link_to "Sign In", user_session_path, class: "font-medium text-indigo-500 hover:text-indigo-600" %>
       </div>
     </div>
   <% end %>
 
-  <div class="pt-5 mt-6 border-t border-slate-200">
-    <div class="text-sm">
-      <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-        <%= link_to "Sign up", new_registration_path(resource_name), class: "font-medium text-indigo-500 hover:text-indigo-600" %>
-      <% end %>
-      or,
-      <%= link_to "Sign In", user_session_path, class: "font-medium text-indigo-500 hover:text-indigo-600" %>
-    </div>
-  </div>
+  <%= render partial: "authentication/shared/footer" %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,31 +1,29 @@
-<div class="max-w-sm mx-auto px-4 py-8">
-  <h1 class="text-3xl text-slate-800 font-bold mb-8">Forgot your password?</h1>
+<div class="max-w-md mx-auto px-4 py-8">
+  <%= render partial: "authentication/shared/header", locals: { heading: "Forgot your password? 🧐"} %>
 
-  <%= render "shared/flash" %>
-  <%= render "shared/errors" %>
-
-  <!-- Form -->
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, 'data-turbo' => "false" }) do |f| %>
-    <div class="space-y-4">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name),
+               html: { method: :post, 'data-turbo' => "false" }) do |f| %>
+    <div class="space-y-6">
       <div>
         <%= f.label :email, class: "block text-sm font-medium mb-1" %>
         <%= f.email_field :email, required: true, autofocus: true, autocomplete: "email", class: "form-input w-full" %>
       </div>
 
-      <div class="flex items-center justify-center mt-6">
-        <%= f.submit "Send reset password instructions", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-3" %>
+      <div class="">
+        <%= f.submit "Send reset instructions", class: "btn bg-indigo-500 hover:bg-indigo-600 text-white w-full" %>
+      </div>
+
+      <div class="text-sm">
+        Or
+        <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+          <%= link_to "Sign up", new_registration_path(resource_name),
+                      class: "font-medium text-indigo-500 hover:text-indigo-600" %>
+        <% end %>
+        or,
+        <%= link_to "Sign In", user_session_path, class: "font-medium text-indigo-500 hover:text-indigo-600" %>
       </div>
     </div>
   <% end %>
 
-  <!-- Footer -->
-  <div class="pt-5 mt-6 border-t border-slate-200">
-    <div class="text-sm">
-      <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-        <%= link_to "Sign up", new_registration_path(resource_name), class: "font-medium text-indigo-500 hover:text-indigo-600" %>
-      <% end %>
-      or,
-      <%= link_to "Sign In", user_session_path, class: "font-medium text-indigo-500 hover:text-indigo-600" %>
-    </div>
-  </div>
+  <%= render partial: "authentication/shared/footer" %>
 </div>


### PR DESCRIPTION
They currently look too plain since there's no branding or any description. This adds consistent footers and headers to all the unauthenticated pages. It uses a logo without a wordmark since we don't have one yet.
![Screenshot 2023-04-07 at 4 04 05 PM](https://user-images.githubusercontent.com/50663/230594232-f18995af-2356-492f-9df3-2e0086fdec3b.png)
![Screenshot 2023-04-07 at 4 04 12 PM](https://user-images.githubusercontent.com/50663/230594245-9a56e902-16de-4095-8d01-0c4dacd35753.png)
![Screenshot 2023-04-07 at 4 04 23 PM](https://user-images.githubusercontent.com/50663/230594267-4dc2049c-4ff4-4ca4-b9c6-343bfb781ca8.png)
![Screenshot 2023-04-07 at 4 04 41 PM](https://user-images.githubusercontent.com/50663/230594292-d07eb84d-5cee-4c99-adad-e168e016d738.png)
