### PR TITLE
Modular versioning strategies

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,4 +1,5 @@
 class ReleasesController < SignedInApplicationController
+  using RefinedString
   around_action :set_time_zone
   before_action :require_write_access!, only: %i[create destroy post_release]
   before_action :set_release, only: [:show, :timeline, :destroy]
@@ -13,8 +14,9 @@ class ReleasesController < SignedInApplicationController
   def create
     @app = current_organization.apps.friendly.find(params[:app_id])
     @train = @app.trains.friendly.find(params[:train_id])
+    @has_major_bump = params[:has_major_bump]&.to_boolean
 
-    response = Triggers::Release.call(@train)
+    response = Triggers::Release.call(@train, has_major_bump: @has_major_bump)
 
     if response.success?
       redirect_to live_release_path, notice: "A new release has started successfully."

--- a/app/controllers/trains_controller.rb
+++ b/app/controllers/trains_controller.rb
@@ -95,6 +95,9 @@ class TrainsController < SignedInApplicationController
       :working_branch,
       :working_repo,
       :version_seeded_with,
+      :major_version_seed,
+      :minor_version_seed,
+      :patch_version_seed,
       :branching_strategy,
       :release_backmerge_branch,
       :release_branch

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include RefinedString
+
   STATUS_COLOR_PALETTE = {
     success: %w[bg-green-100 text-green-600],
     failure: %w[bg-rose-100 text-rose-600],
@@ -47,7 +49,7 @@ module ApplicationHelper
   end
 
   def version_in_progress(version)
-    VersioningStrategies::Semverish.new(version).to_s(patch_glob: true)
+    version.to_semverish.to_s(patch_glob: true)
   end
 
   def text_field_classes(is_disabled:)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,8 +47,7 @@ module ApplicationHelper
   end
 
   def version_in_progress(version)
-    semver = Semantic::Version.new(version)
-    "#{semver.major}.#{semver.minor}.*"
+    VersioningStrategies::Semverish.new(version).to_s(patch_glob: true)
   end
 
   def text_field_classes(is_disabled:)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  include RefinedString
+  using RefinedString
 
   STATUS_COLOR_PALETTE = {
     success: %w[bg-green-100 text-green-600],

--- a/app/javascript/controllers/domain/version_name_help_controller.js
+++ b/app/javascript/controllers/domain/version_name_help_controller.js
@@ -80,8 +80,6 @@ export default class extends Controller {
   }
 
   __allButMinorMissing() {
-    return this.__is_present(this.majorVersion) &&
-      this.__is_present(this.patchVersion) &&
-      !this.__is_present(this.minorVersion)
+    return this.__is_present(this.majorVersion) && this.__is_present(this.patchVersion) && !this.__is_present(this.minorVersion)
   }
 }

--- a/app/libs/triggers/release.rb
+++ b/app/libs/triggers/release.rb
@@ -2,13 +2,14 @@ class Triggers::Release
   include Memery
   include SiteHttp
 
-  def self.call(train)
-    new(train).call
+  def self.call(train, has_major_bump: false)
+    new(train, has_major_bump:).call
   end
 
-  def initialize(train)
+  def initialize(train, has_major_bump: false)
     @train = train
     @starting_time = Time.current
+    @has_major_bump = has_major_bump
   end
 
   # FIXME: should we take a lock around this train? what is someone double triggers the run?
@@ -48,7 +49,8 @@ class Triggers::Release
         code_name: Haikunator.haikunate(100),
         scheduled_at: starting_time,
         branch_name: release_branch,
-        release_version: train.version_current
+        release_version: train.version_current,
+        has_major_bump: major_release?
       )
   end
 
@@ -70,5 +72,9 @@ class Triggers::Release
     end
 
     branch_name
+  end
+
+  def major_release?
+    @has_major_bump
   end
 end

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -7,7 +7,7 @@ class VersioningStrategies::Semverish
   }
 
   INCREMENTS = {
-    pn: proc { |v| (!v.nil?) ? v + 1 : nil },
+    pn: proc { |v| (!v.nil?) ? v.abs + 1 : nil },
     yyyy: proc { |_v| Time.current.year }
   }
 
