### PR TITLE
Synced live releases shim

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -9,9 +9,12 @@ class ReleasesController < SignedInApplicationController
     @steps = @train.steps.order(:step_number).includes(:runs, :train, deployments: [:integration])
     @app = @train.app
     set_pull_requests
+    set_demo_mode_things
 
-    if @current_organization.demo?
-      render :show_demo and return
+    if demo_train?
+      render :show_demo
+    else
+      render :show
     end
   end
 
@@ -42,7 +45,13 @@ class ReleasesController < SignedInApplicationController
     @release = @train.active_run
     redirect_to train_path, notice: "No release in progress." and return unless @release
     set_pull_requests
-    render :show
+    set_demo_mode_things
+
+    if demo_train?
+      render :show_demo
+    else
+      render :show
+    end
   end
 
   def destroy
@@ -80,6 +89,10 @@ class ReleasesController < SignedInApplicationController
 
   def live_release_path
     live_release_app_train_releases_path(@app, @train)
+  end
+
+  def set_demo_mode_things
+    @events = @release.events(10)
   end
 
   def train_path

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -9,6 +9,10 @@ class ReleasesController < SignedInApplicationController
     @steps = @train.steps.order(:step_number).includes(:runs, :train, deployments: [:integration])
     @app = @train.app
     set_pull_requests
+
+    if @current_organization.demo?
+      render :show_demo and return
+    end
   end
 
   def create

--- a/app/controllers/signed_in_application_controller.rb
+++ b/app/controllers/signed_in_application_controller.rb
@@ -12,12 +12,14 @@ class SignedInApplicationController < ApplicationController
 
   protected
 
+  helper_method :demo_org?, :demo_train?
+
   def demo_org?
-    @current_organization.demo?
+    @current_organization&.demo?
   end
 
   def demo_train?
-    demo_org? && @train.demo?
+    demo_org? && @train&.demo?
   end
 
   def require_login

--- a/app/controllers/signed_in_application_controller.rb
+++ b/app/controllers/signed_in_application_controller.rb
@@ -12,6 +12,14 @@ class SignedInApplicationController < ApplicationController
 
   protected
 
+  def demo_org?
+    @current_organization.demo?
+  end
+
+  def demo_train?
+    demo_org? && @train.demo?
+  end
+
   def require_login
     unless current_user
       flash[:error] = t("errors.messages.not_logged_in")

--- a/app/models/releases/train.rb
+++ b/app/models/releases/train.rb
@@ -184,6 +184,10 @@ class Releases::Train < ApplicationRecord
     steps.release.none? && !steps.review.any?
   end
 
+  def demo?
+    Flipper.enabled?(:demo_mode, self)
+  end
+
   private
 
   def set_version_seeded_with

--- a/app/models/releases/train/run.rb
+++ b/app/models/releases/train/run.rb
@@ -230,7 +230,7 @@ class Releases::Train::Run < ApplicationRecord
     last_good_step_run&.build_artifact
   end
 
-  def events
+  def events(limit = nil)
     step_runs
       .left_joins(:commit, deployment_runs: :staged_rollout)
       .pluck("train_step_runs.id, deployment_runs.id, releases_commits.id, staged_rollouts.id")
@@ -238,7 +238,7 @@ class Releases::Train::Run < ApplicationRecord
       .uniq
       .compact
       .push(id)
-      .then { |ids| Passport.where(stampable_id: ids).order(event_timestamp: :desc) }
+      .then { |ids| Passport.where(stampable_id: ids).order(event_timestamp: :desc).limit(limit) }
   end
 
   def all_steps

--- a/app/views/releases/live_release/_commit_log.erb
+++ b/app/views/releases/live_release/_commit_log.erb
@@ -1,4 +1,4 @@
-<section data-controller="reveal" data-reveal-toggle-keys-value="b">
+<section data-controller="reveal">
   <span class="font-bold text-2xl">Commits since last release</span>
 
   <% if release.previous_release.present? %>

--- a/app/views/releases/live_release/_separator.html.erb
+++ b/app/views/releases/live_release/_separator.html.erb
@@ -3,6 +3,6 @@
 <% if margin_only %>
   <div class="mt-12"></div>
 <% else %>
-  <div class="border-t border-dashed border-slate-200 pt-8 mt-8"></div>
+  <div class="border-t border-dashed border-slate-200 mt-8"></div>
 <% end %>
 

--- a/app/views/releases/show_demo.html.erb
+++ b/app/views/releases/show_demo.html.erb
@@ -29,23 +29,15 @@
   <div>
     <%= render partial: "shared/demo/live_release/kick_off", locals: { release: @release, release_train: @train } %>
 
-    <%= render partial: "releases/live_release/separator", locals: { margin_only: true } %>
-
-    <% if @release.release_metadata.present? %>
-      <%= render partial: "shared/demo/live_release/release_metadata",
-                 locals: { release: @release, is_android: @release.app.android? } %>
+    <% if @release.pre_release_prs? %>
+      <%= render partial: "shared/demo/live_release/pre_release_prs", locals: { pre_release_prs: @pre_release_prs } %>
     <% end %>
   </div>
 
   <div>
-    <% if @release.on_track? %>
-      <%= render partial: "shared/demo/live_release/commit_log", locals: { release: @release } %>
-
-      <%= render partial: "releases/live_release/separator", locals: { margin_only: true } %>
-
-      <% if @release.pre_release_prs? %>
-        <%= render partial: "shared/demo/live_release/pre_release_prs", locals: { pre_release_prs: @pre_release_prs } %>
-      <% end %>
+    <% if @release.release_metadata.present? %>
+      <%= render partial: "shared/demo/live_release/release_metadata",
+                 locals: { release: @release, is_android: @release.app.android? } %>
     <% end %>
   </div>
 </div>
@@ -66,17 +58,29 @@
   <span class="text-xl text-slate-400 ml-4"><%= time_ago_in_words(@release.updated_at) %> ago</span>
 </div>
 
