### PR TITLE
Add build number to deployment notification

### DIFF
--- a/app/libs/notifiers/slack/renderers/deployment_finished.rb
+++ b/app/libs/notifiers/slack/renderers/deployment_finished.rb
@@ -8,6 +8,7 @@ module Notifiers
         @step_name = @step_run.step.name
         @train_run = @step_run.train_run
         @version_number = @step_run.build_version
+        @build_number = @step_run.build_number
         @train_name = @train_run.train.name
         @artifact_download_link = artifact_download_link
         super

--- a/app/views/notifiers/slack/deployment_finished.json.erb
+++ b/app/views/notifiers/slack/deployment_finished.json.erb
@@ -4,14 +4,14 @@
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": ":new: *Release <%= @version_number %> is now live!* :new:"
+        "text": ":new: *Release <%= @version_number %> (<%= @build_number %>) is now live!* :new:"
       }
     },
     {
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "*Artifact:* <<%= @artifact_download_link %>|Download>\n*Release Train:* <%= @train_name %>\n*Step Name:* <%= @step_name %>\n*App Version:* <%= @version_number %>"
+        "text": "*Artifact:* <<%= @artifact_download_link %>|Download>\n*Release Train:* <%= @train_name %>\n*Step Name:* <%= @step_name %>\n*App Version:* <%= @version_number %>\n*Build Number:* <%= @build_number %>"
       },
       "accessory": {
         "type": "image",


### PR DESCRIPTION
## This addresses

SInce we now conditionally bump patch versions for new commits on the release branch, we need to identify the distribution correctly when notifying users.

<img width="709" alt="Screenshot 2023-06-05 at 9 16 30 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/18d51dcc-0637-4d79-9bf4-50f0a2a81e02">