@@ -18,7 +18,7 @@ class VersioningStrategies::Semverish
   # and removes support for the prerelease version and the build metadata
   SEMVER_REGEX = /\A(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?\Z/
 
-  attr_accessor :major, :minor, :patch, :pre, :build
+  attr_accessor :major, :minor, :patch
   attr_reader :version
 
   def initialize(version_str)
@@ -28,8 +28,6 @@ class VersioningStrategies::Semverish
     @major = v[1].to_i
     @minor = v[2].to_i
     @patch = v[3].presence && v[3].to_i
-    @pre = v[4]
-    @build = v[5]
     @version = version_str
   end
 

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -76,9 +76,7 @@ class VersioningStrategies::Semverish
     keys.zip(to_a).to_h
   end
 
-  def hash
-    to_a.hash
-  end
+  delegate :hash, to: :to_a
 
   def eql?(other)
     hash == other.hash

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -1,0 +1,93 @@
+class VersioningStrategies::Semverish
+  include Comparable
+
+  TEMPLATES = {
+    pn: "Positive Number",
+    yyyy: "Current Year"
+  }
+
+  INCREMENTS = {
+    pn: proc { |v| (!v.nil?) ? v + 1 : nil },
+    yyyy: proc { |_v| Time.current.year }
+  }
+
+  DEFAULT_TEMPLATE = :pn
+
+  # This is a modified semver regex that makes the patch version, the prerelease version and the build metadata optional
+  SEMVER_REGEX = /\A(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][a-zA-Z0-9-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][a-zA-Z0-9-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?\Z/
+
+  attr_accessor :major, :minor, :patch, :pre, :build
+  attr_reader :version
+
+  def initialize(version_str)
+    v = version_str.match(SEMVER_REGEX)
+
+    raise ArgumentError.new("#{version_str} is not a valid Semverish") if v.nil?
+
+    @major = v[1].to_i
+    @minor = v[2].to_i
+    @patch = v[3].presence && v[3].to_i
+    @pre = v[4]
+    @build = v[5]
+    @version = version_str
+    @is_proper_semver = !@patch.nil?
+  end
+
+  def increment!(term, template_type: DEFAULT_TEMPLATE)
+    term = term.to_sym
+    new_version = clone
+    new_value = INCREMENTS[template_type].call(send(term))
+    new_version.send("#{term}=", new_value)
+    new_version.minor = 0 if term == :major
+    new_version.patch = 0 if semver? && (term == :major || term == :minor)
+    new_version.build = new_version.pre = nil
+    new_version
+  end
+
+  def <=>(other)
+    other = new(other) if other.is_a? String
+
+    if other.partial_semver? != partial_semver?
+      raise ArgumentError.new("cannot compare #{@version} with partial version #{other.version}")
+    end
+
+    [:major, :minor, (semver? ? :patch : nil)].compact.each do |part|
+      c = (send(part) <=> other.send(part))
+
+      if c != 0
+        return c
+      end
+    end
+
+    0
+  end
+
+  def to_a
+    [@major, @minor, @patch].compact
+  end
+
+  def to_s
+    to_a.join "."
+  end
+
+  def to_h
+    keys = [:major, :minor, :patch]
+    keys.zip(to_a).to_h
+  end
+
+  def hash
+    to_a.hash
+  end
+
+  def eql?(other)
+    hash == other.hash
+  end
+
+  def partial_semver?
+    !semver?
+  end
+
+  def semver?
+    !@patch.nil?
+  end
+end

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -21,8 +21,12 @@ class VersioningStrategies::Semverish
   attr_accessor :major, :minor, :patch
   attr_reader :version
 
+  def self.build(major, minor, patch)
+    new([major, minor, patch].compact_blank.join("."))
+  end
+
   def initialize(version_str)
-    v = version_str.match(SEMVER_REGEX)
+    v = version_str&.match(SEMVER_REGEX)
     raise ArgumentError.new("#{version_str} is not a valid Semverish") if v.nil?
 
     @major = v[1].to_i

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -2,16 +2,16 @@ class VersioningStrategies::Semverish
   include Comparable
 
   TEMPLATES = {
-    pn: "Positive Number",
-    yyyy: "Current Year"
+    "Positive Number" => :pn,
+    "Current Year" => :yyyy
   }
 
   INCREMENTS = {
-    pn: proc { |v| (!v.nil?) ? v.abs + 1 : nil },
-    yyyy: proc { |_v| Time.current.year }
+    TEMPLATES["Positive Number"] => proc { |v| (!v.nil?) ? v.abs + 1 : nil },
+    TEMPLATES["Current Year"] => proc { |_v| Time.current.year }
   }
 
-  DEFAULT_TEMPLATE = :pn
+  DEFAULT_TEMPLATE = TEMPLATES["Positive Number"]
 
   # adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
   # makes the patch version optional
@@ -31,7 +31,7 @@ class VersioningStrategies::Semverish
     @version = version_str
   end
 
-  def increment!(term, template_type: DEFAULT_TEMPLATE)
+  def bump!(term, template_type: DEFAULT_TEMPLATE)
     term = term.to_sym
     new_version = clone
     new_value = INCREMENTS[template_type].call(public_send(term))

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -34,11 +34,10 @@ class VersioningStrategies::Semverish
   def increment!(term, template_type: DEFAULT_TEMPLATE)
     term = term.to_sym
     new_version = clone
-    new_value = INCREMENTS[template_type].call(send(term))
-    new_version.send("#{term}=", new_value)
+    new_value = INCREMENTS[template_type].call(public_send(term))
+    new_version.public_send("#{term}=", new_value)
     new_version.minor = 0 if term == :major
     new_version.patch = 0 if proper? && (term == :major || term == :minor)
-    new_version.build = new_version.pre = nil
     new_version
   end
 
@@ -50,7 +49,7 @@ class VersioningStrategies::Semverish
     end
 
     [:major, :minor, (proper? ? :patch : nil)].compact.each do |part|
-      c = (send(part) <=> other.send(part))
+      c = (public_send(part) <=> other.public_send(part))
 
       if c != 0
         return c

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -22,6 +22,7 @@ class VersioningStrategies::Semverish
   attr_reader :version
 
   def self.build(major, minor, patch)
+    raise ArgumentError.new("Cannot build a Semverish without a minor") if major.present? && patch.present? && minor.blank?
     new([major, minor, patch].compact_blank.join("."))
   end
 

--- a/app/libs/webhook_processors/push.rb
+++ b/app/libs/webhook_processors/push.rb
@@ -29,7 +29,7 @@ class WebhookProcessors::Push
     return unless release.staged_rollout_in_progress?
     return if release.step_runs.none?
 
-    train.bump_version!(:patch)
+    train.bump_fix!
     stamp_version_changed
   end
 

--- a/app/models/releases/train.rb
+++ b/app/models/releases/train.rb
@@ -65,9 +65,9 @@ class Releases::Train < ApplicationRecord
   validate :semver_compatibility, on: :create
   validate :ready?, on: :create
   validate :valid_step_configuration, on: :activate_context
-  validates :version_seeded_with, presence: true, on: :create
   validates :name, format: {with: /\A[a-zA-Z0-9\s_\/-]+\z/, message: I18n.t("train_name")}
 
+  after_initialize :set_constituent_seed_versions, if: :persisted?
   before_validation :set_version_seeded_with, if: :new_record?
   before_create :set_current_version
   before_create :set_default_status
@@ -215,5 +215,10 @@ class Releases::Train < ApplicationRecord
     unless steps.release.size == 1
       errors.add(:steps, "there should be one release step")
     end
+  end
+
+  def set_constituent_seed_versions
+    semverish = version_seeded_with.to_semverish
+    self.major_version_seed, self.minor_version_seed, self.patch_version_seed = semverish.major, semverish.minor, semverish.patch
   end
 end

--- a/app/models/releases/train.rb
+++ b/app/models/releases/train.rb
@@ -49,6 +49,7 @@ class Releases::Train < ApplicationRecord
 
   friendly_id :name, use: :slugged
   auto_strip_attributes :name, squish: true
+  attr_accessor :major_version_seed, :minor_version_seed, :patch_version_seed
 
   validates :branching_strategy, :working_branch, presence: true
   validates :release_backmerge_branch, presence: true,
@@ -64,7 +65,7 @@ class Releases::Train < ApplicationRecord
   validate :semver_compatibility
   validate :ready?, on: :create
   validate :valid_step_configuration, on: :activate_context
-  validates :name, format: {with: /\A[a-zA-Z0-9\s_\/-]+\z/, message: "can only contain alphanumerics, underscores, hyphens and forward-slashes."}
+  validates :name, format: {with: /\A[a-zA-Z0-9\s_\/-]+\z/, message: I18n.t("train_name")}
 
   before_create :set_current_version
   before_create :set_default_status

--- a/app/models/releases/train.rb
+++ b/app/models/releases/train.rb
@@ -184,7 +184,7 @@ class Releases::Train < ApplicationRecord
   end
 
   def semver_compatibility
-    Semantic::Version.new(version_seeded_with)
+    VersioningStrategies::Semverish.new(version_seeded_with)
   rescue ArgumentError
     errors.add(:version_seeded_with, "Please choose a valid semver format, eg. major.minor.patch")
   end

--- a/app/models/releases/train.rb
+++ b/app/models/releases/train.rb
@@ -147,12 +147,11 @@ class Releases::Train < ApplicationRecord
     version_current
   end
 
-  def bump_release!(major_version = nil)
-    semverish = version_current.to_semverish
-    bump_term = (major_version.present? && major_version > semverish.major) ? :major : :minor
+  def bump_release!(has_major_bump = false)
+    bump_term = has_major_bump ? :major : :minor
 
     if runs.any?
-      self.version_current = semverish.bump!(bump_term).to_s
+      self.version_current = version_current.ver_bump(bump_term)
       save!
     end
 

--- a/app/models/releases/train.rb
+++ b/app/models/releases/train.rb
@@ -147,9 +147,12 @@ class Releases::Train < ApplicationRecord
     version_current
   end
 
-  def bump_release!
+  def bump_release!(major_version = nil)
+    semverish = version_current.to_semverish
+    bump_term = (major_version.present? && major_version > semverish.major) ? :major : :minor
+
     if runs.any?
-      self.version_current = version_current.ver_bump(:minor)
+      self.version_current = semverish.bump!(bump_term).to_s
       save!
     end
 

--- a/app/models/releases/train.rb
+++ b/app/models/releases/train.rb
@@ -136,9 +136,20 @@ class Releases::Train < ApplicationRecord
     "v#{version_current}"
   end
 
-  def bump_version!(element = :minor)
+  def bump_fix!
     if runs.any?
-      self.version_current = version_current.ver_bump(element)
+      semverish = version_current.to_semverish
+      self.version_current = semverish.bump!(:patch).to_s if semverish.proper?
+      self.version_current = semverish.bump!(:minor).to_s if semverish.partial?
+      save!
+    end
+
+    version_current
+  end
+
+  def bump_release!
+    if runs.any?
+      self.version_current = version_current.ver_bump(:minor)
       save!
     end
 

--- a/app/models/releases/train.rb
+++ b/app/models/releases/train.rb
@@ -138,7 +138,7 @@ class Releases::Train < ApplicationRecord
 
   def bump_version!(element = :minor)
     if runs.any?
-      self.version_current = version_current.semver_bump(element)
+      self.version_current = version_current.ver_bump(element)
       save!
     end
 
@@ -146,7 +146,7 @@ class Releases::Train < ApplicationRecord
   end
 
   def set_current_version
-    self.version_current = version_seeded_with.semver_bump(:minor)
+    self.version_current = version_seeded_with.ver_bump(:minor)
   end
 
   def branching_strategy_name

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -21,6 +21,8 @@ class Releases::Train::Run < ApplicationRecord
   include AASM
   include Passportable
   include ActionView::Helpers::DateHelper
+  include RefinedString
+
   self.implicit_order_column = :scheduled_at
 
   belongs_to :train, class_name: "Releases::Train"
@@ -268,8 +270,7 @@ class Releases::Train::Run < ApplicationRecord
 
   def hotfix?
     return false unless on_track?
-    VersioningStrategies::Semverish.new(release_version) >
-      VersioningStrategies::Semverish.new(original_release_version)
+    release_version.to_semverish > original_release_version.to_semverish
   end
 
   private

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -21,7 +21,7 @@ class Releases::Train::Run < ApplicationRecord
   include AASM
   include Passportable
   include ActionView::Helpers::DateHelper
-  include RefinedString
+  using RefinedString
 
   self.implicit_order_column = :scheduled_at
 

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -97,6 +97,7 @@ class Releases::Train::Run < ApplicationRecord
   scope :pending_release, -> { where.not(status: [:finished, :stopped]) }
   scope :released, -> { where(status: :finished).where.not(completed_at: nil) }
   delegate :app, :pre_release_prs?, to: :train
+  attr_accessor :manually_set_major_version
 
   def set_default_release_metadata
     create_release_metadata!(locale: DEFAULT_LOCALE, release_notes: DEFAULT_RELEASE_NOTES)
@@ -164,7 +165,7 @@ class Releases::Train::Run < ApplicationRecord
   end
 
   def set_version
-    new_version = train.bump_release!
+    new_version = train.bump_release!(manually_set_major_version)
     self.release_version = new_version
     self.original_release_version = new_version
   end

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -164,7 +164,7 @@ class Releases::Train::Run < ApplicationRecord
   end
 
   def set_version
-    new_version = train.bump_version!.to_s
+    new_version = train.bump_release!
     self.release_version = new_version
     self.original_release_version = new_version
   end

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -268,7 +268,8 @@ class Releases::Train::Run < ApplicationRecord
 
   def hotfix?
     return false unless on_track?
-    Semantic::Version.new(release_version) > Semantic::Version.new(original_release_version)
+    VersioningStrategies::Semverish.new(release_version) >
+      VersioningStrategies::Semverish.new(original_release_version)
   end
 
   private

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -97,7 +97,7 @@ class Releases::Train::Run < ApplicationRecord
   scope :pending_release, -> { where.not(status: [:finished, :stopped]) }
   scope :released, -> { where(status: :finished).where.not(completed_at: nil) }
   delegate :app, :pre_release_prs?, to: :train
-  attr_accessor :manually_set_major_version
+  attr_accessor :has_major_bump
 
   def set_default_release_metadata
     create_release_metadata!(locale: DEFAULT_LOCALE, release_notes: DEFAULT_RELEASE_NOTES)
@@ -165,7 +165,7 @@ class Releases::Train::Run < ApplicationRecord
   end
 
   def set_version
-    new_version = train.bump_release!(manually_set_major_version)
+    new_version = train.bump_release!(has_major_bump)
     self.release_version = new_version
     self.original_release_version = new_version
   end

--- a/app/refinements/refined_string.rb
+++ b/app/refinements/refined_string.rb
@@ -40,8 +40,8 @@ module RefinedString
       []
     end
 
-    def semver_bump(element)
-      Semantic::Version.new(to_s).increment!(element).to_s
+    def semver_bump(term)
+      VersioningStrategies::Semverish.new(to_s).bump!(term).to_s
     end
   end
 end

--- a/app/refinements/refined_string.rb
+++ b/app/refinements/refined_string.rb
@@ -40,8 +40,12 @@ module RefinedString
       []
     end
 
-    def semver_bump(term)
-      VersioningStrategies::Semverish.new(to_s).bump!(term).to_s
+    def to_semverish
+      VersioningStrategies::Semverish.new(to_s)
+    end
+
+    def ver_bump(term)
+      to_semverish.bump!(term).to_s
     end
   end
 end

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -20,40 +20,36 @@
           <span class="font-mono" data-domain--branch-name-help-target="helpTextVal"></span>
         </p>
       </div>
+
+      <div>
+        <%= form.label :description, class: "block text-sm font-medium mb-1" %>
+        <%= form.text_area :description, class: "form-input w-full h-24",
+                           placeholder: "Describe the purpose of your train..." %>
+      </div>
     </div>
 
     <div>
-      <%= form.label :description, class: "block text-sm font-medium mb-1" %>
-      <%= form.text_area :description, class: "form-input w-full h-24",
-                         placeholder: "Describe the purpose of your train..." %>
-    </div>
-
-    <div data-controller="domain--version-name-help"
-         data-domain--version-name-help-disabled-value="<%= train.persisted? %>"
-         data-domain--version-name-help-version-current-value="<%= train.version_current %>">
-      <%= form.label :version_seeded_with, class: "block text-sm font-medium mb-1" %>
-      <%= form.text_field :version_seeded_with,
-                          class: text_field_classes(is_disabled: train.persisted?),
-                          placeholder: "eg., 0.1.0",
+      <%= form.label :major_version_seed, "Current Major Version", class: "inline-flex text-sm font-medium mb-1" %>
+      <%= form.text_field :major_version_seed,
+                          class: text_field_classes(is_disabled: false),
+                          placeholder: "will only be bumped manually",
                           required: true,
-                          disabled: train.persisted?,
                           data: { domain__version_name_help_target: "input",
                                   action: "domain--version-name-help#bump" } %>
-      <div class="text-sm mt-1">
-        <p class="italic">
-          <span data-domain--version-name-help-target="helpTextTitle"></span>&nbsp;
-          <span class="font-mono" data-domain--version-name-help-target="helpTextVal"></span>
-        </p>
-        <p class="pt-2">
-          Tramline increments the version name for every release build created, which guarantees that every build can be
-          uniquely identified. We follow <a href="https://semver.org" class="underline">SemVer</a>.
-        </p>
-        <p class="pt-1">
-          Every new release will increment the minor version.
-          Every build generated during a release itself will increment the patch version. Once this is setup, teams do
-          not need to worry about manually incrementing the version name for every release.
-        </p>
-      </div>
+      <%= form.label :minor_version_seed, "Current Minor Version", class: "inline-flex text-sm font-medium mb-1" %>
+      <%= form.text_field :minor_version_seed,
+                          class: text_field_classes(is_disabled: false),
+                          placeholder: "bumped for every new release",
+                          required: true,
+                          data: { domain__version_name_help_target: "input",
+                                  action: "domain--version-name-help#bump" } %>
+      <%= form.label :patch_version_seed, "Current Point Version (optional)", class: "inline-flex text-sm font-medium mb-1" %>
+      <%= form.text_field :patch_version_seed,
+                          class: text_field_classes(is_disabled: false),
+                          placeholder: "bumped only for hotfixes",
+                          required: false,
+                          data: { domain__version_name_help_target: "input",
+                                  action: "domain--version-name-help#bump" } %>
     </div>
   </div>
 

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -4,56 +4,116 @@
               url: url,
               builder: ButtonHelper::AuthzForms) do |form| %>
 
-  <div class="grid gap-5 md:grid-cols-2">
+  <div class="grid gap-x-5 gap-y-2 md:grid-cols-2">
     <div data-controller="domain--branch-name-help"
          data-domain--branch-name-help-current-value="<%= train.display_name %>">
-      <%= form.label :name, class: "block text-sm font-medium mb-1" %>
-      <%= form.text_field :name,
-                          class: "form-input w-full",
-                          placeholder: "Enter train name...",
-                          required: true,
-                          data: { domain__branch_name_help_target: "input",
-                                  action: "domain--branch-name-help#set" } %>
-      <div class="text-sm mt-1">
-        <p class="italic">
-          <span data-domain--branch-name-help-target="helpTextTitle"></span>
-          <span class="font-mono" data-domain--branch-name-help-target="helpTextVal"></span>
-        </p>
+      <div class="mb-2">
+        <%= form.label :name, class: "block text-sm font-medium mb-1" %>
+        <%= form.text_field :name,
+                            class: "form-input w-full",
+                            placeholder: "Enter train name...",
+                            required: true,
+                            data: { domain__branch_name_help_target: "input",
+                                    action: "domain--branch-name-help#set" } %>
       </div>
 
-      <div>
+      <div class="text-sm italic">
+        <span data-domain--branch-name-help-target="helpTextTitle"></span>
+        <span class="font-mono" data-domain--branch-name-help-target="helpTextVal"></span>
+      </div>
+
+      <div class="mt-6">
         <%= form.label :description, class: "block text-sm font-medium mb-1" %>
         <%= form.text_area :description, class: "form-input w-full h-24",
                            placeholder: "Describe the purpose of your train..." %>
       </div>
     </div>
 
-    <div>
-      <%= form.label :major_version_seed, "Current Major Version", class: "inline-flex text-sm font-medium mb-1" %>
-      <%= form.text_field :major_version_seed,
-                          class: text_field_classes(is_disabled: false),
-                          placeholder: "will only be bumped manually",
-                          required: true,
-                          data: { domain__version_name_help_target: "input",
-                                  action: "domain--version-name-help#bump" } %>
-      <%= form.label :minor_version_seed, "Current Minor Version", class: "inline-flex text-sm font-medium mb-1" %>
-      <%= form.text_field :minor_version_seed,
-                          class: text_field_classes(is_disabled: false),
-                          placeholder: "bumped for every new release",
-                          required: true,
-                          data: { domain__version_name_help_target: "input",
-                                  action: "domain--version-name-help#bump" } %>
-      <%= form.label :patch_version_seed, "Current Point Version (optional)", class: "inline-flex text-sm font-medium mb-1" %>
-      <%= form.text_field :patch_version_seed,
-                          class: text_field_classes(is_disabled: false),
-                          placeholder: "bumped only for hotfixes",
-                          required: false,
-                          data: { domain__version_name_help_target: "input",
-                                  action: "domain--version-name-help#bump" } %>
+    <div class="grid gap-x-5 md:grid-cols-1"
+         data-controller="domain--version-name-help"
+         data-domain--version-name-help-disabled-value="<%= train.persisted? %>">
+
+      <div>
+        <%= form.label :major_version_seed,
+                       "Seed with your current version name (build name)",
+                       class: "block text-sm font-medium mb-1" %>
+        <%= form.text_field :major_version_seed,
+                            class: text_field_classes(is_disabled: train.persisted?).concat(" w-1/4"),
+                            placeholder: "major",
+                            required: true,
+                            disabled: train.persisted?,
+                            data: { domain__version_name_help_target: "majorInput",
+                                    action: "domain--version-name-help#bump" } %>
+
+        <span class="mx-1">.</span>
+        <%= form.text_field :minor_version_seed,
+                            class: text_field_classes(is_disabled: train.persisted?).concat(" w-1/4"),
+                            placeholder: "minor",
+                            required: true,
+                            disabled: train.persisted?,
+                            data: { domain__version_name_help_target: "minorInput",
+                                    action: "domain--version-name-help#bump" } %>
+
+        <span class="mx-1">.</span>
+        <%= form.text_field :patch_version_seed,
+                            class: text_field_classes(is_disabled: train.persisted?).concat(" w-1/4"),
+                            placeholder: "patch (optional)",
+                            required: false,
+                            disabled: train.persisted?,
+                            data: { domain__version_name_help_target: "patchInput",
+                                    action: "domain--version-name-help#bump" } %>
+      </div>
+
+      <% unless train.persisted? %>
+        <div class="text-sm italic mt-2">
+          <span hidden data-domain--version-name-help-target="helpTextVal"></span>
+        </div>
+
+        <div class="text-sm mt-2">
+          <div class="grid gap-x-5 gap-y-2 md:grid-cols-2">
+            <div class="flex flex-col bg-slate-50 rounded-sm pl-4 pt-4 mt-2 items-center justify-center">
+              <div class="flex-grow mb-2">
+                <div class="uppercase tracking-wider text-2xl drop-shadow-sm font-mono">
+                  <span data-domain--version-name-help-target="currentVersion">x.x</span>
+                </div>
+              </div>
+              <div class="mt-3 mb-3 text-stone text-xs drop-shadow-sm">
+                Your <strong>current</strong> release version
+              </div>
+            </div>
+            <div class="flex flex-col bg-slate-50 rounded-sm pl-4 pt-4 mt-2 items-center justify-center">
+              <div class="flex-grow mb-2">
+                <div class="uppercase tracking-wider text-2xl drop-shadow-sm font-mono">
+                  <span data-domain--version-name-help-target="nextVersion">x.x</span>
+                </div>
+              </div>
+              <div class="mt-3 mb-3 text-stone text-xs drop-shadow-sm">
+                Your <strong>next</strong> release will start with this version
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="text-sm mt-2">
+          <p>
+            Tramline increments the version name for every release build created, which guarantees that every build can be
+            uniquely identified. We allow a
+            <%= link_to_external "SemVer", "https://semver.org", class: "underline" %>-like scheme, for eg.
+            <code>MAJOR.MINOR.PATCH</code> and <code>MAJOR.MINOR</code>.
+          </p>
+
+          <p class="pt-2">
+            Refer to
+            the <%= link_to_external "docs", "https://docs.tramline.app/automations#version-name", class: "underline" %>
+            to learn more about versioning.
+          </p>
+        </div>
+      <% end %>
     </div>
   </div>
 
   <div class="text-xl text-slate-600 font-medium mt-8 mb-2">Branching strategy</div>
+
   <div class="grid gap-x-5 md:grid-cols-2">
     <div data-controller="branching-selector">
       <%= form.label "Strategy", class: "block text-sm font-medium mb-1" %>
@@ -89,7 +149,8 @@
 
   <% unless train.persisted? %>
     <div class="text-sm mt-4">
-      Refer to the <%= link_to_external "docs", "https://docs.tramline.app/branching-strategies", class: "underline" %> to learn more about our supported branching strategies.
+      Refer to the <%= link_to_external "docs", "https://docs.tramline.app/branching-strategies", class: "underline" %>
+      to learn more about our supported branching strategies.
     </div>
   <% end %>
 

--- a/app/views/trains/show.html.erb
+++ b/app/views/trains/show.html.erb
@@ -12,6 +12,7 @@
       <%= decorated_link_to :green, "Ongoing Release", live_release_app_train_releases_path(@app, @train) %>
     <% elsif @train.startable? %>
       <%= authz_button_to :blue, "Start new release", app_train_releases_path(@app, @train) %>
+      <%= authz_button_to :amber, "Start new major release", app_train_releases_path(@app, @train, has_major_bump: true) %>
     <% end %>
 
     <% if @train.runs.size > 0 %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -63,3 +63,4 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} exceptions prohibited this %{resource} from being saved:"
