### PR TITLE
Add post release PR create and merge for Almost Trunk strategy

### DIFF
--- a/app/libs/installations/github/error.rb
+++ b/app/libs/installations/github/error.rb
@@ -48,6 +48,7 @@ module Installations
     ]
 
     def self.handle(exception)
+      Rails.logger.error(exception)
       new(exception).handle
     end
 

--- a/app/libs/triggers/post_release/almost_trunk.rb
+++ b/app/libs/triggers/post_release/almost_trunk.rb
@@ -25,7 +25,7 @@ class Triggers::PostRelease
         release: release,
         new_pull_request: release.pull_requests.post_release.open.build,
         to_branch_ref: working_branch,
-        from_branch_ref: namespaced_release_branch,
+        from_branch_ref: release_branch,
         title: pr_title,
         description: pr_description
       ).then do |value|
@@ -48,10 +48,6 @@ class Triggers::PostRelease
       rescue Installations::Errors::TaggedReleaseAlreadyExists
         logger.debug("Release finalization: skipping since tagged release for #{train.tag_name} already exists!")
       end
-    end
-
-    def namespaced_release_branch
-      vcs_provider.namespaced_branch(release_branch)
     end
 
     def pr_title

--- a/app/libs/triggers/post_release/almost_trunk.rb
+++ b/app/libs/triggers/post_release/almost_trunk.rb
@@ -17,7 +17,7 @@ class Triggers::PostRelease
 
     attr_reader :train, :release
     delegate :logger, to: Rails
-    delegate :vcs_provider, :working_branch, to: :train
+    delegate :working_branch, to: :train
     delegate :release_branch, to: :release
 
     def create_and_merge_pr

--- a/app/libs/triggers/post_release/almost_trunk.rb
+++ b/app/libs/triggers/post_release/almost_trunk.rb
@@ -57,7 +57,7 @@ class Triggers::PostRelease
     def pr_description
       <<~TEXT
         The release train #{train.name} with version #{release.release_version} has finished.
-        The #{release_branch} branch has to be merged into #{working_branch} branch, as per #{train.branching_strategy_name} branching strategy.
+        The #{release_branch} branch has to be merged into #{working_branch} branch.
       TEXT
     end
   end

--- a/app/libs/triggers/post_release/almost_trunk.rb
+++ b/app/libs/triggers/post_release/almost_trunk.rb
@@ -10,13 +10,35 @@ class Triggers::PostRelease
     end
 
     def call
-      create_tag
+      create_tag.then { create_and_merge_pr }
     end
 
     private
 
     attr_reader :train, :release
     delegate :logger, to: Rails
+    delegate :vcs_provider, :working_branch, to: :train
+    delegate :release_branch, to: :release
+
+    def create_and_merge_pr
+      Triggers::PullRequest.create_and_merge!(
+        release: release,
+        new_pull_request: release.pull_requests.post_release.open.build,
+        to_branch_ref: working_branch,
+        from_branch_ref: namespaced_release_branch,
+        title: pr_title,
+        description: pr_description
+      ).then do |value|
+        Rails.logger.info "AT: Create and merge PR result", value
+        stamp_pr_success
+        GitHub::Result.new { value }
+      end
+    end
+
+    def stamp_pr_success
+      pr = release.reload.pull_requests.post_release.first
+      release.event_stamp!(reason: :post_release_pr_succeeded, kind: :success, data: {url: pr.url, number: pr.number}) if pr
+    end
 
     def create_tag
       GitHub::Result.new do
@@ -26,6 +48,21 @@ class Triggers::PostRelease
       rescue Installations::Errors::TaggedReleaseAlreadyExists
         logger.debug("Release finalization: skipping since tagged release for #{train.tag_name} already exists!")
       end
+    end
+
+    def namespaced_release_branch
+      vcs_provider.namespaced_branch(release_branch)
+    end
+
+    def pr_title
+      "[#{release.release_version}] Post-release merge"
+    end
+
+    def pr_description
+      <<~TEXT
+        The release train #{train.name} with version #{release.release_version} has finished.
+        The #{release_branch} branch has to be merged into #{working_branch} branch, as per #{train.branching_strategy_name} branching strategy.
+      TEXT
     end
   end
 end

