### PR TITLE
Release commit log

### DIFF
--- a/app/jobs/releases/fetch_commit_log_job.rb
+++ b/app/jobs/releases/fetch_commit_log_job.rb
@@ -1,0 +1,8 @@
+class Releases::FetchCommitLogJob < ApplicationJob
+  queue_as :high
+
+  def perform(train_run_id)
+    run = Releases::Train::Run.find(train_run_id)
+    run.fetch_commit_log
+  end
+end

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -169,6 +169,15 @@ module Installations
       end
     end
 
+    def commits_between(repo, from_branch, to_branch, transforms)
+      execute do
+        @client
+          .compare(repo, from_branch, to_branch)
+          .dig(:commits)
+          .then { |commits| Installations::Response::Keys.transform(commits, transforms) }
+      end
+    end
+
     def head(repo, working_branch_name)
       execute do
         # FIXME: this method is unsupported and could get deprecated, find a way around it

--- a/app/libs/installations/gitlab/api.rb
+++ b/app/libs/installations/gitlab/api.rb
@@ -185,6 +185,20 @@ module Installations
       execute(:get, COMPARE_URL.expand(project_id:).to_s, params)["diffs"].present?
     end
 
+    def commits_between(project_id, from, to, transforms)
+      params = {
+        params: {
+          from:,
+          to:,
+          straight: false # `git diff from...to`
+        }
+      }
+
+      execute(:get, COMPARE_URL.expand(project_id:).to_s, params)
+        .dig("commits")
+        .then { |commits| Installations::Response::Keys.transform(commits, transforms) }
+    end
+
     private
 
     def execute(verb, url, params)

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -49,6 +49,16 @@ class GithubIntegration < ApplicationRecord
     avatar_url: [:account, :avatar_url]
   }
 
+  COMMITS_TRANSFORMATIONS = {
+    url: :html_url,
+    sha: :sha,
+    message: [:commit, :message],
+    author_name: [:commit, :author, :name],
+    author_timestamp: [:commit, :author, :date],
+    author_login: [:author, :login],
+    author_url: [:author, :html_url]
+  }
+
   def install_path
     unless integration.version_control? || integration.ci_cd?
       raise Integration::IntegrationNotImplemented, "We don't support that yet!"
@@ -204,6 +214,10 @@ class GithubIntegration < ApplicationRecord
 
   def merge_pr!(pr_number)
     installation.merge_pr!(app_config.code_repository_name, pr_number)
+  end
+
+  def commit_log(from_branch, to_branch)
+    installation.commits_between(app_config.code_repository_name, from_branch, to_branch, COMMITS_TRANSFORMATIONS)
   end
 
   private

--- a/app/models/gitlab_integration.rb
+++ b/app/models/gitlab_integration.rb
@@ -50,6 +50,15 @@ class GitlabIntegration < ApplicationRecord
     avatar_url: :avatar_url
   }
 
+  COMMITS_TRANSFORMATIONS = {
+    url: :web_url,
+    sha: :id,
+    message: :title,
+    author_name: :author_name,
+    author_timestamp: :created_at,
+    author_email: :author_email
+  }
+
   def install_path
     unless integration.version_control? || integration.ci_cd?
       raise Integration::IntegrationNotImplemented, "We don't support that yet!"
@@ -183,6 +192,10 @@ class GitlabIntegration < ApplicationRecord
 
   def merge_pr!(pr_number)
     with_api_retries { installation.merge_pr!(app_config.code_repository_name, pr_number) }
+  end
+
+  def commit_log(from_branch, to_branch)
+    with_api_retries { installation.commits_between(app_config.code_repository_name, from_branch, to_branch, COMMITS_TRANSFORMATIONS) }
   end
 
   private

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -107,7 +107,7 @@ class Releases::Train::Run < ApplicationRecord
 
   def fetch_commit_log
     if previous_release.present?