+  train_name: "can only contain alphanumerics, underscores, hyphens and forward-slashes."

--- a/db/data/20230526110416_backfill_original_release_version.rb
+++ b/db/data/20230526110416_backfill_original_release_version.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# FIXME: All uses of the `Semantic::Version` library have been replaced with an internal SemVer handler.
+# But the gem is kept around because this backfill migration depends on it.
 class BackfillOriginalReleaseVersion < ActiveRecord::Migration[7.0]
   def up
     Releases::Train::Run.all.each do |release|

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+describe VersioningStrategies::Semverish do
+  describe "validity" do
+    it "follows the semver rules for every term" do
+      expect(described_class.new("1.2.1").to_s).to eq("1.2.1")
+      expect(described_class.new("1.2.0").to_s).to eq("1.2.0")
+      expect(described_class.new("0.2").to_s).to eq("0.2")
+      expect { described_class.new("1.02").to_s }.to raise_error(ArgumentError)
+      expect { described_class.new("01.02").to_s }.to raise_error(ArgumentError)
+      expect { described_class.new("1.02.1").to_s }.to raise_error(ArgumentError)
+      expect { described_class.new("01.2.1").to_s }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#increment!" do
+    subject(:semverish) { described_class.new("1.2.1") }
+    subject(:partial_semverish) { described_class.new("1.2") }
+
+    context "semverish" do
+      context "updates the correct term based on positive numbers" do
+        it "bumps up major" do
+          expect(semverish.increment!(:major, template_type: :pn).to_s).to eq("2.0.0")
+        end
+
+        it "bumps up minor" do
+          expect(semverish.increment!(:minor, template_type: :pn).to_s).to eq("1.3.0")
+        end
+
+        it "bumps up patch" do
+          expect(semverish.increment!(:patch, template_type: :pn).to_s).to eq("1.2.2")
+        end
+      end
+    end
+
+    context "partial semverish" do
+      context "updates the correct term based on positive numbers" do
+        it "bumps up major" do
+          expect(partial_semverish.increment!(:major, template_type: :pn).to_s).to eq("2.0")
+        end
+
+        it "bumps up minor" do
+          expect(partial_semverish.increment!(:minor, template_type: :pn).to_s).to eq("1.3")
+        end
+
+        it "does not do anything if patch" do
+          expect(partial_semverish.increment!(:patch, template_type: :pn).to_s).to eq("1.2")
+        end
+      end
+    end
+  end
+
+  describe "comparisons" do
+    subject(:semverish) { described_class.new("1.2.1") }
+    subject(:partial_semverish) { described_class.new("1.2") }
+
+    context "semverish" do
+      it "compares using > or <" do
+        bigger = described_class.new("1.2.1")
+        smaller = described_class.new("1.2.0")
+
+        expect(bigger > smaller).to eq(true)
+        expect(bigger < smaller).to eq(false)
+      end
+
+      it "does not compare a partial and a proper semver" do
+        bigger = described_class.new("1.2.1")
+        smaller = described_class.new("1.2")
+
+        expect { bigger > smaller }.to raise_error(ArgumentError)
+      end
+
+      it "determines sort order" do
+        v1 = described_class.new("1.2.1")
+        v2 = described_class.new("1.2.3")
+        v3 = described_class.new("1.1.3")
+        v4 = described_class.new("2.1.3")
+
+        pv1 = described_class.new("2.1")
+        pv2 = described_class.new("2.1")
+        pv3 = described_class.new("1.2")
+        pv4 = described_class.new("1.3")
+        pv5 = described_class.new("0.1")
+
+        expect([v1, v2, v3, v4].sort).to eq([v3, v1, v2, v4])
+        expect([pv1, pv2, pv3, pv4, pv5].sort).to eq([pv5, pv3, pv4, pv1, pv2])
+      end
+    end
+  end
+end

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -18,8 +18,9 @@ describe VersioningStrategies::Semverish do
   end
 
   describe "comparisons" do
