### PR TITLE
Remove store flag from Firebase integration

### DIFF
--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -171,8 +171,6 @@ class DeploymentRun < ApplicationRecord
   end
 
   def start_release!
-    return unless store?
-
     release.with_lock do
       return unless release_startable?
 

--- a/app/models/google_firebase_integration.rb
+++ b/app/models/google_firebase_integration.rb
@@ -41,7 +41,7 @@ class GoogleFirebaseIntegration < ApplicationRecord
   end
 
   def store?
-    true
+    false
   end
 
   def controllable_rollout?


### PR DESCRIPTION
## Because

We assume one store provider for both app types: the Play Store and App Store for Android and iOS respectively.

What is the `store?` check for Tramline at the moment:
- a way to identify _the_ stores for both Android and iOS
- it affects fetching of current store status for the app when It is onboarded
- even though Firebase behaves as a store, it is not a store in the true sense of it. It is not a marketplace, so to say.

## This addresses

- Removes store flag from Firebase integration. 
- Allows the state machine in DeploymentRun to determine the feasibility of `start_release` instead of the `store?` check.