-      cache.fetch("app/#{app.id}/train/#{train.id}/releases/#{id}/commit_log", expires_in: 10.minutes) do
+      cache.fetch("app/#{app.id}/train/#{train.id}/releases/#{id}/commit_log", expires_in: 30.days) do
         vcs_provider.commit_log(previous_release.tag_name, train.working_branch)
       end
     end

--- a/app/views/releases/live_release/_builds.html.erb
+++ b/app/views/releases/live_release/_builds.html.erb
@@ -1,6 +1,6 @@
 <section>
   <div class="flex">
-    <h2 class="font-bold text-2xl">All commits</h2>
+    <h2 class="font-bold text-2xl">Commits after release kick-off</h2>
   </div>
 
   <% commits_count = release.commits.size %>

--- a/app/views/releases/live_release/_commit_log.erb
+++ b/app/views/releases/live_release/_commit_log.erb
@@ -1,0 +1,42 @@
+<section class="max-h-96 overflow-y-scroll" data-controller="reveal" data-reveal-toggle-keys-value="b">
+  <span class="font-bold text-2xl">Commits since last release</span>
+
+  <% if release.previous_release.present? %>
+    <table class="w-full mt-4 h-full">
+      <thead class="group text-slate-500 bg-slate-50 border-t border-b border-slate-200">
+      <tr>
+        <th>
+          <button class="px-2 py-3 transform flex" data-action="reveal#toggle">
+            <div class="text-xs font-semibold uppercase group-hover:text-slate-700">commits
+              – <%= release.fetch_commit_log.size %></div>
+            <%= inline_svg("caret_down.svg", classname: "w-3 h-3 shrink-0 ml-1 mt-0.5 fill-current group-hover:text-slate-700 rotate-0") %>
+          </button>
+        </th>
+      </tr>
+      </thead>
+
+      <tbody data-reveal class="text-sm border-b last:border-b-0" data-controller="reveal" data-reveal-toggle-keys-value="b">
+      <% release.fetch_commit_log.each_with_index do |commit, index| %>
+
+        <tr>
+          <td class="py-4 whitespace-nowrap">
+            <div class="text-slate-500">
+            <span class="text-xs uppercase tracking-wide font-medium rounded-full text-center px-1 py-0.5">
+            #<%= index + 1 %>
+            </span>
+              <code><%= short_sha(commit[:sha]) %></code>
+              <%= link_to_external commit[:message].truncate(50), commit[:url], class: "underline font-medium" %>
+              <%= ago_in_words commit[:author_timestamp] %>
+              by <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || commit[:author_email]), class: "underline" %>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="text-xs font-semibold uppercase px-2 py-3 text-slate-500 bg-slate-50 border-t border-b border-slate-200 w-full mt-4 h-full">
+      No previous release found to compare
+    </div>
+  <% end %>
+</section>

--- a/app/views/releases/live_release/_commit_log.erb
+++ b/app/views/releases/live_release/_commit_log.erb
@@ -28,11 +28,11 @@
                 </div>
                 <div class="flex flex-col">
                   <div>
-                    <code><%= short_sha(commit[:sha]) %></code>
-                    <%= link_to_external commit[:message].truncate(62), commit[:url], class: "underline font-medium" %>
+                    <%= link_to_external commit[:message].truncate(62), commit[:url], class: "underline font-medium text-black" %>
                   </div>
                   <div class="mt-1">
-                    <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || "mailto:#{commit[:author_email]}"), class: "underline" %>
+                    <code><%= short_sha(commit[:sha]) %></code>
+                    • <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || "mailto:#{commit[:author_email]}"), class: "underline" %>
                     committed <%= ago_in_words commit[:author_timestamp] %>
                   </div>
                 </div>

--- a/app/views/releases/live_release/_commit_log.erb
+++ b/app/views/releases/live_release/_commit_log.erb
@@ -30,7 +30,7 @@
                   <%= link_to_external commit[:message].truncate(80), commit[:url], class: "underline font-medium" %>
                 </div>
                 <div class="mt-1">