-    subject(:semverish) { described_class.new("1.2.1") }
     subject(:partial_semverish) { described_class.new("1.2") }
+
+    let(:semverish) { described_class.new("1.2.1") }
 
     it "compares using > or <" do
       v1 = described_class.new("1.2.1")
@@ -67,8 +68,9 @@ describe VersioningStrategies::Semverish do
   end
 
   describe "#increment!" do
-    subject(:semverish) { described_class.new("1.2.1") }
     subject(:partial_semverish) { described_class.new("1.2") }
+
+    let(:semverish) { described_class.new("1.2.1") }
 
     context "semverish" do
       context "updates the correct term based on positive numbers" do

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -67,7 +67,7 @@ describe VersioningStrategies::Semverish do
     end
   end
 
-  describe "#increment!" do
+  describe "#bump!" do
     subject(:partial_semverish) { described_class.new("1.2") }
 
     let(:semverish) { described_class.new("1.2.1") }
@@ -75,15 +75,15 @@ describe VersioningStrategies::Semverish do
     context "semverish" do
       context "updates the correct term based on positive numbers" do
         it "bumps up major" do
-          expect(semverish.increment!(:major, template_type: :pn).to_s).to eq("2.0.0")
+          expect(semverish.bump!(:major, template_type: :pn).to_s).to eq("2.0.0")
         end
 
         it "bumps up minor" do
