### PR TITLE
Remove persistence of dynamic attributes of a Slack channel

### DIFF
--- a/app/models/slack_integration.rb
+++ b/app/models/slack_integration.rb
@@ -70,9 +70,10 @@ class SlackIntegration < ApplicationRecord
   end
 
   def channels
-    cache.fetch(channels_cache_key, expires_in: CACHE_EXPIRY) do
+    chans = cache.fetch(channels_cache_key, expires_in: CACHE_EXPIRY) do
       get_all_channels
     end
+    chans.map { |channel| channel.slice(:id, :name, :is_private) }
   end
 
   def build_channels(with_production:)

--- a/db/data/20230523153426_prune_notification_channel_attributes_in_app_config.rb
+++ b/db/data/20230523153426_prune_notification_channel_attributes_in_app_config.rb
@@ -1,0 +1,12 @@
+class PruneNotificationChannelAttributesInAppConfig < ActiveRecord::Migration[7.0]
+  def up
+    AppConfig.where.not(notification_channel: nil).each do |app_config|
+      app_config.notification_channel = app_config.notification_channel.slice("id", "name", "is_private")
+      app_config.save
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230511074005)
+DataMigrate::Data.define(version: 20230523153426)


### PR DESCRIPTION
The Slack attributes like description and member count change very frequently. We should use them only for view purposes, not for identifying selected notification channels.