--- a/app/libs/triggers/post_release/parallel_branches.rb
+++ b/app/libs/triggers/post_release/parallel_branches.rb
@@ -54,8 +54,8 @@ class Triggers::PostRelease
 
     def pr_description
       <<~TEXT
-        New release train #{train.name} triggered.
-        The #{working_branch} branch has been merged into #{release.branch_name} branch, as per #{train.branching_strategy_name} branching strategy.
+        The release train #{train.name} with version #{release.release_version} has finished.
+        The #{release_branch} branch has to be merged into #{working_branch} branch.
       TEXT
     end
   end

--- a/app/libs/triggers/post_release/parallel_branches.rb
+++ b/app/libs/triggers/post_release/parallel_branches.rb
@@ -16,7 +16,7 @@ class Triggers::PostRelease
     private
 
     attr_reader :train, :release
-    delegate :vcs_provider, :release_branch, :working_branch, to: :train
+    delegate :release_branch, :working_branch, to: :train
     delegate :logger, to: Rails
 
     def create_and_merge_pr

--- a/app/libs/triggers/post_release/parallel_branches.rb
+++ b/app/libs/triggers/post_release/parallel_branches.rb
@@ -24,7 +24,7 @@ class Triggers::PostRelease
         release: release,
         new_pull_request: release.pull_requests.post_release.open.build,
         to_branch_ref: working_branch,
-        from_branch_ref: namespaced_release_branch,
+        from_branch_ref: release_branch,
         title: pr_title,
         description: pr_description
       ).then do |value|
@@ -46,10 +46,6 @@ class Triggers::PostRelease
       rescue Installations::Errors::TaggedReleaseAlreadyExists
         logger.debug("Release finalization: skipping since tagged release for #{train.tag_name} already exists!")
       end
-    end
-
-    def namespaced_release_branch
-      vcs_provider.namespaced_branch(release_branch)
     end
 
     def pr_title

--- a/app/libs/triggers/post_release/release_back_merge.rb
+++ b/app/libs/triggers/post_release/release_back_merge.rb
@@ -25,7 +25,7 @@ class Triggers::PostRelease
         release: release,
         new_pull_request: release.pull_requests.post_release.open.build,
         to_branch_ref: release_backmerge_branch,
-        from_branch_ref: namespaced_release_branch,
+        from_branch_ref: branch_name,
         title: release_pr_title,
         description: pr_description
       ).then do
@@ -33,7 +33,7 @@ class Triggers::PostRelease
           release: release,
           new_pull_request: release.pull_requests.post_release.open.build,
           to_branch_ref: working_branch,
-          from_branch_ref: namespaced_backmerge_branch,
+          from_branch_ref: release_backmerge_branch,
           title: backmerge_pr_title,
           description: pr_description
         )
@@ -57,14 +57,6 @@ class Triggers::PostRelease
       rescue Installations::Errors::TaggedReleaseAlreadyExists
         logger.debug("Release finalization: skipping since tagged release for #{train.tag_name} already exists!")
       end
-    end
-
-    def namespaced_backmerge_branch
-      vcs_provider.namespaced_branch(release_backmerge_branch)
-    end
-
-    def namespaced_release_branch
-      vcs_provider.namespaced_branch(branch_name)
     end
 
     def release_pr_title

--- a/app/libs/triggers/post_release/release_back_merge.rb
+++ b/app/libs/triggers/post_release/release_back_merge.rb
@@ -27,7 +27,7 @@ class Triggers::PostRelease
         to_branch_ref: release_backmerge_branch,
         from_branch_ref: branch_name,
         title: release_pr_title,