-          expect(semverish.increment!(:minor, template_type: :pn).to_s).to eq("1.3.0")
+          expect(semverish.bump!(:minor, template_type: :pn).to_s).to eq("1.3.0")
         end
 
         it "bumps up patch" do
-          expect(semverish.increment!(:patch, template_type: :pn).to_s).to eq("1.2.2")
+          expect(semverish.bump!(:patch, template_type: :pn).to_s).to eq("1.2.2")
         end
       end
     end
@@ -91,15 +91,15 @@ describe VersioningStrategies::Semverish do
     context "partial semverish" do
       context "updates the correct term based on positive numbers" do
         it "bumps up major" do
-          expect(partial_semverish.increment!(:major, template_type: :pn).to_s).to eq("2.0")
+          expect(partial_semverish.bump!(:major, template_type: :pn).to_s).to eq("2.0")
         end
 
         it "bumps up minor" do
-          expect(partial_semverish.increment!(:minor, template_type: :pn).to_s).to eq("1.3")
+          expect(partial_semverish.bump!(:minor, template_type: :pn).to_s).to eq("1.3")
         end
 
         it "does not do anything if patch" do
-          expect(partial_semverish.increment!(:patch, template_type: :pn).to_s).to eq("1.2")
+          expect(partial_semverish.bump!(:patch, template_type: :pn).to_s).to eq("1.2")
         end
       end
     end

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -1,16 +1,21 @@
-require "rails_helper"
+rbeuire "rails_helper"
 
 describe VersioningStrategies::Semverish do
   describe "validity" do
     it "follows the semver rules for every term" do