-
 <div class="grid grid-cols-2 gap-6 mt-8">
   <%= render partial: "shared/demo/live_release/stability", locals: { platform: "Android release", release: @release, steps: @steps, release_train: @train } %>
-  <%= render partial: "shared/demo/live_release/stability", locals: { platform: "iOS release", release: @release, steps: @steps, release_train: @train } %>
+  <%= render partial: "shared/demo/live_release/ios_stability", locals: { release: @release, steps: @steps, release_train: @train } %>
 </div>
 
 <%= render partial: "releases/live_release/separator" %>
 
 <div class="mt-8">
-  <!--commits after live release kickoff-->
   <%= render partial: "shared/demo/live_release/builds", locals: { release: @release } %>
+</div>
+
+<%= render partial: "releases/live_release/separator" %>
+
+<div class="grid grid-cols-2 gap-6 mt-8">
+  <div>
+    <span class="font-bold text-2xl">Release Events</span>
+    <%= render partial: "shared/event_timeline", locals: { events: @events, short_width: true } %>
+    <span class="text-sm text-slate-400">Showing the last 10 events, <span class="underline">view all</span>.</span>
+  </div>
+
+  <div>
+    <%= render partial: "shared/demo/live_release/commit_log", locals: { release: @release } %>
+  </div>
 </div>
 
 <%= render partial: "releases/live_release/separator" %>

--- a/app/views/releases/show_demo.html.erb
+++ b/app/views/releases/show_demo.html.erb
@@ -75,7 +75,7 @@
   <div>
     <span class="font-bold text-2xl">Release Events</span>
     <%= render partial: "shared/event_timeline", locals: { events: @events, short_width: true } %>
-    <span class="text-sm text-slate-400">Showing the last 10 events, <span class="underline">view all</span>.</span>
+    <span class="text-sm text-slate-400">Showing the last 10 events, <%= link_to "view all", timeline_release_path(@release), class: "underline" %></span>
   </div>
 
   <div>

--- a/app/views/releases/show_demo.html.erb
+++ b/app/views/releases/show_demo.html.erb
@@ -53,7 +53,7 @@
   </div>
 <% end %>
 
-<div>
+<div class="mt-8">
   <span class="font-bold text-2xl">Build stability</span>
   <span class="text-xl text-slate-400 ml-4"><%= time_ago_in_words(@release.updated_at) %> ago</span>
 </div>

--- a/app/views/releases/show_demo.html.erb
+++ b/app/views/releases/show_demo.html.erb
@@ -1,0 +1,86 @@
+<% if @release.finished? || @release.stopped? %>
+  <% content_for :sticky_page_message do %>
+    <%= render partial: "shared/sticky_topbar_message",
+               locals: { msg: "This release was completed and is now completed." } %>
+  <% end %>
+<% end %>
+
+<% breadcrumb :release, @release %>
+
+<div class="sm:flex sm:justify-between sm:items-center pb-8 border-b border-slate-200">
+  <!-- Left: Title -->
+  <div class="mb-4 sm:mb-0">
+    <h2 class="text-2xl md:text-3xl text-slate-800 font-bold">
+      <%= @release.release_version %>
+    </h2>
+  </div>
+
+  <!-- Right: Actions -->
+  <div class="grid grid-flow-col sm:auto-cols-max justify-start sm:justify-end gap-2">
+    <%= decorated_link_to :neutral, "Event Timeline", timeline_release_path(@release) %>
+
+    <% if @release.stoppable? %>
+      <%= authz_button_to :red, "Stop release", release_path(@release.id), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
+    <% end %>
+  </div>
+</div>
+
+<div class="grid grid-cols-2 gap-6 mt-8">
+  <div>
+    <%= render partial: "shared/demo/live_release/kick_off", locals: { release: @release, release_train: @train } %>
+
+    <%= render partial: "releases/live_release/separator", locals: { margin_only: true } %>
+
+    <% if @release.release_metadata.present? %>
+      <%= render partial: "shared/demo/live_release/release_metadata",
+                 locals: { release: @release, is_android: @release.app.android? } %>
+    <% end %>
+  </div>
+
+  <div>
+    <% if @release.on_track? %>
+      <%= render partial: "shared/demo/live_release/commit_log", locals: { release: @release } %>
+
+      <%= render partial: "releases/live_release/separator", locals: { margin_only: true } %>
+
+      <% if @release.pre_release_prs? %>
+        <%= render partial: "shared/demo/live_release/pre_release_prs", locals: { pre_release_prs: @pre_release_prs } %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<%= render partial: "releases/live_release/separator" %>
+
+<% if @release.hotfix? %>
+  <div class="flex flex-col bg-slate-800 text-white rounded-sm py-5 mb-5 text-center pr-8">
+    <div class="uppercase tracking-wide text-2xl drop-shadow-md">
+      <%= inline_svg("band_aid.svg", classname: "w-10 opacity-80 inline-flex align-bottom") %>
+      <span class="align-baseline pl-2">release is now in <span class="underline">hotfix</span> mode</span>
+    </div>
+  </div>
+<% end %>
+
+<div>
+  <span class="font-bold text-2xl">Build stability</span>
+  <span class="text-xl text-slate-400 ml-4"><%= time_ago_in_words(@release.updated_at) %> ago</span>
+</div>
+
+
+<div class="grid grid-cols-2 gap-6 mt-8">
+  <%= render partial: "shared/demo/live_release/stability", locals: { platform: "Android release", release: @release, steps: @steps, release_train: @train } %>
+  <%= render partial: "shared/demo/live_release/stability", locals: { platform: "iOS release", release: @release, steps: @steps, release_train: @train } %>
+</div>
+
+<%= render partial: "releases/live_release/separator" %>
+
+<div class="mt-8">
+  <!--commits after live release kickoff-->
+  <%= render partial: "shared/demo/live_release/builds", locals: { release: @release } %>
+</div>
+
+<%= render partial: "releases/live_release/separator" %>
+
+<div class="mt-8">
+  <%= render partial: "shared/demo/live_release/finalize", locals: { release: @release, post_release_prs: @post_release_prs } %>
+</div>

