### PR TITLE
Make release suffix optional for android apps

### DIFF
--- a/app/javascript/controllers/domain/release_suffix_help_controller.js
+++ b/app/javascript/controllers/domain/release_suffix_help_controller.js
@@ -20,7 +20,10 @@ export default class extends Controller {
   }
 
   __set(suffix) {
-    this.helpTextTarget.innerHTML = this.versionValue + "-" + suffix;
+    if (suffix !== "") {
+      this.helpTextTarget.innerHTML = this.versionValue + "-" + suffix;
+    } else {
+      this.helpTextTarget.innerHTML = this.versionValue;
+    }
   }
 }
-

--- a/app/libs/triggers/step_run.rb
+++ b/app/libs/triggers/step_run.rb
@@ -23,7 +23,7 @@ class Triggers::StepRun
 
   def build_version
     version = release.release_version
-    version += "-" + step.release_suffix if step.release_suffix
+    version += "-" + step.release_suffix if step.release_suffix.present?
     version
   end
 end

--- a/app/models/releases/step.rb
+++ b/app/models/releases/step.rb
@@ -28,8 +28,7 @@ class Releases::Step < ApplicationRecord
   has_many :deployment_runs, through: :deployments, class_name: "DeploymentRun"
 
   validates :ci_cd_channel, presence: true, uniqueness: {scope: :train_id, message: "you have already used this in another step of this train!"}
-  validates :release_suffix, presence: true, if: :android?
-  validates :release_suffix, format: {with: /\A[a-zA-Z\-_]+\z/, message: "only allows letters and underscore"}, if: :release_suffix
+  validates :release_suffix, format: {with: /\A[a-zA-Z\-_]+\z/, message: "only allows letters and underscore"}, if: -> { release_suffix.present? }
   validates :deployments, presence: true, on: :create
   validate :unique_deployments, on: :create
   validate :unique_store_deployments_per_train, on: :create

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -27,7 +27,6 @@
                               class: "form-input w-full",
                               placeholder: "Eg: qa-staging",
                               autocomplete: "off",
-                              required: true,
                               data: { domain__release_suffix_help_target: "input",
                                       action: "domain--release-suffix-help#set" } %>
           <div class="text-sm mt-1">

--- a/spec/models/releases/step_spec.rb
+++ b/spec/models/releases/step_spec.rb
@@ -93,18 +93,7 @@ describe Releases::Step do
       expect(step.reload.deployments.pluck(:deployment_number)).to contain_exactly(1, 2)
     end
 
-    it "validates presence of release suffix for android apps" do
-      app = create(:app, :android)
-      train = create(:releases_train, app: app)
-      step = build(:releases_step, :with_deployment, train: train, release_suffix: nil)
-
-      step.save
-
-      expect(step.persisted?).to be(false)
-      expect(step.errors).to contain_exactly("release suffix →\ncan't be blank")
-    end
-
-    it "validates release suffix to be valid for android apps" do
+    it "validates release suffix to be valid if present" do
       app = create(:app, :android)
       train = create(:releases_train, app: app)
       step = build(:releases_step, :with_deployment, train: train, release_suffix: "%^&")
@@ -117,6 +106,17 @@ describe Releases::Step do
 
     it "allows release suffix to be nil for ios apps" do
       app = create(:app, :ios)
+      train = create(:releases_train, app: app)
+      step = build(:releases_step, :with_deployment, train: train, release_suffix: nil)
+
+      step.save
+
+      expect(step.persisted?).to be(true)
+      expect(step.errors).to be_empty
+    end
+
+    it "allows release suffix to be nil for android apps" do
+      app = create(:app, :android)
       train = create(:releases_train, app: app)
       step = build(:releases_step, :with_deployment, train: train, release_suffix: nil)
 


### PR DESCRIPTION
## Because

No everyone wants to add a release suffix to their app's version