-      expect(described_class.new("1.2.1").to_s).to eq("1.2.1")
-      expect(described_class.new("1.2.0").to_s).to eq("1.2.0")
-      expect(described_class.new("0.2").to_s).to eq("0.2")
+      expect(described_class.new("1.2.1").to_s).to be("1.2.1")
+      expect(described_class.new("1.2.0").to_s).to be("1.2.0")
+      expect(described_class.new("0.2").to_s).to be("0.2")
+    end
 
+    it "rejects invalids" do
       expect { described_class.new("1.02").to_s }.to raise_error(ArgumentError)
       expect { described_class.new("01.02").to_s }.to raise_error(ArgumentError)
       expect { described_class.new("1.02.1").to_s }.to raise_error(ArgumentError)
       expect { described_class.new("01.2.1").to_s }.to raise_error(ArgumentError)
+    end
+
+    it "rejects prerelease / buildmetadat" do
       expect { described_class.new("1.2.1+1").to_s }.to raise_error(ArgumentError)
       expect { described_class.new("1.2.1-alpha").to_s }.to raise_error(ArgumentError)
       expect { described_class.new("1.2.1-alpha+1").to_s }.to raise_error(ArgumentError)
@@ -27,10 +32,10 @@ describe VersioningStrategies::Semverish do
       v2 = described_class.new("1.2.0")
       v3 = described_class.new("1.2.0")
 
-      expect(v1 > v2).to eq(true)
-      expect(v1 < v2).to eq(false)
-      expect(v2 <= v3).to eq(true)
-      expect(v3 >= v2).to eq(true)
+      expect(v1 > v2).to be(true)
+      expect(v1 < v2).to be(false)
+      expect(v2 <= v3).to be(true)
+      expect(v3 >= v2).to be(true)
     end
 
     it "compares using ==" do
@@ -38,9 +43,9 @@ describe VersioningStrategies::Semverish do
       v2 = described_class.new("1.2.1")
       v3 = described_class.new("1.2.2")
 
-      expect(v1 == v2).to eq(true)
-      expect(v2 != v3).to eq(true)
-      expect(v1 == v3).to eq(false)
+      expect(v1 == v2).to be(true)
+      expect(v2 != v3).to be(true)
+      expect(v1 == v3).to be(false)
     end
 
     it "does not compare a partial and a proper semver" do
@@ -62,8 +67,8 @@ describe VersioningStrategies::Semverish do
       pv4 = described_class.new("1.3")
       pv5 = described_class.new("0.1")
 
-      expect([v1, v2, v3, v4].sort).to eq([v3, v1, v2, v4])
-      expect([pv1, pv2, pv3, pv4, pv5].sort).to eq([pv5, pv3, pv4, pv1, pv2])
+      expect([v1, v2, v3, v4].sort).to be([v3, v1, v2, v4])
+      expect([pv1, pv2, pv3, pv4, pv5].sort).to be([pv5, pv3, pv4, pv1, pv2])
     end
   end
 
@@ -72,35 +77,31 @@ describe VersioningStrategies::Semverish do
 
     let(:semverish) { described_class.new("1.2.1") }
 