-                  <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || commit[:author_email]), class: "underline" %>
+                  <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || "mailto:#{commit[:author_email]}"), class: "underline" %>
                   committed <%= ago_in_words commit[:author_timestamp] %>
                 </div>
               </div>

--- a/app/views/releases/live_release/_commit_log.erb
+++ b/app/views/releases/live_release/_commit_log.erb
@@ -1,45 +1,48 @@
-<section class="max-h-96 overflow-y-scroll overflow-x-hidden" data-controller="reveal" data-reveal-toggle-keys-value="b">
+<section data-controller="reveal" data-reveal-toggle-keys-value="b">
   <span class="font-bold text-2xl">Commits since last release</span>
 
   <% if release.previous_release.present? %>
-    <table class="w-full mt-4 h-full">
-      <thead class="group text-slate-500 bg-slate-50 border-t border-b border-slate-200">
-      <tr>
-        <th>
-          <button class="px-2 py-3 transform flex" data-action="reveal#toggle">
-            <div class="text-xs font-semibold uppercase group-hover:text-slate-700">commits
-              – <%= release.fetch_commit_log.size %></div>
-            <%= inline_svg("caret_down.svg", classname: "w-3 h-3 shrink-0 ml-1 mt-0.5 fill-current group-hover:text-slate-700 rotate-0") %>
-          </button>
-        </th>
-      </tr>
-      </thead>
-
-      <tbody data-reveal class="text-sm border-b last:border-b-0" data-controller="reveal" data-reveal-toggle-keys-value="b">
-      <% release.fetch_commit_log.each_with_index do |commit, index| %>
-
+    <div class="max-h-96 overflow-y-scroll overflow-x-hidden mt-4">
+      <table class="w-full">
+        <thead class="group text-slate-500 bg-slate-50 border-t border-b border-slate-200">
         <tr>
-          <td class="py-4 whitespace-nowrap text-slate-500">
-            <div class="flex flex-row">
-              <div class="text-xs uppercase tracking-wide font-medium rounded-full text-center px-2 py-0.5">
-                #<%= index + 1 %>
+          <th>
+            <button class="px-2 py-3 transform flex" data-action="reveal#toggle">
+              <div class="text-xs font-semibold uppercase group-hover:text-slate-700">
+                <span class="font-bold"><%= release.fetch_commit_log.size %></span>&nbsp;commits
               </div>
-              <div class="flex flex-col">
-                <div>
-                  <code><%= short_sha(commit[:sha]) %></code>
-                  <%= link_to_external commit[:message].truncate(80), commit[:url], class: "underline font-medium" %>
-                </div>
-                <div class="mt-1">
-                  <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || "mailto:#{commit[:author_email]}"), class: "underline" %>
-                  committed <%= ago_in_words commit[:author_timestamp] %>
-                </div>
-              </div>
-            </div>
-          </td>
+              <%= inline_svg("caret_down.svg", classname: "w-3 h-3 shrink-0 ml-1 mt-0.5 fill-current group-hover:text-slate-700 rotate-0") %>
+            </button>
+          </th>
         </tr>
-      <% end %>
-      </tbody>
-    </table>
+        </thead>
+
+        <tbody data-reveal class="text-sm border-b last:border-b-0" data-controller="reveal" data-reveal-toggle-keys-value="b">
+        <% release.fetch_commit_log.each_with_index do |commit, index| %>
+
+          <tr>
+            <td class="py-4 whitespace-nowrap text-slate-500">
+              <div class="flex flex-row items-start">
+                <div class="text-xs uppercase tracking-wide font-medium rounded-full text-center px-2 py-0.5 mr-2 bg-slate-100">
+                  #<%= index + 1 %>
+                </div>
+                <div class="flex flex-col">
+                  <div>
+                    <code><%= short_sha(commit[:sha]) %></code>
+                    <%= link_to_external commit[:message].truncate(62), commit[:url], class: "underline font-medium" %>
+                  </div>
+                  <div class="mt-1">
+                    <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || "mailto:#{commit[:author_email]}"), class: "underline" %>
+                    committed <%= ago_in_words commit[:author_timestamp] %>
+                  </div>
+                </div>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
   <% else %>
     <div class="text-xs font-semibold uppercase px-2 py-3 text-slate-500 bg-slate-50 border-t border-b border-slate-200 w-full mt-4 h-full">
       No previous release found to compare

