### PR TITLE
Do not create duplicate PR on finalize if PR is closed without merge

### DIFF
--- a/app/libs/triggers/post_release/almost_trunk.rb
+++ b/app/libs/triggers/post_release/almost_trunk.rb
@@ -27,7 +27,8 @@ class Triggers::PostRelease
         to_branch_ref: working_branch,
         from_branch_ref: release_branch,
         title: pr_title,
-        description: pr_description
+        description: pr_description,
+        existing_pr: release.pull_requests.post_release.first
       ).then do |value|
         Rails.logger.info "AT: Create and merge PR result", value
         stamp_pr_success


### PR DESCRIPTION
- Fetches updated PR data from VCS
- Closes the PR in db if closed on repo