-        description: pr_description
+        description: pr_description(branch_name, release_backmerge_branch)
       ).then do
         Triggers::PullRequest.create_and_merge!(
           release: release,
@@ -35,7 +35,7 @@ class Triggers::PostRelease
           to_branch_ref: working_branch,
           from_branch_ref: release_backmerge_branch,
           title: backmerge_pr_title,
-          description: pr_description
+          description: pr_description(release_backmerge_branch, working_branch)
         )
       end.then do |value|
         stamp_pr_success
@@ -67,9 +67,10 @@ class Triggers::PostRelease
       "[#{release.release_version}] Backmerge to working branch"
     end
 
-    def pr_description
+    def pr_description(from, to)
       <<~TEXT
-        Verbose description for #{train.name} release on #{release.scheduled_at}
+        The release train #{train.name} with version #{release.release_version} has finished.
+        The #{from} branch has to be merged into #{to} branch.
       TEXT
     end
   end

--- a/app/libs/triggers/post_release/release_back_merge.rb
+++ b/app/libs/triggers/post_release/release_back_merge.rb
@@ -16,7 +16,7 @@ class Triggers::PostRelease
     private
 
     attr_reader :train, :release
-    delegate :vcs_provider, :release_backmerge_branch, :working_branch, to: :train
+    delegate :release_backmerge_branch, :working_branch, to: :train
     delegate :branch_name, to: :release
     delegate :logger, to: Rails
 

--- a/app/libs/triggers/pre_release/parallel_branches.rb
+++ b/app/libs/triggers/pre_release/parallel_branches.rb
@@ -28,7 +28,7 @@ class Triggers::PreRelease
         release: release,
         new_pull_request: release.pull_requests.pre_release.open.build,
         to_branch_ref: release_branch,
-        from_branch_ref: namespaced_working_branch,
+        from_branch_ref: working_branch,
         title: pr_title,
         description: PR_DESCRIPTION,
         allow_without_diff: false
@@ -37,10 +37,6 @@ class Triggers::PreRelease
         release.event_stamp_now!(reason: :kickoff_pr_succeeded, kind: :success, data: {url: pr.url, number: pr.number})
         GitHub::Result.new { value }
       end
-    end
-
-    def namespaced_working_branch
-      vcs_provider.namespaced_branch(working_branch)
     end
 
     def pr_title

--- a/app/libs/triggers/pre_release/parallel_branches.rb
+++ b/app/libs/triggers/pre_release/parallel_branches.rb
@@ -21,8 +21,6 @@ class Triggers::PreRelease
     delegate :train, to: :release
     delegate :vcs_provider, :working_branch, to: :train
 
-    PR_DESCRIPTION = "Merging this before starting release.".freeze
-
     def create_and_merge_pr
       Triggers::PullRequest.create_and_merge!(
         release: release,
@@ -30,7 +28,7 @@ class Triggers::PreRelease
         to_branch_ref: release_branch,
         from_branch_ref: working_branch,
         title: pr_title,
-        description: PR_DESCRIPTION,
+        description: pr_description,
         allow_without_diff: false
       ).then do |value|
         pr = release.reload.pull_requests.pre_release.first
@@ -41,6 +39,10 @@ class Triggers::PreRelease
 
     def pr_title
       "[#{version_in_progress(train.version_current)}] Pre-release merge"
+    end
+
+    def pr_description
+      "A new release train #{train.name} is starting. The #{working_branch} branch has to be merged into #{release_branch} branch."
     end
   end
 end

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -175,11 +175,11 @@ class GithubIntegration < ApplicationRecord
   }
 
   def create_pr!(to_branch_ref, from_branch_ref, title, description)
-    installation.create_pr!(app_config.code_repository_name, to_branch_ref, from_branch_ref, title, description)
+    installation.create_pr!(app_config.code_repository_name, to_branch_ref, namespaced_branch(from_branch_ref), title, description)
   end
 
   def find_pr(to_branch_ref, from_branch_ref)
-    installation.find_pr(app_config.code_repository_name, to_branch_ref, from_branch_ref)
+    installation.find_pr(app_config.code_repository_name, to_branch_ref, namespaced_branch(from_branch_ref))
   end
 
   def get_pr(pr_number)