--- a/app/views/releases/timeline.html.erb
+++ b/app/views/releases/timeline.html.erb
@@ -1,25 +1,3 @@
 <%= render PageComponent.new(breadcrumb: breadcrumb(:timeline_release, @release), title: "Event Timeline") do %>
-  <ul class="mt-6">
-    <% @events.each do |passport| %>
-      <li class="flex px-2">
-        <div class="grow flex items-center border-b border-slate-100 text-sm py-2">
-          <div class="grow flex justify-start">
-            <div class="w-36">
-              <span class="font-medium text-stone-500">
-                <%= time_format(passport.event_timestamp) %>
-              </span>
-            </div>
-
-            <span class="text-xs inline-flex font-medium <%= passport_badge(passport) %> rounded-full text-center mr-3 ml-2 px-2 py-1">
-              <%= image_tag("#{passport_icon(passport)}.svg", width: 20, class: "inline-flex") %>
-            </span>
-
-            <div class="self-center text-slate-800">
-              <%= raw passport.message %>
-            </div>
-          </div>
-        </div>
-      </li>
-    <% end %>
-  </ul>
+  <%= render partial: "shared/event_timeline", locals: { events: @events, short_width: false } %>
 <% end %>

--- a/app/views/shared/_event_timeline.html.erb
+++ b/app/views/shared/_event_timeline.html.erb
@@ -3,7 +3,7 @@
     <li class="flex pr-2">
       <div class="grow flex items-center border-b border-slate-100 text-sm py-2">
         <div class="grow flex justify-start">
-          <div class="w-36">
+          <div class="w-40">
               <span class="font-medium text-stone-500">
                 <%= time_format(passport.event_timestamp) %>
               </span>

--- a/app/views/shared/_event_timeline.html.erb
+++ b/app/views/shared/_event_timeline.html.erb
@@ -9,13 +9,15 @@
               </span>
           </div>
 
-          <span class="text-xs inline-flex font-medium <%= passport_badge(passport) %> rounded-full text-center mr-3 ml-2 px-2 py-1">
+          <span class="w-3/4 inline-flex">
+            <span class="text-xs font-medium <%= passport_badge(passport) %> rounded-full text-center mr-3 ml-2 px-2 py-1">
               <%= image_tag("#{passport_icon(passport)}.svg", width: 20, class: "inline-flex") %>
             </span>
 
-          <div class="self-center text-slate-800 <%= short_width ? "truncate" : nil %>">
-            <%= raw passport.message %>
-          </div>
+            <span class="self-center text-slate-800 <%= short_width ? "truncate" : nil %>">
+              <%= raw passport.message %>
+            </span>
+          </span>
         </div>
       </div>
     </li>

--- a/app/views/shared/_event_timeline.html.erb
+++ b/app/views/shared/_event_timeline.html.erb
@@ -1,0 +1,23 @@
+<ul class="mt-6 mb-4">
+  <% events.each do |passport| %>
+    <li class="flex pr-2">
+      <div class="grow flex items-center border-b border-slate-100 text-sm py-2">
+        <div class="grow flex justify-start">
+          <div class="w-36">
+              <span class="font-medium text-stone-500">
+                <%= time_format(passport.event_timestamp) %>
+              </span>
+          </div>
+
+          <span class="text-xs inline-flex font-medium <%= passport_badge(passport) %> rounded-full text-center mr-3 ml-2 px-2 py-1">
+              <%= image_tag("#{passport_icon(passport)}.svg", width: 20, class: "inline-flex") %>
+            </span>
+
+          <div class="self-center text-slate-800 <%= short_width ? "truncate" : nil %>">
+            <%= raw passport.message %>
+          </div>
+        </div>
+      </div>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/shared/demo/_release_approvals.html.erb
+++ b/app/views/shared/demo/_release_approvals.html.erb
@@ -1,4 +1,4 @@
-<% if !deployment.production_channel? && @current_organization.demo? %>
+<% if !deployment.production_channel? && demo_org? %>
   <% if step_run.success? || deployment_run&.released? %>
     <div class="flex flex-col mt-2 w-full bg-slate-200 p-2 mb-2 border-l-8 border-green-500 rounded-sm text-sm">
       <div>

--- a/app/views/shared/demo/_release_schedule_form.html.erb
+++ b/app/views/shared/demo/_release_schedule_form.html.erb
@@ -1,8 +1,10 @@
-<% if @current_organization.demo? %>
-  <div class="text-xl text-slate-600 font-medium mt-8 mb-4">Release Schedule</div>
+<% if demo_org? %>
+  <div class="border-t border-dashed border-slate-200 pt-8 mt-8"></div>
+
+  <div class="text-xl text-slate-600 font-medium mt-2 mb-4">Release Schedule</div>
 
   <div class="grid md:grid-cols-1 w-1/2" data-controller="demo--release-schedule-help">
-    <div>
+    <div class="mb-1">
       <%= form.label "This release will repeat every", class: "wblock text-sm font-medium mb-1" %>
       <%= form.text_field :release_schedule_value,
                           value: 7,

--- a/app/views/shared/demo/live_release/_builds.html.erb
+++ b/app/views/shared/demo/live_release/_builds.html.erb
@@ -5,7 +5,7 @@
 
   <% commits_count = release.commits.size %>
 
-  <table class="table-auto w-full mt-4">
+  <table class="table-auto w-full mt-6">
     <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
     <tr>
       <th class="px-2 py-3 whitespace-nowrap">

