### PR TITLE
Remove the sidebar

### DIFF
--- a/app/views/authentication/registrations/new.html.erb
+++ b/app/views/authentication/registrations/new.html.erb
@@ -31,7 +31,7 @@
           <%= f.fields_for :organizations, @organization do |m| %>
             <%= m.label :name, "Organization name", class: "block text-sm font-medium mb-1" %>
             <%= m.text_field :name, required: true, autofocus: true, autocomplete: "organization-name",
-                             placeholder: "Use your name for a personal account", class: "form-input w-full" %>
+                             placeholder: "Use your own name for a personal account", class: "form-input w-full" %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/authentication/shared/_header.html.erb
+++ b/app/views/authentication/shared/_header.html.erb
@@ -1,6 +1,8 @@
-<a href="https://tramline.app" target=_blank", rel="nofollow noopener">
-  <div class="flex mb-8"><%= inline_svg("tramline.svg") %></div>
-</a>
+<div class="flex mb-8">
+  <a href="https://tramline.app" target=_blank", rel="nofollow noopener">
+    <%= inline_svg("tramline.svg") %>
+  </a>
+</div>
 
 <h1 class="text-3xl text-slate-800 font-bold mb-6"><%= heading %></h1>
 

--- a/app/views/layouts/signed_in_application.html.erb
+++ b/app/views/layouts/signed_in_application.html.erb
@@ -17,17 +17,18 @@
 
 <body>
 <div class="flex h-screen overflow-hidden">
-  <%= render partial: 'shared/sidebar', locals: { active_apps: current_organization.apps.with_trains } %>
-  <div class="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden">
+  <div class="relative flex flex-col flex-1 overflow-y-auto overflow-x-hidden h-full">
     <%= render partial: 'shared/header' %>
 
-    <main>
-      <div class="px-4 sm:px-6 lg:px-8 py-8 w-full max-w-9xl mx-auto">
+    <main class="mb-64">
+      <div class="py-8 w-full max-w-7xl mx-auto">
         <%= render partial: 'shared/flash' %>
         <%= breadcrumbs fragment_class: 'text-slate-500', separator: ' » ', class: 'text-sm text-slate-500 mb-4' %>
         <%= yield %>
       </div>
     </main>
+
+    <%= render partial: 'shared/footer' %>
   </div>
 </div>
 </body>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,25 @@
+<footer class="mt-auto border-t">
+  <div class="w-full mx-auto max-w-screen-xl flex items-center justify-between py-4">
+    <div class="text-sm text-gray-500">
+      <div>
+        Ver. <code><%= current_deploy[:ref] %></code> • <%= current_deploy[:ago] %>
+      </div>
+
+      Copyright © <%= Date.current.year %>
+
+      <a href="https://tramline.app" class="hover:underline">Tramline Inc.</a>
+    </div>
+
+    <ul class="flex flex-wrap items-center mt-3 text-sm font-medium text-gray-500">
+      <li>
+        <a href="https://tramline.app/why" class="mr-4 hover:underline md:mr-6 ">About</a>
+      </li>
+      <li>
+        <a href="https://docs.tramline.app" class="mr-4 hover:underline md:mr-6">Docs</a>
+      </li>
+      <li>
+        <a href="https://docs.tramline.app/getting-support" class="hover:underline">Support</a>
+      </li>
+    </ul>
+  </div>
+</footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,13 +1,16 @@
 <header class="sticky top-0 <%= dynamic_header_color %> border-b border-slate-200 z-30">
-  <div class="px-4 sm:px-6 lg:px-8">
-    <div class="flex items-center justify-between h-16 -mb-px">
+  <div class="w-full max-w-7xl mx-auto">
+    <div class="flex items-center justify-between h-16">
       <!-- Header: Left side -->
-      <div class="flex"></div>
+      <div class="flex">
+        <a class="block" href="/">
+          <%= inline_svg("tramline.svg", classname: "inline-flex w-12") %>
+        </a>
+      </div>
+
       <!-- Header: Right side -->
       <div class="flex items-center space-x-3">
-        <!-- Divider -->
         <hr class="w-px h-6 bg-slate-200"/>
-        <!-- User button -->
         <div class="relative inline-flex" data-controller="reveal" data-reveal-away-value="true">
           <button
             class="inline-flex justify-center items-center group"

--- a/app/views/shared/_sticky_topbar_message.html.erb
+++ b/app/views/shared/_sticky_topbar_message.html.erb
@@ -1,5 +1,5 @@
 <div class="px-4 py-2 rounded-sm text-sm bg-indigo-100 border border-indigo-200 text-indigo-500">
-  <div class="flex w-full justify-between items-start">
+  <div class="flex w-full justify-between items-start max-w-7xl mx-auto">
     <div class="flex">
       <div class="font-medium">
         <%= msg %>


### PR DESCRIPTION
**Closes:** #196 

## Because

The sidebar does not add much value and takes up space.

## This addresses

Removes the sidebar, puts the logo on the top-left and adds a footer.

![Screenshot 2023-04-07 at 5 28 52 PM](https://user-images.githubusercontent.com/50663/230605105-019ebd1b-98bb-41cf-92d7-375e0d484218.png)