--- a/app/models/gitlab_integration.rb
+++ b/app/models/gitlab_integration.rb
@@ -128,10 +128,6 @@ class GitlabIntegration < ApplicationRecord
     false
   end
 
-  def namespaced_branch(branch_name)
-    branch_name
-  end
-
   COMMIT_TRANSFORMATIONS = {
     commit_sha: :id,
     author_email: :author_email,

--- a/app/views/releases/live_release/_pull_requests.html.erb
+++ b/app/views/releases/live_release/_pull_requests.html.erb
@@ -19,7 +19,7 @@
           </div>
         <% else %>
           <div class="font-mono text-xs mt-2">
-            <%= short_sha(pr.base_ref) %> ← <%= short_sha(pr.head_ref) %>
+            <%= pr.base_ref %> ← <%= pr.head_ref %>
           </div>
         <% end %>
 

--- a/spec/libs/triggers/pull_request_spec.rb
+++ b/spec/libs/triggers/pull_request_spec.rb
@@ -28,8 +28,9 @@ describe Triggers::PullRequest do
         title: pr_title,
         description: pr_description
       )
+      namespaced_release_branch = "#{release.train.app.config.code_repo_namespace}:#{release_branch}"
 
-      expect(repo_integration).to have_received(:create_pr!).with(repo_name, working_branch, release_branch, pr_title, pr_description)
+      expect(repo_integration).to have_received(:create_pr!).with(repo_name, working_branch, namespaced_release_branch, pr_title, pr_description)
       expect(repo_integration).to have_received(:merge_pr!)
       expect(result.ok?).to be(true)
       expect(release.reload.pull_requests.closed.size).to eq(1)
@@ -47,8 +48,9 @@ describe Triggers::PullRequest do
         title: pr_title,
         description: pr_description
       )
+      namespaced_release_branch = "#{release.train.app.config.code_repo_namespace}:#{release_branch}"
 
-      expect(repo_integration).to have_received(:create_pr!).with(repo_name, working_branch, release_branch, pr_title, pr_description)
+      expect(repo_integration).to have_received(:create_pr!).with(repo_name, working_branch, namespaced_release_branch, pr_title, pr_description)
       expect(repo_integration).not_to have_received(:merge_pr!)
       expect(result.ok?).to be(true)
       expect(release.reload.pull_requests.size).to eq(0)
@@ -67,8 +69,9 @@ describe Triggers::PullRequest do
         description: pr_description,
         allow_without_diff: false
       )
+      namespaced_release_branch = "#{release.train.app.config.code_repo_namespace}:#{release_branch}"
 
-      expect(repo_integration).to have_received(:create_pr!).with(repo_name, working_branch, release_branch, pr_title, pr_description)
+      expect(repo_integration).to have_received(:create_pr!).with(repo_name, working_branch, namespaced_release_branch, pr_title, pr_description)
       expect(repo_integration).not_to have_received(:merge_pr!)
       expect(result.ok?).to be(false)
       expect(release.reload.pull_requests.size).to eq(0)
@@ -86,8 +89,9 @@ describe Triggers::PullRequest do
         title: pr_title,
         description: pr_description
       )
+      namespaced_release_branch = "#{release.train.app.config.code_repo_namespace}:#{release_branch}"
 
-      expect(repo_integration).to have_received(:create_pr!).with(repo_name, working_branch, release_branch, pr_title, pr_description)
+      expect(repo_integration).to have_received(:create_pr!).with(repo_name, working_branch, namespaced_release_branch, pr_title, pr_description)
       expect(repo_integration).to have_received(:merge_pr!)
       expect(result.ok?).to be(false)
       expect(release.reload.pull_requests.open.size).to eq(1)


### PR DESCRIPTION
**Closes:** #88 

## Because

Ensure that the release changes make it back to the working branch after a release is finished.

NOTE: This is being done using the PR creation and merge process as GitHub does not allow cherry-picking commits using their REST API. GitLab does allow it but we need to be consistent in our approach.