--- a/app/views/shared/demo/live_release/_builds.html.erb
+++ b/app/views/shared/demo/live_release/_builds.html.erb
@@ -1,0 +1,141 @@
+<section>
+  <div class="flex">
+    <h2 class="font-bold text-2xl">Commits after release kick-off</h2>
+  </div>
+
+  <% commits_count = release.commits.size %>
+
+  <table class="table-auto w-full mt-4">
+    <thead class="text-xs font-semibold uppercase text-slate-500 bg-slate-50 border-t border-b border-slate-200">
+    <tr>
+      <th class="px-2 py-3 whitespace-nowrap">
+        <div class="font-semibold text-left">commits</div>
+      </th>
+
+      <th class="py-3 whitespace-nowrap"><!-- build details accordion --></th>
+    </tr>
+    </thead>
+
+    <% release.commits.order(created_at: :desc).includes(step_runs: :step).each_with_index do |commit, index| %>
+      <% is_stale_commit = commit.stale? %>
+      <tbody class="text-sm border-b last:border-b-0" data-controller="reveal" data-reveal-toggle-keys-value="b">
+
+      <!-- commit details -->
+      <tr>
+        <td class="py-4 whitespace-nowrap">
+          <%
+            if is_stale_commit
+              link_text_class = "text-slate-400"
+              number_text_class = "bg-slate-100 text-slate-400"
+            else
+              link_text_class = "font-medium"
+              number_text_class = "bg-slate-200 text-slate-600"
+            end
+          %>
+
+          <%= link_to_external commit.message.truncate(50), commit.url, class: "underline #{link_text_class}" %>
+          <span class="text-xs uppercase tracking-wide inline-flex font-medium <%= number_text_class %> rounded-full text-center px-2 py-0.5">
+            #<%= commits_count - index %>
+          </span>
+
+          <div class="text-slate-500">
+            <code><%= commit.short_sha %></code> • <%= ago_in_words commit.timestamp %>
+          </div>
+        </td>
+        <td class="align-text-top pt-4 whitespace-nowrap w-px">
+          <button
+            class="text-slate-400 hover:text-slate-500 transform"
+            data-action="reveal#toggle">
+
+            <div class="flex truncate">
+              <span class="truncate mx-2 font-medium text-slate-500 group-hover:text-slate-800 underline">Details</span>
+              <%= inline_svg("caret_down.svg", classname: "w-3 h-3 shrink-0 ml-1 mt-1 fill-current text-slate-500 group-hover:text-slate-800 rotate-0") %>
+            </div>
+          </button>
+        </td>
+      </tr>
+
+      <!-- indented commit body -->
+      <tr data-reveal <%= "hidden" if is_stale_commit %>>
+        <td colspan="2" class="pb-4 whitespace-nowrap">
+          <div class="grid grid-cols-1 gap-y-1 ml-4">
+            <% if is_stale_commit %>
+              <span class="font-medium mb-2">This commit has been replaced by a newer commit.</span>
+            <% end %>
+
+            <% commit.step_runs.includes(:step).order(:created_at).each_with_index do |step_run| %>
+              <div class="border-dashed border-t border-slate-700 last:border-t-0 mb-2"></div>
+
+              <div class="pt-2 <%= "opacity-50" if is_stale_commit %>">
+                <div class="mb-2 font-medium text-base">
+                  <%= step_run.step.name %>
+                  <%= dev_show { step_run.id.strip } %>
+                </div>
+                <!-- per step info -->
+                <div>
+                  <!-- ci link -->
+                  <div class="mb-2">
+                    <% if step_run.ci_link.present? %>
+                      <%= link_to_external "CI workflow run ↗", step_run.ci_link, class: "underline" %>
+                    <% else %>
+                      CI workflow running
+                    <% end %>
+
+                    <span class="ml-1"><%= build_status_badge(step_run) %></span>
+                    <% if step_run.fetching_build? %>
+                      <%= status_badge("Waiting for build", %w[bg-green-500 text-white], pulse: true) %>
+                    <% end %>
+                  </div>
+
+                  <!-- download build -->
+                  <% if step_run.build_artifact_available? %>
+                    <div class="mb-2">
+                      <%= link_to_external "Download build ↗", step_run.download_url, class: "underline" %>
+
+                      <div class="text-slate-500">
+                        <%= render partial: "shared/build_details", locals: { step_run:, with_artifact: true } %>
+                      </div>
+                    </div>
+                  <% end %>
+
+                  <!-- distributions -->
+                  <% if step_run.deployment_runs.exists? %>
+                    <div class="mb-2">
+                      <%= Deployment.display.pluralize %>
+                      <div class="mt-2">
+                        <% step_run.deployment_runs.each do |deployment_run| %>
+                          <% deployment = deployment_run.deployment %>
+                          <div class="mb-1">
+                            <div class="mr-1 inline">
+                              <%= render partial: "shared/deployment", locals: { deployment: deployment } %>
+                            </div>
+
+                            <%= deployment_run_status_badge(deployment_run) %>
+
+                            <% if deployment_run.released? && deployment_run.rollout_percentage %>
+                              <div class="text-xs ml-6 mt-1">
+                                <span>Released to <%= number_to_percentage deployment_run.rollout_percentage %> of the users</span>
+                                <div class="border-slate-200 w-1/2">
+                                  <div class="relative w-full h-2 bg-slate-300">
+                                    <div class="absolute inset-0 bg-emerald-500" aria-hidden="true" style="width: <%= deployment_run.rollout_percentage %>%"></div>
+                                  </div>
+                                </div>
+                              </div>
+                            <% end %>
+
+                            <%= render partial: "releases/live_release/external_release", locals: { deployment_run: } %>
+                          </div>
+                        <% end %>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </td>
+      </tr>
+      </tbody>
+    <% end %>
+  </table>
+</section>

--- a/app/views/shared/demo/live_release/_commit_log.erb
+++ b/app/views/shared/demo/live_release/_commit_log.erb
@@ -2,7 +2,7 @@
   <span class="font-bold text-2xl">Commits since last release</span>
 
   <% if release.previous_release.present? %>
