### PR TITLE
Enable Github Actions for iOS apps

### DIFF
--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -28,7 +28,7 @@ class Integration < ApplicationRecord
   ALLOWED_INTEGRATIONS_FOR_APP = {
     ios: {
       "version_control" => %w[GithubIntegration GitlabIntegration],
-      "ci_cd" => %w[BitriseIntegration],
+      "ci_cd" => %w[BitriseIntegration GithubIntegration],
       "notification" => %w[SlackIntegration],
       "build_channel" => %w[AppStoreIntegration]
     },


### PR DESCRIPTION
## Because

iOS releases happen using Github Actions as well.

Tested with iOS release for Ueno with and without Fastlane.

Relevant docs PR: https://github.com/tramlinehq/docs/pull/2