-    context "semverish" do
-      context "updates the correct term based on positive numbers" do
-        it "bumps up major" do
-          expect(semverish.bump!(:major, template_type: :pn).to_s).to eq("2.0.0")
-        end
+    context "when semverish based on positive numbers" do
+      it "bumps up major" do
+        expect(semverish.bump!(:major, template_type: :pn).to_s).to be("2.0.0")
+      end
 
-        it "bumps up minor" do
-          expect(semverish.bump!(:minor, template_type: :pn).to_s).to eq("1.3.0")
-        end
+      it "bumps up minor" do
+        expect(semverish.bump!(:minor, template_type: :pn).to_s).to be("1.3.0")
+      end
 
-        it "bumps up patch" do
-          expect(semverish.bump!(:patch, template_type: :pn).to_s).to eq("1.2.2")
-        end
+      it "bumps up patch" do
+        expect(semverish.bump!(:patch, template_type: :pn).to_s).to be("1.2.2")
       end
     end
 
-    context "partial semverish" do
-      context "updates the correct term based on positive numbers" do
-        it "bumps up major" do
-          expect(partial_semverish.bump!(:major, template_type: :pn).to_s).to eq("2.0")
-        end
+    context "with partial semverish based on positive numbers" do
+      it "bumps up major" do
+        expect(partial_semverish.bump!(:major, template_type: :pn).to_s).to be("2.0")
+      end
 
-        it "bumps up minor" do
-          expect(partial_semverish.bump!(:minor, template_type: :pn).to_s).to eq("1.3")
-        end
+      it "bumps up minor" do
+        expect(partial_semverish.bump!(:minor, template_type: :pn).to_s).to be("1.3")
+      end
 
-        it "does not do anything if patch" do
-          expect(partial_semverish.bump!(:patch, template_type: :pn).to_s).to eq("1.2")
-        end
+      it "does not do anything if patch" do
+        expect(partial_semverish.bump!(:patch, template_type: :pn).to_s).to be("1.2")
       end
     end
   end

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -6,10 +6,63 @@ describe VersioningStrategies::Semverish do
       expect(described_class.new("1.2.1").to_s).to eq("1.2.1")
       expect(described_class.new("1.2.0").to_s).to eq("1.2.0")
       expect(described_class.new("0.2").to_s).to eq("0.2")
+
       expect { described_class.new("1.02").to_s }.to raise_error(ArgumentError)
       expect { described_class.new("01.02").to_s }.to raise_error(ArgumentError)
       expect { described_class.new("1.02.1").to_s }.to raise_error(ArgumentError)
       expect { described_class.new("01.2.1").to_s }.to raise_error(ArgumentError)
+      expect { described_class.new("1.2.1+1").to_s }.to raise_error(ArgumentError)
+      expect { described_class.new("1.2.1-alpha").to_s }.to raise_error(ArgumentError)
+      expect { described_class.new("1.2.1-alpha+1").to_s }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "comparisons" do
+    subject(:semverish) { described_class.new("1.2.1") }
+    subject(:partial_semverish) { described_class.new("1.2") }
+
+    it "compares using > or <" do
+      v1 = described_class.new("1.2.1")
+      v2 = described_class.new("1.2.0")
+      v3 = described_class.new("1.2.0")
+
+      expect(v1 > v2).to eq(true)
+      expect(v1 < v2).to eq(false)
+      expect(v2 <= v3).to eq(true)
+      expect(v3 >= v2).to eq(true)
+    end
+
+    it "compares using ==" do
+      v1 = described_class.new("1.2.1")
+      v2 = described_class.new("1.2.1")
+      v3 = described_class.new("1.2.2")
+
+      expect(v1 == v2).to eq(true)
+      expect(v2 != v3).to eq(true)
+      expect(v1 == v3).to eq(false)
+    end
+
+    it "does not compare a partial and a proper semver" do
+      bigger = described_class.new("1.2.1")
+      smaller = described_class.new("1.2")
+
+      expect { bigger > smaller }.to raise_error(ArgumentError)
+    end
+
+    it "determines sort order" do
+      v1 = described_class.new("1.2.1")
+      v2 = described_class.new("1.2.3")
+      v3 = described_class.new("1.1.3")
+      v4 = described_class.new("2.1.3")
+
+      pv1 = described_class.new("2.1")
+      pv2 = described_class.new("2.1")
+      pv3 = described_class.new("1.2")
+      pv4 = described_class.new("1.3")
+      pv5 = described_class.new("0.1")
+
+      expect([v1, v2, v3, v4].sort).to eq([v3, v1, v2, v4])
+      expect([pv1, pv2, pv3, pv4, pv5].sort).to eq([pv5, pv3, pv4, pv1, pv2])
     end
   end
 
@@ -46,44 +99,6 @@ describe VersioningStrategies::Semverish do
         it "does not do anything if patch" do
           expect(partial_semverish.increment!(:patch, template_type: :pn).to_s).to eq("1.2")
         end
-      end
-    end
-  end
-
-  describe "comparisons" do
-    subject(:semverish) { described_class.new("1.2.1") }
-    subject(:partial_semverish) { described_class.new("1.2") }
-
-    context "semverish" do
-      it "compares using > or <" do
-        bigger = described_class.new("1.2.1")
-        smaller = described_class.new("1.2.0")
-
-        expect(bigger > smaller).to eq(true)
-        expect(bigger < smaller).to eq(false)
-      end
-
-      it "does not compare a partial and a proper semver" do
-        bigger = described_class.new("1.2.1")
-        smaller = described_class.new("1.2")
-
-        expect { bigger > smaller }.to raise_error(ArgumentError)
-      end
-
-      it "determines sort order" do
-        v1 = described_class.new("1.2.1")
-        v2 = described_class.new("1.2.3")
-        v3 = described_class.new("1.1.3")
-        v4 = described_class.new("2.1.3")
-
-        pv1 = described_class.new("2.1")
-        pv2 = described_class.new("2.1")
-        pv3 = described_class.new("1.2")
-        pv4 = described_class.new("1.3")
-        pv5 = described_class.new("0.1")
-
-        expect([v1, v2, v3, v4].sort).to eq([v3, v1, v2, v4])
-        expect([pv1, pv2, pv3, pv4, pv5].sort).to eq([pv5, pv3, pv4, pv1, pv2])
       end
     end
   end

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -1,30 +1,29 @@
-rbeuire "rails_helper"
+require "rails_helper"
 
 describe VersioningStrategies::Semverish do
   describe "validity" do
     it "follows the semver rules for every term" do
-      expect(described_class.new("1.2.1").to_s).to be("1.2.1")
-      expect(described_class.new("1.2.0").to_s).to be("1.2.0")
-      expect(described_class.new("0.2").to_s).to be("0.2")
+      expect(described_class.new("1.2.1").to_s).to eq("1.2.1")
+      expect(described_class.new("1.2.0").to_s).to eq("1.2.0")
+      expect(described_class.new("0.2").to_s).to eq("0.2")
     end
 
     it "rejects invalids" do
