### PR TITLE
Support for Release Notes on Android

### DIFF
--- a/app/libs/installations/google/play_developer/api.rb
+++ b/app/libs/installations/google/play_developer/api.rb
@@ -43,11 +43,12 @@ module Installations
       end
     end
 
-    def create_release(track_name, version_code, release_version, rollout_percentage)
+    def create_release(track_name, version_code, release_version, rollout_percentage, release_notes = "")
       @track_name = track_name
       @version_code = version_code
       @release_version = release_version
       @rollout_percentage = rollout_percentage
+      @release_notes = release_notes
 
       execute do
         edit = client.insert_edit(package_name)
@@ -56,10 +57,11 @@ module Installations
       end
     end
 
-    def create_draft_release(track_name, version_code, release_version)
+    def create_draft_release(track_name, version_code, release_version, release_notes = "")
       @track_name = track_name
       @version_code = version_code
       @release_version = release_version
+      @release_notes = release_notes
 
       execute do
         edit = client.insert_edit(package_name)
@@ -95,13 +97,13 @@ module Installations
 
     def active_release
       rollout_status = @rollout_percentage.eql?(100) ? RELEASE_STATUS[:completed] : RELEASE_STATUS[:in_progress]
-      params = release_params.merge(status: rollout_status)
+      params = release_params.merge(status: rollout_status, release_notes: @release_notes)
       params[:user_fraction] = user_fraction if @rollout_percentage && user_fraction < 1.0
       ANDROID_PUBLISHER::TrackRelease.new(**params)
     end
 
     def draft_release
-      params = release_params.merge(status: RELEASE_STATUS[:draft])
+      params = release_params.merge(status: RELEASE_STATUS[:draft], release_notes: @release_notes)
       ANDROID_PUBLISHER::TrackRelease.new(**params)
     end
 


### PR DESCRIPTION
**Closes:** #395 

## Because

We allow users to add release notes for a release, but we only use them when release to App Store.

## This addresses

Use them with Play Store as well.