-    <div class="max-h-96 overflow-y-scroll overflow-x-hidden mt-4">
+    <div class="max-h-96 overflow-y-scroll overflow-x-hidden mt-6">
       <table class="w-full">
         <thead class="group text-slate-500 bg-slate-50 border-t border-b border-slate-200">
         <tr>

--- a/app/views/shared/demo/live_release/_commit_log.erb
+++ b/app/views/shared/demo/live_release/_commit_log.erb
@@ -1,4 +1,4 @@
-<section data-controller="reveal" data-reveal-toggle-keys-value="b">
+<section data-controller="reveal">
   <span class="font-bold text-2xl">Commits since last release</span>
 
   <% if release.previous_release.present? %>
@@ -19,7 +19,6 @@
 
         <tbody data-reveal class="text-sm border-b last:border-b-0" data-controller="reveal" data-reveal-toggle-keys-value="b">
         <% release.fetch_commit_log.each_with_index do |commit, index| %>
-
           <tr>
             <td class="py-4 whitespace-nowrap text-slate-500">
               <div class="flex flex-row items-start">

--- a/app/views/shared/demo/live_release/_commit_log.erb
+++ b/app/views/shared/demo/live_release/_commit_log.erb
@@ -1,0 +1,51 @@
+<section data-controller="reveal" data-reveal-toggle-keys-value="b">
+  <span class="font-bold text-2xl">Commits since last release</span>
+
+  <% if release.previous_release.present? %>
+    <div class="max-h-96 overflow-y-scroll overflow-x-hidden mt-4">
+      <table class="w-full">
+        <thead class="group text-slate-500 bg-slate-50 border-t border-b border-slate-200">
+        <tr>
+          <th>
+            <button class="px-2 py-3 transform flex" data-action="reveal#toggle">
+              <div class="text-xs font-semibold uppercase group-hover:text-slate-700">
+                <span class="font-bold"><%= release.fetch_commit_log.size %></span>&nbsp;commits
+              </div>
+              <%= inline_svg("caret_down.svg", classname: "w-3 h-3 shrink-0 ml-1 mt-0.5 fill-current group-hover:text-slate-700 rotate-0") %>
+            </button>
+          </th>
+        </tr>
+        </thead>
+
+        <tbody data-reveal class="text-sm border-b last:border-b-0" data-controller="reveal" data-reveal-toggle-keys-value="b">
+        <% release.fetch_commit_log.each_with_index do |commit, index| %>
+
+          <tr>
+            <td class="py-4 whitespace-nowrap text-slate-500">
+              <div class="flex flex-row items-start">
+                <div class="text-xs uppercase tracking-wide font-medium rounded-full text-center px-2 py-0.5 mr-2 bg-slate-100">
+                  #<%= index + 1 %>
+                </div>
+                <div class="flex flex-col">
+                  <div>
+                    <%= link_to_external commit[:message].truncate(62), commit[:url], class: "underline font-medium text-black" %>
+                  </div>
+                  <div class="mt-1">
+                    <code><%= short_sha(commit[:sha]) %></code>
+                    • <%= link_to_external (commit[:author_login] || commit[:author_name]), (commit[:author_url] || "mailto:#{commit[:author_email]}"), class: "underline" %>
+                    committed <%= ago_in_words commit[:author_timestamp] %>
+                  </div>
+                </div>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="text-xs font-semibold uppercase px-2 py-3 text-slate-500 bg-slate-50 border-t border-b border-slate-200 w-full mt-4 h-full">
+      No previous release found to compare
+    </div>
+  <% end %>
+</section>

--- a/app/views/shared/demo/live_release/_deployment_status.html.erb
+++ b/app/views/shared/demo/live_release/_deployment_status.html.erb
@@ -1,0 +1,46 @@
+<% if step_run.present? %>
+  <% if step_run.manually_startable_deployment?(deployment) %>
+    <%= authz_button_to :blue,
+                        "Start this deployment",
+                        start_release_step_run_deployment_path(release, step_run, deployment),
+                        { class: 'mt-2 btn-xs' } %>
+  <% end %>
+
+  <% deployment_run = step_run.last_run_for(deployment) %>
+
+  <% if deployment_run.present? %>
+    <span class="ml-1"><%= deployment_run_status_badge(deployment_run) %></span>
+
+    <% if deployment_run.reviewable? %>
+      <%= authz_button_to :blue,
+                          "Submit for review",
+                          submit_for_review_deployment_run_path(deployment_run),
+                          { method: :patch, class: 'mt-2 btn-xs' } %>
+    <% end %>
+
+    <% if deployment_run.releasable? %>
+      <%= authz_button_to :blue,
+                          "Start release",
+                          start_release_deployment_run_path(deployment_run),
+                          { method: :patch, class: 'mt-2 btn-xs' } %>
+    <% end %>
+
+    <% if deployment_run.failed_prepare_release? %>
+      <%= authz_button_to :blue,
+                          "Replace inflight release",
+                          prepare_release_deployment_run_path(deployment_run),
+                          { method: :patch,
+                            class: 'mt-2 btn-xs',
+                            params: { deployment_run: { force: true } },
+                            data: { turbo_confirm: "This will over-write the current inflight release submission, are you sure?" } } %>
+    <% end %>
+
+    <% if deployment_run.staged_rollout.present? %>
+      <div class="ml-0 mt-4 pb-1 border-t border-dashed">
+        <%= render StagedRolloutComponent.new(deployment_run.staged_rollout) %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <%= render partial: "shared/demo/release_approvals", locals: { step_run: step_run, deployment: deployment, deployment_run: deployment_run } %>
+<% end %>