-      expect { described_class.new("1.02").to_s }.to raise_error(ArgumentError)
-      expect { described_class.new("01.02").to_s }.to raise_error(ArgumentError)
-      expect { described_class.new("1.02.1").to_s }.to raise_error(ArgumentError)
-      expect { described_class.new("01.2.1").to_s }.to raise_error(ArgumentError)
+      expect { described_class.new("1.02") }.to raise_error(ArgumentError)
+      expect { described_class.new("01.02") }.to raise_error(ArgumentError)
+      expect { described_class.new("1.02.1") }.to raise_error(ArgumentError)
+      expect { described_class.new("01.2.1") }.to raise_error(ArgumentError)
     end
 
-    it "rejects prerelease / buildmetadat" do
-      expect { described_class.new("1.2.1+1").to_s }.to raise_error(ArgumentError)
-      expect { described_class.new("1.2.1-alpha").to_s }.to raise_error(ArgumentError)
-      expect { described_class.new("1.2.1-alpha+1").to_s }.to raise_error(ArgumentError)
+    it "rejects pre-release and build metadata" do
+      expect { described_class.new("1.2.1+1") }.to raise_error(ArgumentError)
+      expect { described_class.new("1.2.1-alpha") }.to raise_error(ArgumentError)
+      expect { described_class.new("1.2.1-alpha+1") }.to raise_error(ArgumentError)
     end
   end
 
   describe "comparisons" do
-    subject(:partial_semverish) { described_class.new("1.2") }
-
+    let(:partial_semverish) { described_class.new("1.2") }
     let(:semverish) { described_class.new("1.2.1") }
 
     it "compares using > or <" do
@@ -67,41 +66,40 @@ describe VersioningStrategies::Semverish do
       pv4 = described_class.new("1.3")
       pv5 = described_class.new("0.1")
 
-      expect([v1, v2, v3, v4].sort).to be([v3, v1, v2, v4])
-      expect([pv1, pv2, pv3, pv4, pv5].sort).to be([pv5, pv3, pv4, pv1, pv2])
+      expect([v1, v2, v3, v4].sort).to eq([v3, v1, v2, v4])
+      expect([pv1, pv2, pv3, pv4, pv5].sort).to eq([pv5, pv3, pv4, pv1, pv2])
     end
   end
 
   describe "#bump!" do
-    subject(:partial_semverish) { described_class.new("1.2") }
-
+    let(:partial_semverish) { described_class.new("1.2") }
     let(:semverish) { described_class.new("1.2.1") }
 
     context "when semverish based on positive numbers" do
       it "bumps up major" do
-        expect(semverish.bump!(:major, template_type: :pn).to_s).to be("2.0.0")
+        expect(semverish.bump!(:major, template_type: :pn).to_s).to eq("2.0.0")
       end
 
       it "bumps up minor" do
-        expect(semverish.bump!(:minor, template_type: :pn).to_s).to be("1.3.0")
+        expect(semverish.bump!(:minor, template_type: :pn).to_s).to eq("1.3.0")
       end
 
       it "bumps up patch" do
-        expect(semverish.bump!(:patch, template_type: :pn).to_s).to be("1.2.2")
+        expect(semverish.bump!(:patch, template_type: :pn).to_s).to eq("1.2.2")
       end
     end
 
     context "with partial semverish based on positive numbers" do
       it "bumps up major" do
-        expect(partial_semverish.bump!(:major, template_type: :pn).to_s).to be("2.0")
+        expect(partial_semverish.bump!(:major, template_type: :pn).to_s).to eq("2.0")
       end
 
       it "bumps up minor" do
-        expect(partial_semverish.bump!(:minor, template_type: :pn).to_s).to be("1.3")
+        expect(partial_semverish.bump!(:minor, template_type: :pn).to_s).to eq("1.3")
       end
 
       it "does not do anything if patch" do
-        expect(partial_semverish.bump!(:patch, template_type: :pn).to_s).to be("1.2")
+        expect(partial_semverish.bump!(:patch, template_type: :pn).to_s).to eq("1.2")
       end
     end
   end

--- a/spec/models/releases/train_spec.rb
+++ b/spec/models/releases/train_spec.rb
@@ -34,4 +34,66 @@ describe Releases::Train do
       expect(train.reload.active?).to be(true)
     end
   end
+
+  describe "#bump_fix!" do
+    it "updates the minor version if the current version is a partial semver" do
+      train = create(:releases_train, version_seeded_with: "1.2")
+      _run = create(:releases_train_run, train:)
+
+      train.bump_fix!
+      train.reload
+
+      expect(train.version_current).to eq("1.4")
+    end
+
+    it "updates the patch version if the current version is a proper semver" do
+      train = create(:releases_train, version_seeded_with: "1.2.1")
+      _run = create(:releases_train_run, train:)
+
+      train.bump_fix!
+      train.reload
+
+      expect(train.version_current).to eq("1.3.1")
+    end
+
+    it "does not do anything if there are no runs" do
+      train = create(:releases_train, version_seeded_with: "1.2.1")
+
+      train.bump_fix!
+      train.reload
+
+      expect(train.version_current).to eq("1.3.0")
+    end
+  end
+
+  describe "#bump_release!" do
+    it "updates the minor version" do
+      train = create(:releases_train, version_seeded_with: "1.2.1")
+      _run = create(:releases_train_run, train:)
+
+      train.bump_release!
+      train.reload
+
+      expect(train.version_current).to eq("1.4.0")
+    end
+
+    it "updates the major version if a greater major version is specified" do
+      train = create(:releases_train, version_seeded_with: "1.2.1")
+      _run = create(:releases_train_run, train:)
+
+      train.bump_release!(true)
+      train.reload
+
+      expect(train.version_current).to eq("2.0.0")
+    end
+
+    it "does not do anything if there are no runs" do
+      train = create(:releases_train, version_seeded_with: "1.2.1")
+
+      train.bump_release!
+      train.reload
+
+      expect(train.version_current).to eq("1.3.0")
+    end
+  end
 end


### PR DESCRIPTION
## Because

Users want to be able to use `MAJOR.MINOR`

## This addresses

Supports partial SemVer and paves the way for other dynamic versioning strategies also, like CalVer

**New Train**

![versioning](https://github.com/tramlinehq/tramline/assets/50663/f741e41d-dec7-4249-93bd-b7e1e040ab95)

**Existing Train**

![Screenshot 2023-06-02 at 6 43 06 PM](https://github.com/tramlinehq/tramline/assets/50663/2d7594f5-4c42-4693-a414-88d9321b0195)


**Play Store Live Release**

Originally kicked off with 10.3, hotfixed into 10.4

![Screenshot 2023-06-02 at 6 44 30 PM](https://github.com/tramlinehq/tramline/assets/50663/5db795ed-2541-450c-89d3-91e6c4293954)