### PR TITLE
Fixes for release metadata and version bump within a release

### DIFF
--- a/app/controllers/release_metadata_controller.rb
+++ b/app/controllers/release_metadata_controller.rb
@@ -1,11 +1,11 @@
 class ReleaseMetadataController < SignedInApplicationController
   before_action :require_write_access!, only: %i[edit update]
   before_action :set_release, only: %i[edit update]
+  before_action :set_train, only: %i[edit update]
+  before_action :set_app, only: %i[edit update]
   before_action :ensure_editable, only: %i[edit update]
 
   def edit
-    @train = @release.train
-    @app = @train.app
     @release_metadata = @release.release_metadata
   end
 
@@ -26,6 +26,14 @@ class ReleaseMetadataController < SignedInApplicationController
       :release_notes,
       :promo_text
     )
+  end
+
+  def set_train
+    @train = @release.train
+  end
+
+  def set_app
+    @app = @train.app
   end
 
   def set_release

--- a/app/libs/webhook_processors/push.rb
+++ b/app/libs/webhook_processors/push.rb
@@ -26,7 +26,7 @@ class WebhookProcessors::Push
   delegate :train, to: :release
 
   def bump_version!
-    return unless release.staged_rollout_in_progress?
+    return unless release.version_bump_required?
     return if release.step_runs.none?
 
     train.bump_fix!

--- a/app/models/release_metadata.rb
+++ b/app/models/release_metadata.rb
@@ -15,8 +15,8 @@ class ReleaseMetadata < ApplicationRecord
 
   belongs_to :train_run, class_name: "Releases::Train::Run"
 
-  PLAINTEXT_REGEX = /\A[a-zA-Z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.\/?\s]+\z/
+  PLAINTEXT_REGEX = /\A[!@#$%^&*()_+\-=\[\]{};':"\\|,.\/?\s\p{Alnum}\p{P}\p{Zs}\p{Emoji_Presentation}]+\z/
 
-  validates :release_notes, format: {with: PLAINTEXT_REGEX, message: :no_special_characters}
-  validates :promo_text, format: {with: PLAINTEXT_REGEX, message: :no_special_characters, allow_blank: true}
+  validates :release_notes, format: {with: PLAINTEXT_REGEX, message: :no_special_characters, multiline: true}, length: {maximum: 4000}
+  validates :promo_text, format: {with: PLAINTEXT_REGEX, message: :no_special_characters, allow_blank: true, multiline: true}, length: {maximum: 170}
 end

--- a/app/models/releases/step/run.rb
+++ b/app/models/releases/step/run.rb
@@ -132,6 +132,7 @@ class Releases::Step::Run < ApplicationRecord
   delegate :commit_hash, to: :commit
   delegate :download_url, to: :build_artifact
   alias_method :release, :train_run
+  scope :not_failed, -> { where.not(status: [:ci_workflow_failed, :ci_workflow_halted, :build_not_found_in_store, :build_unavailable, :deployment_failed]) }
 
   def find_build
     store_provider.find_build(build_number)

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -287,7 +287,7 @@ class Releases::Train::Run < ApplicationRecord
 
   def hotfix?
     return false unless on_track?
-    release_version.to_semverish > original_release_version.to_semverish
+    release_version.to_semverish > original_release_version.to_semverish && production_release_started?
   end
 
   private
@@ -319,5 +319,9 @@ class Releases::Train::Run < ApplicationRecord
       .where(step: step)
       .not_failed
       .last
+  end
+
+  def production_release_started?
+    latest_non_failure_store_release&.status&.in? [DeploymentRun::STATES[:rollout_started], DeploymentRun::STATES[:released]]
   end
 end

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -282,7 +282,7 @@ class Releases::Train::Run < ApplicationRecord
   # this check internally assumes production
   def version_bump_required?
     return latest_non_failure_store_release&.rollout_started? if android?
-    latest_non_failure_store_release&.status&.in? ["ready_to_release", "rollout_started"]
+    latest_non_failure_store_release&.status&.in? [DeploymentRun::STATES[:rollout_started], DeploymentRun::STATES[:ready_to_release]]
   end
 
   def hotfix?

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -100,6 +100,7 @@ class Releases::Train::Run < ApplicationRecord
   attr_accessor :has_major_bump
   delegate :app, :pre_release_prs?, :vcs_provider, to: :train
   delegate :cache, to: Rails
+  delegate :android?, to: :app
 
   def set_default_release_metadata
     create_release_metadata!(locale: DEFAULT_LOCALE, release_notes: DEFAULT_RELEASE_NOTES)
@@ -279,8 +280,9 @@ class Releases::Train::Run < ApplicationRecord
 
   # since we do not currently support staged-rollouts on non-production channels
   # this check internally assumes production
-  def staged_rollout_in_progress?
-    latest_store_release&.rollout_started?
+  def version_bump_required?
+    return latest_store_release&.rollout_started? if android?
+    latest_store_release&.status&.in? [:ready_to_release, :rollout_started]
   end
 
   def hotfix?

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -278,8 +278,6 @@ class Releases::Train::Run < ApplicationRecord
     end
   end
 
-  # since we do not currently support staged-rollouts on non-production channels
-  # this check internally assumes production
   def version_bump_required?
     return latest_non_failure_store_release&.rollout_started? if android?
     latest_non_failure_store_release&.status&.in? [DeploymentRun::STATES[:rollout_started], DeploymentRun::STATES[:ready_to_release]]

--- a/app/views/releases/live_release/_release_metadata.html.erb
+++ b/app/views/releases/live_release/_release_metadata.html.erb
@@ -8,7 +8,7 @@
 
   <%= render MetaTableComponent.new do |mt| %>
     <% mt.with_description("Release Notes") do %>
-      <%= simple_format release_metadata.release_notes %>
+      <%= simple_format release_metadata.release_notes.truncate(200) %>
     <% end %>
 
     <% unless is_android %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,9 +84,9 @@ en:
         release_metadata:
           attributes:
             release_notes:
-              no_special_characters: "only allows letters, numbers, and some special characters"
+              no_special_characters: "only allows letters, numbers, emojis, and some special characters"
             promo_text:
-              no_special_characters: "only allows letters, numbers, and some special characters"
+              no_special_characters: "only allows letters, numbers, emojis, and some special characters"
         integration:
           format: "%{message}"
         app_store_integration:


### PR DESCRIPTION
## This addresses

- Fixes rendering of release metadata edit page when validation fails
- Fixes release metadata and promotional text to allow emojis
- Also adds length checks to them
- Fixes version bump for iOS apps to account for approval, and not just rollout beginning 
  - This is due to a new store quirk we have encountered where the TestFlight upload of a new build fails if the same version_name was approved for release in App Store.

Error from App Store for uploading the same version name as last approved for production release :

`[07:25:48]: Asset validation failed This bundle is invalid. The value for key CFBundleShortVersionString [5.11.0] in the Info.plist file must contain a higher version than that of the previously approved version [5.11.0]. Please find more information about CFBundleShortVersionString at https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring (ID: 2e2b693e-5116-4997-9c89-57dee5d2caba) (90062)`

TODO:
- [ ] Add the above store behavior to store quirks