--- a/app/views/shared/demo/live_release/_external_release.html.erb
+++ b/app/views/shared/demo/live_release/_external_release.html.erb
@@ -1,0 +1,40 @@
+<% if deployment_run.external_release.present? %>
+  <%
+    deployment = deployment_run.deployment
+    external_release = deployment_run.external_release
+  %>
+  <div class="w-full 2xl:w-2/3 bg-white shadow-sm my-3 rounded-sm border border-slate-200 px-1">
+    <div class="flex flex-col h-full p-4">
+      <header>
+        <h2 class="text-md leading-snug font-semibold">
+          <%= "Added to #{deployment.display_attr(:integration_type)} " + ago_in_words(external_release.added_at) %>
+        </h2>
+      </header>
+
+      <div class="grow mt-2 text-sm">
+        Version
+        <span class="font-mono"><%= external_release.name %></span>
+        • Build
+        <span class="font-mono"><%= external_release.build_number %></span>
+      </div>
+
+      <footer class="mt-5">
+        <div class="text-sm font-medium text-slate-500 mb-2">
+          <%= external_release_status_timestamp(external_release) %>
+        </div>
+
+        <div class="flex justify-between items-center">
+          <span class="bg-slate-400 rounded-full py-1 px-2 text-xs text-white">
+            <%= external_release.status.titleize.upcase %>
+          </span>
+
+          <div>
+            <%= link_to_external "Store dashboard ↗",
+                                 external_release.external_link,
+                                 class: "underline text-sm font-medium text-indigo-500 hover:text-indigo-600" %>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/demo/live_release/_finalize.html.erb
+++ b/app/views/shared/demo/live_release/_finalize.html.erb
@@ -1,0 +1,114 @@
+<section>
+  <div>
+    <span class="font-bold text-2xl">Finalize</span>
+
+    <% unless release.finished? %>
+      <span class="text-xl text-slate-400 ml-4">pending</span>
+    <% end %>
+  </div>
+
+  <% if release.finished? && release.completed_at.present? %>
+    <div class="text-slate-600 animate-bounce mt-2">
+      Great work team! This release is complete!
+    </div>
+  <% end %>
+
+  <% if release.post_release_started? %>
+    <div class="text-center px-4 mb-6">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gradient-to-t from-slate-200 to-slate-100 mb-4 animate-pulse">
+        <%= image_tag("cube.svg", class: "glowing cube", width: 20) %>
+      </div>
+      <h2 class="text-2xl text-slate-400 mb-6">Finishing up, give us a few!</h2>
+      <%= decorated_button_tag :blue, "Refresh", onclick: "window.location.reload();" %>
+    </div>
+  <% end %>
+
+  <% if release.post_release_failed? %>
+    <div class="mt-2">
+      <%= render "shared/note_box",
+                 type: :error,
+                 message: "We couldn't fully finalize this release, please fix any merge conflicts and/or protection rules applied for your branches and try finalizing again." %>
+    </div>
+
+    <div class="mt-6">
+      <%= authz_button_to :blue, "Retry finalize", post_release_release_path(release), class: "btn-sm" %>
+    </div>
+
+    <div class="mt-6">
+      <div class="text-sm font-semibold text-slate-800 mb-1">Pull Requests</div>
+    </div>
+
+    <%= render partial: "releases/live_release/pull_requests", locals: { prs: post_release_prs } %>
+  <% end %>
+
+  <% if release.finished? && release.completed_at.present? %>
+    <% finalize_metadata = release.finalize_phase_metadata %>
+    <div class="mt-4 bg-indigo-50 rounded-md border border-indigo-200">
+      <div class="py-4 px-8 lg:px-8 text-sm">
+        <div class="max-w-sm mx-auto lg:max-w-none">
+          <div class="font-semibold text-slate-800 mb-1">Release Summary</div>
+
+          <ul class="mt-3">
+            <li class="flex items-center justify-between py-3 border-b border-indigo-200">
+              <div>Total Run Time</div>
+              <div class="text-slate-800 ml-2">
+                <%= finalize_metadata.dig(:total_run_time) %>
+              </div>
+            </li>
+
+            <li class="flex items-center justify-between py-3 border-b border-indigo-200">
+              <div>Release Tag</div>
+              <div class="flex items-center whitespace-nowrap">
+                <%= image_tag("git_tag.svg", width: 20, class: "inline-flex mr-2") %>
+                <div class="font-mono text-slate-800">
+                  <%= link_to_external finalize_metadata.dig(:release_tag),
+                                       finalize_metadata.dig(:release_tag_url) %>
+                </div>
+              </div>
+            </li>
+
+            <% last_deployment_run = release.last_good_step_run&.deployment_runs.last %>
+            <% if last_deployment_run&.deployment.controllable_rollout? %>
+              <li class="flex items-center justify-between py-3 border-b border-indigo-200">
+                <div>Release % to users</div>
+                <div class="flex items-center whitespace-nowrap">
+                  <%= number_to_percentage(last_deployment_run.rollout_percentage) %>
+                  (<%= link_to_external "Edit on Play Store", "https://play.google.com/console/u/0/developers", class: "underline" %>
+                  )
+                </div>
+              </li>
+            <% end %>
+
+            <% unless finalize_metadata.dig(:final_artifact_url).nil? %>
+              <li class="flex items-center justify-between py-3 border-b border-indigo-200">
+                <div>Final Release Build</div>
+                <div class="flex items-center whitespace-nowrap">
+                  <%= image_tag("link.svg", width: 20, class: "inline-flex mr-2") %>
+                  <div class="text-slate-800">
+                    <%= link_to_external "Download Artifact", finalize_metadata.dig(:final_artifact_url) %>
+                  </div>
+                </div>
+              </li>
+            <% end %>
+
+            <li class="flex items-center justify-between py-3">
+              <div>Store Link</div>
+              <div class="flex items-center whitespace-nowrap">
+                <%= link_to_external image_tag("link_external.svg", width: 20, class: "inline-flex mr-2"),
+                                     finalize_metadata.dig(:store_url) %>
+              </div>
+            </li>
+          </ul>
+
+          <% if post_release_prs&.exists? %>
+            <div class="mt-6">
+              <div class="font-semibold text-slate-800 mb-1">Pull Requests</div>
+            </div>
+
+            <%= render partial: "releases/live_release/pull_requests", locals: { prs: post_release_prs } %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</section>

