### PR TITLE
Shim to allow release scheduling for a train

### DIFF
--- a/app/javascript/controllers/demo/release_schedule_help_controller.js
+++ b/app/javascript/controllers/demo/release_schedule_help_controller.js
@@ -1,0 +1,36 @@
+import {Controller} from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["nextDateNumber", "nextDateUnit", "output"];
+
+  initialize() {
+    this.change();
+  }
+
+  change() {
+    const nextDateNumber = parseInt(this.nextDateNumberTarget.value);
+    const nextDateUnit = this.nextDateUnitTarget.value;
+    const currentDateObj = new Date();
+    const nextDate = new Date(currentDateObj);
+
+    switch (nextDateUnit) {
+      case 'day(s)':
+        nextDate.setDate(currentDateObj.getDate() + nextDateNumber);
+        break;
+      case 'week(s)':
+        nextDate.setDate(currentDateObj.getDate() + nextDateNumber * 7);
+        break;
+      case 'month(s)':
+        nextDate.setMonth(currentDateObj.getMonth() + nextDateNumber);
+        break;
+      default:
+        return;
+    }
+
+    this.outputTarget.textContent = nextDate.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  }
+}

--- a/app/views/shared/demo/_release_schedule_form.html.erb
+++ b/app/views/shared/demo/_release_schedule_form.html.erb
@@ -1,0 +1,28 @@
+<% if @current_organization.demo? %>
+  <div class="text-xl text-slate-600 font-medium mt-8 mb-4">Release Schedule</div>
+
+  <div class="grid md:grid-cols-1 w-1/2" data-controller="demo--release-schedule-help">
+    <div>
+      <%= form.label "This release will repeat every", class: "wblock text-sm font-medium mb-1" %>
+      <%= form.text_field :release_schedule_value,
+                          value: 7,
+                          class: text_field_classes(is_disabled: false),
+                          data: { action: 'demo--release-schedule-help#change',
+                                  demo__release_schedule_help_target: "nextDateNumber" },
+                          placeholder: "1" %>
+    </div>
+    <div>
+      <%= form.select :release_schedule_unit,
+                      options_for_select(%w[day(s) week(s) month(s)], "day(s)"),
+                      { required: false, },
+                      { class: text_field_classes(is_disabled: false),
+                        data: { action: 'demo--release-schedule-help#change',
+                                demo__release_schedule_help_target: "nextDateUnit" }
+                      } %>
+    </div>
+    <div class="text-sm italic mt-2">
+      <span>If you start the release today, your next release will be on: </span>
+      <span data-demo--release-schedule-help-target="output"></span>
+    </div>
+  </div>
+<% end %>

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -112,7 +112,36 @@
     </div>
   </div>
 
-  <div class="text-xl text-slate-600 font-medium mt-8 mb-2">Branching strategy</div>
+  <% if @current_organization.demo? %>
+    <div class="text-xl text-slate-600 font-medium mt-8 mb-4">Release Schedule</div>
+
+    <div class="grid md:grid-cols-1 w-1/2" data-controller="demo--release-schedule-help">
+      <div>
+        <%= form.label "This release will repeat every", class: "wblock text-sm font-medium mb-1" %>
+        <%= form.text_field :release_schedule_value,
+                            value: 7,
+                            class: text_field_classes(is_disabled: false),
+                            data: { action: 'demo--release-schedule-help#change',
+                                    demo__release_schedule_help_target: "nextDateNumber" },
+                            placeholder: "1" %>
+      </div>
+      <div>
+        <%= form.select :release_schedule_unit,
+                        options_for_select(%w[day(s) week(s) month(s)], "day(s)"),
+                        { required: false, },
+                        { class: text_field_classes(is_disabled: train.persisted?),
+                          data: { action: 'demo--release-schedule-help#change',
+                                  demo__release_schedule_help_target: "nextDateUnit" }
+                        } %>
+      </div>
+      <div class="text-sm italic mt-2">
+        <span>If you start the release today, your next release will be on: </span>
+        <span data-demo--release-schedule-help-target="output"></span>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="text-xl text-slate-600 font-medium mt-8 mb-4">Branching strategy</div>
 
   <div class="grid gap-x-5 md:grid-cols-2">
     <div data-controller="branching-selector">

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -112,34 +112,7 @@
     </div>
   </div>
 
-  <% if @current_organization.demo? %>
-    <div class="text-xl text-slate-600 font-medium mt-8 mb-4">Release Schedule</div>
-
-    <div class="grid md:grid-cols-1 w-1/2" data-controller="demo--release-schedule-help">
-      <div>
-        <%= form.label "This release will repeat every", class: "wblock text-sm font-medium mb-1" %>
-        <%= form.text_field :release_schedule_value,
-                            value: 7,
-                            class: text_field_classes(is_disabled: false),
-                            data: { action: 'demo--release-schedule-help#change',
-                                    demo__release_schedule_help_target: "nextDateNumber" },
-                            placeholder: "1" %>
-      </div>
-      <div>
-        <%= form.select :release_schedule_unit,
-                        options_for_select(%w[day(s) week(s) month(s)], "day(s)"),
-                        { required: false, },
-                        { class: text_field_classes(is_disabled: train.persisted?),
-                          data: { action: 'demo--release-schedule-help#change',
-                                  demo__release_schedule_help_target: "nextDateUnit" }
-                        } %>
-      </div>
-      <div class="text-sm italic mt-2">
-        <span>If you start the release today, your next release will be on: </span>
-        <span data-demo--release-schedule-help-target="output"></span>
-      </div>
-    </div>
-  <% end %>
+  <%= render partial: "shared/demo/release_schedule_form", locals: { form: } %>
 
   <div class="text-xl text-slate-600 font-medium mt-8 mb-4">Branching strategy</div>
 


### PR DESCRIPTION
To support our previous shim that shows the release schedule on the train page, this change shims a few form inputs whilst creating the train.

![Screenshot 2023-06-06 at 4 27 20 PM](https://github.com/tramlinehq/tramline/assets/50663/1c954d76-e259-49ef-b4ce-093030079b2c)