--- a/app/views/releases/live_release/_commit_log.erb
+++ b/app/views/releases/live_release/_commit_log.erb
@@ -1,4 +1,4 @@
-<section class="max-h-96 overflow-y-scroll" data-controller="reveal" data-reveal-toggle-keys-value="b">
+<section class="max-h-96 overflow-y-scroll overflow-x-hidden" data-controller="reveal" data-reveal-toggle-keys-value="b">
   <span class="font-bold text-2xl">Commits since last release</span>
 
   <% if release.previous_release.present? %>
@@ -19,15 +19,21 @@
       <% release.fetch_commit_log.each_with_index do |commit, index| %>
 
         <tr>
-          <td class="py-4 whitespace-nowrap">
-            <div class="text-slate-500">
-            <span class="text-xs uppercase tracking-wide font-medium rounded-full text-center px-1 py-0.5">
-            #<%= index + 1 %>
-            </span>
-              <code><%= short_sha(commit[:sha]) %></code>
-              <%= link_to_external commit[:message].truncate(50), commit[:url], class: "underline font-medium" %>
-              <%= ago_in_words commit[:author_timestamp] %>
-              by <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || commit[:author_email]), class: "underline" %>
+          <td class="py-4 whitespace-nowrap text-slate-500">
+            <div class="flex flex-row">
+              <div class="text-xs uppercase tracking-wide font-medium rounded-full text-center px-2 py-0.5">
+                #<%= index + 1 %>
+              </div>
+              <div class="flex flex-col">
+                <div>
+                  <code><%= short_sha(commit[:sha]) %></code>
+                  <%= link_to_external commit[:message].truncate(80), commit[:url], class: "underline font-medium" %>
+                </div>
+                <div class="mt-1">
+                  <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || commit[:author_email]), class: "underline" %>
+                  committed <%= ago_in_words commit[:author_timestamp] %>
+                </div>
+              </div>
             </div>
           </td>
         </tr>

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -28,6 +28,11 @@
 <div class="grid grid-cols-2 gap-6 mt-8">
   <%= render partial: "releases/live_release/stability", locals: { release: @release, steps: @steps, release_train: @train } %>
   <div>
+    <% if @release.on_track? %>
+      <%= render partial: "releases/live_release/commit_log", locals: { release: @release } %>
+      <%= render partial: "releases/live_release/separator" %>
+    <% end %>
+
     <% if @release.pre_release_prs? %>
       <%= render partial: "releases/live_release/pre_release_prs", locals: { pre_release_prs: @pre_release_prs } %>
       <%= render partial: "releases/live_release/separator" %>


### PR DESCRIPTION
**Partially Closes:** https://github.com/tramlinehq/tramline/issues/449

## Because

People want to see what changes are going in the release at a glance.

## This addresses

- Fetch commit log for the release on kick-off
- Show commit log only for live release

When no previous finished release exist in Tramline:

<img width="676" alt="Screenshot 2023-06-02 at 10 18 39 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/8c7d83e9-1ec5-40dd-ac3b-e3fd42226630">

When a previous finished release exists in Tramline:

<img width="666" alt="Screenshot 2023-06-04 at 8 52 48 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/367d29bf-f2ef-4a87-84d2-88a8600046f8">


When a previous finished release exists in Tramline (collapsed):

<img width="678" alt="Screenshot 2023-06-02 at 9 59 45 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/e989596f-f7b3-4e6e-8b55-7fca44c4e1db">