--- a/app/views/shared/demo/live_release/_ios_stability.html.erb
+++ b/app/views/shared/demo/live_release/_ios_stability.html.erb
@@ -1,0 +1,39 @@
+<% release =
+     Releases::Train::Run.find_by(id: Flipper.feature("demo_mode_ios_release")&.actors_value&.first&.split(";")&.last)
+   release_train = release&.train
+   steps = release_train&.steps
+%>
+
+<% if @train.demo? && release.present? %>
+  <section>
+    <div>
+      <span class="font-bold text-xl">iOS Release</span>
+    </div>
+
+    <div class="flex flex-col mt-2">
+      <ol class="mt-2">
+        <% steps.each do |step| %>
+          <% step_run = release.last_run_for(step) %>
+
+          <li>
+            <div class="flex items-center">
+              <% if release.on_track? && release.startable_step?(step) %>
+                <%= authz_button_to :blue,
+                                    "Move to this step",
+                                    start_release_step_run_path(release, step),
+                                    { class: "btn-xs mb-2" } %>
+              <% end %>
+            </div>
+
+            <div>
+              <%= render partial: "shared/per_step_metadata",
+                         locals: { editable: false, release: release, step: step, step_run: step_run } %>
+            </div>
+          </li>
+
+          <%= render partial: "shared/step_tree_connector", locals: { color: step_color(step.kind) } %>
+        <% end %>
+      </ol>
+    </div>
+  </section>
+<% end %>

--- a/app/views/shared/demo/live_release/_kick_off.html.erb
+++ b/app/views/shared/demo/live_release/_kick_off.html.erb
@@ -1,5 +1,5 @@
 <section class="max-h-96 h-44">
-  <div class="mb-4">
+  <div class="mb-6">
     <span class="font-bold text-2xl">Kick-off</span>
     <span class="text-xl text-slate-400 ml-4"><%= time_ago_in_words(release.created_at) %> ago</span>
   </div>

--- a/app/views/shared/demo/live_release/_kick_off.html.erb
+++ b/app/views/shared/demo/live_release/_kick_off.html.erb
@@ -1,0 +1,16 @@
+<section>
+  <div class="mb-4">
+    <span class="font-bold text-2xl">Kick-off</span>
+    <span class="text-xl text-slate-400 ml-4"><%= time_ago_in_words(release.created_at) %> ago</span>
+  </div>
+
+  <%= render MetaTableComponent.new do |mt| %>
+    <% mt.with_description("Branching Strategy") do %>
+      <%= release_train.branching_strategy_name %>
+    <% end %>
+
+    <% mt.with_description("Release Branch") do %>
+      <span class="underline"><%= link_to_external "#{release.branch_name} ↗", release.branch_url %></span>
+    <% end %>
+  <% end %>
+</section>

--- a/app/views/shared/demo/live_release/_kick_off.html.erb
+++ b/app/views/shared/demo/live_release/_kick_off.html.erb
@@ -1,4 +1,4 @@
-<section>
+<section class="max-h-96 h-44">
   <div class="mb-4">
     <span class="font-bold text-2xl">Kick-off</span>
     <span class="text-xl text-slate-400 ml-4"><%= time_ago_in_words(release.created_at) %> ago</span>

--- a/app/views/shared/demo/live_release/_pre_release_prs.html.erb
+++ b/app/views/shared/demo/live_release/_pre_release_prs.html.erb
@@ -1,6 +1,5 @@
 <section>
-  <span class="font-bold text-2xl">Pre-release PRs</span>
-
+  <span class="font-bold text-xl">Pre-release PRs</span>
   <% if pre_release_prs&.exists? %>
     <% if pre_release_prs.any?(&:open?) %>
       <div class="mt-4">

--- a/app/views/shared/demo/live_release/_pre_release_prs.html.erb
+++ b/app/views/shared/demo/live_release/_pre_release_prs.html.erb
@@ -1,0 +1,16 @@
+<section>
+  <span class="font-bold text-2xl">Pre-release PRs</span>
+
+  <% if pre_release_prs&.exists? %>
+    <% if pre_release_prs.any?(&:open?) %>
+      <div class="mt-4">
+        <%= render "shared/note_box", message: "Please merge the pre-release PR to continue the release.", type: :error %>
+      </div>
+    <% end %>
+    <%= render partial: "releases/live_release/pull_requests", locals: { prs: pre_release_prs } %>
+  <% else %>
+    <div class="text-sm mt-4">
+      None.
+    </div>
+  <% end %>
+</section>

