### PR TITLE
Handle upload error after previous review rejection from Play Store

### DIFF
--- a/app/libs/installations/google/play_developer/error.rb
+++ b/app/libs/installations/google/play_developer/error.rb
@@ -50,6 +50,12 @@ module Installations
         code: 403,
         message_matcher: /We have failed to run 'bundletool build-apks' on this Android App Bundle. Please ensure your bundle is valid by running 'bundletool build-apks' locally and try again. Error message output: File 'BundleConfig.pb' was not found/,
         decorated_reason: :apks_not_allowed
+      },
+      {
+        status: "INVALID_ARGUMENT",
+        code: 400,
+        message_matcher: /Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI/,
+        decorated_reason: :app_review_rejected
       }
     ]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,7 @@ en:
           missing_export_compliance: "the release missing export compliance"
           beta_group_not_found: "the beta group not existing in store"
           release_not_found: "the release not being present in store"
-          build_not_submittable: "the build not being submittable "
+          build_not_submittable: "the build not being submittable"
           build_mismatch: "the build not matching the release that exists in store"
           review_in_progress: "a review already being in progress"
           review_submission_exists: "a release already being added for review in the store"
@@ -43,6 +43,7 @@ en:
           duplicate_build_upload: "build already being present in the store"
           invalid_api_package: "the build artifact being invalid for the store"
           apks_not_allowed: "the build artifact being an apk, which is not accepted by the store"
+          app_review_rejected: "the build needs to be uploaded manually as a previous build was rejected by the store"
       deployment:
         integration_type:
           app_store: "App Store (production)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
           duplicate_build_upload: "build already being present in the store"
           invalid_api_package: "the build artifact being invalid for the store"
           apks_not_allowed: "the build artifact being an apk, which is not accepted by the store"
-          app_review_rejected: "the build needs to be uploaded manually as a previous build was rejected by the store"
+          app_review_rejected: "the build needs to be uploaded manually on Google Play Console UI as a previous build was rejected by the store"
       deployment:
         integration_type:
           app_store: "App Store (production)"


### PR DESCRIPTION
This happens when a new build is uploaded to Play Store while an existing build was rejected by the play store.

There are a couple of manual ways to work around the error:
- Resolve the rejection and submit again
- Upload the new build via web google play console in a testing track, publish it, and set the status as "Changes in review".

Not covered in this PR: According to https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit there is a possibility to set `changesNotSentForReview` as a query parameter, which Tramline can ask the user and retry deployment.