### PR TITLE
Cancel CI workflows for older commits when a new commit lands

### DIFF
--- a/app/jobs/releases/cancel_workflow_run.rb
+++ b/app/jobs/releases/cancel_workflow_run.rb
@@ -1,0 +1,12 @@
+class Releases::CancelWorkflowRun < ApplicationJob
+  include Loggable
+
+  queue_as :high
+
+  def perform(step_run_id)
+    step_run = StepRun.find(step_run_id)
+    return unless step_run.release_platform_run.on_track?
+    return unless step_run.ci_workflow_started?
+    step_run.cancel_ci_workflow!
+  end
+end

--- a/app/jobs/releases/cancel_workflow_run.rb
+++ b/app/jobs/releases/cancel_workflow_run.rb
@@ -6,7 +6,10 @@ class Releases::CancelWorkflowRun < ApplicationJob
   def perform(step_run_id)
     step_run = StepRun.find(step_run_id)
     return unless step_run.release_platform_run.on_track?
-    return unless step_run.ci_workflow_started?
-    step_run.cancel_ci_workflow!
+
+    step_run.with_lock do
+      return unless step_run.ci_workflow_started?
+      step_run.cancel_ci_workflow!
+    end
   end
 end

--- a/app/libs/installations/bitrise/api.rb
+++ b/app/libs/installations/bitrise/api.rb
@@ -11,6 +11,7 @@ module Installations
     LIST_APPS_URL = "https://api.bitrise.io/v0.1/apps"
     LIST_WORKFLOWS_URL = Addressable::Template.new("https://api.bitrise.io/v0.1/apps/{app_slug}/build-workflows")
     TRIGGER_WORKFLOW_URL = Addressable::Template.new("https://api.bitrise.io/v0.1/apps/{app_slug}/builds")
+    CANCEL_WORKFLOW_URL = Addressable::Template.new("https://api.bitrise.io/v0.1/apps/{app_slug}/builds/{build_slug}/abort")
     WORKFLOW_RUN_URL = Addressable::Template.new("https://api.bitrise.io/v0.1/apps/{app_slug}/builds/{build_slug}")
     WORKFLOW_RUN_ARTIFACTS_URL = Addressable::Template.new("https://api.bitrise.io/v0.1/apps/{app_slug}/builds/{build_slug}/artifacts")
     WORKFLOW_RUN_ARTIFACT_URL = Addressable::Template.new("https://api.bitrise.io/v0.1/apps/{app_slug}/builds/{build_slug}/artifacts/{artifact_slug}")
@@ -77,6 +78,17 @@ module Installations
         .tap { |response| raise Installations::Errors::WorkflowTriggerFailed if response.blank? }
         .then { |response| Installations::Response::Keys.transform([response], transforms) }
         .first
+    end
+
+    def cancel_workflow!(app_slug, build_slug)
+      params = {
+        json: {
+          abort_reason: "build for a newer commit has started",
+          abort_with_success: true,
+          skip_notifications: true
+        }
+      }
+      execute(:post, CANCEL_WORKFLOW_URL.expand(app_slug:, build_slug:).to_s, params)
     end
 
     def get_workflow_run(app_slug, build_slug)

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -84,6 +84,12 @@ module Installations
       end
     end
 
+    def cancel_workflow!(repo, run_id)
+      execute do
+        @client.cancel_workflow_run(repo, run_id)
+      end
+    end
+
     def create_repo_webhook!(repo, url, transforms)
       execute do
         @client.create_hook(

--- a/app/models/bitrise_integration.rb
+++ b/app/models/bitrise_integration.rb
@@ -101,6 +101,10 @@ class BitriseIntegration < ApplicationRecord
     installation.run_workflow!(project, ci_cd_channel, branch_name, inputs, commit_hash, WORKFLOW_RUN_TRANSFORMATIONS)
   end
 
+  def cancel_workflow_run!(ci_ref)
+    installation.cancel_workflow!(project, ci_ref)
+  end
+
   def find_workflow_run(_workflow_id, _branch, _commit_sha)
     raise Integrations::UnsupportedAction
   end

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -169,6 +169,10 @@ class GithubIntegration < ApplicationRecord
     raise WorkflowRun unless installation.run_workflow!(code_repository_name, ci_cd_channel, ref, inputs)
   end
 
+  def cancel_workflow_run!(ci_ref)
+    installation.cancel_workflow!(code_repository_name, ci_ref)
+  end
+
   def find_workflow_run(workflow_id, branch, commit_sha)
     installation.find_workflow_run(code_repository_name, workflow_id, branch, commit_sha, WORKFLOW_RUN_TRANSFORMATIONS)
   end


### PR DESCRIPTION
## Because

This is an optimization to reduce unnecessary CI workload and also reduces the number of review builds being distributed for concurrent changes in the release branch