--- a/app/views/shared/demo/live_release/_pull_requests.html.erb
+++ b/app/views/shared/demo/live_release/_pull_requests.html.erb
@@ -1,0 +1,34 @@
+<div class="grid grid-cols-2 gap-3 mt-3">
+  <% prs.each do |pr| %>
+    <div class="mt-2 rounded-md bg-white rounded-sm border border-slate-200 p-4">
+      <%= image_tag("integrations/logo_#{pr.source}.png", width: 40, class: "mb-4") %>
+
+      <div class="h-full">
+        <h2 class="font-semibold text-slate-800">
+          <%= pr.title %><span class="ml-1 underline">(#<%= link_to_external pr.number, pr.url %>)</span>
+        </h2>
+
+        <div class="mt-2">
+          <%= image_tag("git_pull_request.svg", width: 20, class: "inline-flex") %>
+          <%= pull_request_badge(pr) %>
+        </div>
+
+        <% if pr.base_ref == pr.head_ref %>
+          <div class="font-mono text-xs mt-2">
+            HEAD – <%= short_sha(pr.head_ref) %>
+          </div>
+        <% else %>
+          <div class="font-mono text-xs mt-2">
+            <%= pr.base_ref %> ← <%= pr.head_ref %>
+          </div>
+        <% end %>
+
+        <% if pr.closed_at.nil? %>
+          <div class="text-sm mt-2">Opened at – <%= pr.opened_at.to_s(:short) %></div>
+        <% else %>
+          <div class="text-sm mt-2">Closed at – <%= pr.closed_at.to_s(:short) %></div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/demo/live_release/_release_metadata.html.erb
+++ b/app/views/shared/demo/live_release/_release_metadata.html.erb
@@ -1,7 +1,7 @@
 <% release_metadata = release.release_metadata %>
 
-<section>
-  <div class="flex justify-between items-center mb-4">
+<section class="max-h-96 h-44">
+  <div class="flex justify-between items-center mb-3">
     <span class="font-bold text-2xl">Release Metadata</span>
     <%= authz_link_to (release.metadata_editable? ? :neutral : :disabled), "Edit", edit_release_release_metadatum_path(release) %>
   </div>

--- a/app/views/shared/demo/live_release/_release_metadata.html.erb
+++ b/app/views/shared/demo/live_release/_release_metadata.html.erb
@@ -1,7 +1,7 @@
 <% release_metadata = release.release_metadata %>
 
 <section class="max-h-96 h-44">
-  <div class="flex justify-between items-center mb-3">
+  <div class="flex justify-between items-center mb-4">
     <span class="font-bold text-2xl">Release Metadata</span>
     <%= authz_link_to (release.metadata_editable? ? :neutral : :disabled), "Edit", edit_release_release_metadatum_path(release) %>
   </div>

--- a/app/views/shared/demo/live_release/_release_metadata.html.erb
+++ b/app/views/shared/demo/live_release/_release_metadata.html.erb
@@ -1,0 +1,20 @@
+<% release_metadata = release.release_metadata %>
+
+<section>
+  <div class="flex justify-between items-center mb-4">
+    <span class="font-bold text-2xl">Release Metadata</span>
+    <%= authz_link_to (release.metadata_editable? ? :neutral : :disabled), "Edit", edit_release_release_metadatum_path(release) %>
+  </div>
+
+  <%= render MetaTableComponent.new do |mt| %>
+    <% mt.with_description("Release Notes") do %>
+      <%= simple_format release_metadata.release_notes %>
+    <% end %>
+
+    <% unless is_android %>
+      <% mt.with_description("Promotional Text") do %>
+        <%= simple_format release_metadata.promo_text %>
+      <% end %>
+    <% end %>
+  <% end %>
+</section>

--- a/app/views/shared/demo/live_release/_stability.html.erb
+++ b/app/views/shared/demo/live_release/_stability.html.erb
@@ -1,0 +1,31 @@
+<section>
+  <div>
+    <span class="font-bold text-xl"><%= platform %></span>
+  </div>
+
+  <div class="flex flex-col mt-2">
+    <ol class="mt-2">
+      <% steps.each do |step| %>
+        <% step_run = release.last_run_for(step) %>
+
+        <li>
+          <div class="flex items-center">
+            <% if release.on_track? && release.startable_step?(step) %>
+              <%= authz_button_to :blue,
+                                  "Move to this step",
+                                  start_release_step_run_path(release, step),
+                                  { class: "btn-xs mb-2" } %>
+            <% end %>
+          </div>
+
+          <div>
+            <%= render partial: "shared/per_step_metadata",
+                       locals: { editable: false, release: release, step: step, step_run: step_run } %>
+          </div>
+        </li>
+
+        <%= render partial: "shared/step_tree_connector", locals: { color: step_color(step.kind) } %>
+      <% end %>
+    </ol>
+  </div>
+</section>

--- a/app/views/shared/demo/live_release/_step_run_status.html.erb
+++ b/app/views/shared/demo/live_release/_step_run_status.html.erb
@@ -1,0 +1,13 @@
+<% ring_color = step_color(step.kind) %>
+
+<div class="flex items-center">
+  <% if step_run&.in_progress? %>
+    <span class="w-4 h-4 mt-2 mr-1 bg-indigo-100 rounded-full animate-ping ring-2"></span>
+  <% elsif step_run&.done? %>
+    <span class="w-6 h-6 bg-green-100 rounded-full ring-2 ring-green-500 text-white"></span>
+  <% elsif step_run&.failed? %>
+    <span class="w-6 h-6 bg-rose-100 rounded-full ring-2 ring-rose-500"></span>
+  <% else %>
+    <span class="w-6 h-6 rounded-full ring-2 ring-<%= ring_color %>-300"></span>
+  <% end %>
+</div>

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -114,7 +114,9 @@
 
   <%= render partial: "shared/demo/release_schedule_form", locals: { form: } %>
 
-  <div class="text-xl text-slate-600 font-medium mt-8 mb-4">Branching strategy</div>
+  <div class="border-t border-dashed border-slate-200 pt-8 mt-8"></div>
+
+  <div class="text-xl text-slate-600 font-medium mt-2 mb-4">Branching strategy</div>
 
   <div class="grid gap-x-5 md:grid-cols-2">
     <div data-controller="branching-selector">


### PR DESCRIPTION
A potential way in where we can show two sets of release steps for two platforms in one single live release page. Many of these positional changes can be incorporated back if we prefer them.

![Screenshot 2023-06-07 at 6 53 21 PM](https://github.com/tramlinehq/tramline/assets/50663/37b45dcc-4e9d-496f-8675-9ba5d009d0d0)

![Screenshot 2023-06-07 at 6 53 31 PM](https://github.com/tramlinehq/tramline/assets/50663/29d4b76a-60b7-407d-8443-5a7dedd7d447)

![Screenshot 2023-06-07 at 6 53 51 PM](https://github.com/tramlinehq/tramline/assets/50663/fda87794-fd85-404c-8627-e2482e2fc2ad)

