### PR TITLE
Reduce build number clashes and rejections from stores

### DIFF
--- a/app/libs/installations/apple/app_store_connect/api.rb
+++ b/app/libs/installations/apple/app_store_connect/api.rb
@@ -14,6 +14,7 @@ module Installations
     GROUPS_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/groups"
     FIND_APP_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}"
     FIND_BUILD_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/builds/{build_number}"
+    FIND_LATEST_BUILD_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/builds/latest"
     ADD_BUILD_TO_GROUP_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/groups/{group_id}/add_build"
     APP_CURRENT_STATUS = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/current_status"
     PREPARE_RELEASE_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/release/prepare"
@@ -39,6 +40,12 @@ module Installations
 
     def find_build(build_number, transforms)
       execute(:get, FIND_BUILD_URL.expand(bundle_id:, build_number:).to_s, {})
+        .then { |response| Installations::Response::Keys.transform([response], transforms) }
+        .first
+    end
+
+    def find_latest_build(transforms)
+      execute(:get, FIND_LATEST_BUILD_URL.expand(bundle_id:).to_s, {})
         .then { |response| Installations::Response::Keys.transform([response], transforms) }
         .first
     end

--- a/app/libs/installations/google/play_developer/api.rb
+++ b/app/libs/installations/google/play_developer/api.rb
@@ -31,6 +31,17 @@ module Installations
       end
     end
 
+    def find_latest_build_number
+      execute do
+        edit = client.insert_edit(package_name)
+        client.list_edit_bundles(package_name, edit.id)
+          &.bundles
+          &.sort_by(&:version_code)
+          &.last
+          &.version_code
+      end
+    end
+
     def list_tracks(transforms)
       execute do
         edit = client.insert_edit(package_name)

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -92,18 +92,12 @@ class App < ApplicationRecord
   # to reduce build upload rejection probability
   def bump_build_number!
     with_lock do
-      ios_latest_build_number = ios_store_provider&.latest_build_number
-      android_latest_build_number = android_store_provider&.latest_build_number
+      self.build_number = [
+        ios_store_provider&.latest_build_number,
+        android_store_provider&.latest_build_number,
+        build_number
+      ].compact.max.succ
 
-      if ios_latest_build_number.present? && build_number < ios_latest_build_number
-        self.build_number = ios_latest_build_number
-      end
-
-      if android_latest_build_number.present? && build_number < android_latest_build_number
-        self.build_number = android_latest_build_number
-      end
-
-      self.build_number = build_number.succ
       save!
       build_number.to_s
     end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -88,8 +88,16 @@ class App < ApplicationRecord
     integrations.ready? and config&.ready?
   end
 
+  # NOTE: fetches and uses latest build numbers from the stores, if added,
+  # to reduce build upload rejection probability
   def bump_build_number!
     with_lock do
+      ios_latest_build_number = ios_store_provider&.latest_build_number
+
+      if ios_latest_build_number && build_number < ios_latest_build_number
+        self.build_number = ios_latest_build_number
+      end
+
       self.build_number = build_number.succ
       save!
       build_number.to_s

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -93,9 +93,14 @@ class App < ApplicationRecord
   def bump_build_number!
     with_lock do
       ios_latest_build_number = ios_store_provider&.latest_build_number
+      android_latest_build_number = android_store_provider&.latest_build_number
 
-      if ios_latest_build_number && build_number < ios_latest_build_number
+      if ios_latest_build_number.present? && build_number < ios_latest_build_number
         self.build_number = ios_latest_build_number
+      end
+
+      if android_latest_build_number.present? && build_number < android_latest_build_number
+        self.build_number = android_latest_build_number
       end
 
       self.build_number = build_number.succ

--- a/app/models/app_store_integration.rb
+++ b/app/models/app_store_integration.rb
@@ -10,6 +10,7 @@
 #  key_id     :string
 #
 class AppStoreIntegration < ApplicationRecord
+  using RefinedString
   has_paper_trail
 
   InvalidTransformations = Class.new(StandardError)
@@ -133,6 +134,17 @@ class AppStoreIntegration < ApplicationRecord
 
   def find_build(build_number)
     GitHub::Result.new { build_info(installation.find_build(build_number, BUILD_TRANSFORMATIONS)) }
+  end
+
+  def find_latest_build
+    GitHub::Result.new { build_info(installation.find_latest_build(BUILD_TRANSFORMATIONS)) }
+  end
+
+  def latest_build_number
+    result = find_latest_build
+    if result.ok?
+      result.value!.build_info.dig(:build_number)&.safe_integer
+    end
   end
 
   def find_release(build_number)

--- a/app/models/google_play_store_integration.rb
+++ b/app/models/google_play_store_integration.rb
@@ -151,6 +151,10 @@ class GooglePlayStoreIntegration < ApplicationRecord
     PUBLIC_ICON
   end
 
+  def latest_build_number
+    installation.find_latest_build_number
+  end
+
   private
 
   def project_id

--- a/app/refinements/refined_string.rb
+++ b/app/refinements/refined_string.rb
@@ -28,6 +28,12 @@ module RefinedString
       0.0
     end
 
+    def safe_integer
+      Integer(self)
+    rescue ArgumentError, TypeError
+      0
+    end
+
     def safe_json_parse
       JSON.parse(self)
     rescue JSON::ParserError

--- a/spec/models/step_run_spec.rb
+++ b/spec/models/step_run_spec.rb
@@ -199,22 +199,22 @@ describe StepRun do
   describe "#trigger_ci!" do
     let(:ci_ref) { Faker::Lorem.word }
     let(:ci_link) { Faker::Internet.url }
+    let(:api_double) { instance_double(Installations::Google::PlayDeveloper::Api) }
+    let(:step_run) { create(:step_run) }
 
     before do
       allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!).and_return(ci_ref:, ci_link:)
+      allow_any_instance_of(GooglePlayStoreIntegration).to receive(:installation).and_return(api_double)
+      allow(api_double).to receive(:find_latest_build_number).and_return(123)
     end
 
     it "transitions state" do
-      step_run = create(:step_run)
-
       step_run.trigger_ci!
 
       expect(step_run.ci_workflow_triggered?).to be(true)
     end
 
     it "updates ci metadata" do
-      step_run = create(:step_run)
-
       step_run.trigger_ci!
       step_run.reload
 
@@ -223,7 +223,6 @@ describe StepRun do
     end
 
     it "stamps an event" do
-      step_run = create(:step_run)
       id = step_run.id
       name = step_run.class.name
       allow(PassportJob).to receive(:perform_later)


### PR DESCRIPTION
**Closes:** #479 

## Because

If Tramline is not the only source of build uploads build number clashes, and rejections can happen in stores.

## This addresses

Checks for the latest build numbers (version codes) in the stores at the time of bumping the app version.

Relevant Applelink PR - https://github.com/tramlinehq/applelink/pull/22
