### PR TITLE
Cancel old step runs when new commits land

### DIFF
--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -46,6 +46,8 @@ module ReleasesHelper
         ["Build unavailable", :failure]
       when :deployment_failed
         ["Deployment failed", :failure]
+      when :cancelled
+        ["Cancelled", :neutral]
       else
         ["Unknown", :neutral]
       end

--- a/app/jobs/releases/cancel_step_run.rb
+++ b/app/jobs/releases/cancel_step_run.rb
@@ -5,7 +5,7 @@ class Releases::CancelStepRun < ApplicationJob
 
   def perform(step_run_id)
     step_run = StepRun.find(step_run_id)
-    return unless step_run.release_platform_run.on_track?
+    return unless step_run.active?
 
     step_run.cancel!
   end

--- a/app/jobs/releases/cancel_step_run.rb
+++ b/app/jobs/releases/cancel_step_run.rb
@@ -1,0 +1,12 @@
+class Releases::CancelStepRun < ApplicationJob
+  include Loggable
+
+  queue_as :high
+
+  def perform(step_run_id)
+    step_run = StepRun.find(step_run_id)
+    return unless step_run.release_platform_run.on_track?
+
+    step_run.cancel!
+  end
+end

--- a/app/jobs/releases/cancel_workflow_run.rb
+++ b/app/jobs/releases/cancel_workflow_run.rb
@@ -5,11 +5,6 @@ class Releases::CancelWorkflowRun < ApplicationJob
 
   def perform(step_run_id)
     step_run = StepRun.find(step_run_id)
-    return unless step_run.release_platform_run.on_track?
-
-    step_run.with_lock do
-      return unless step_run.ci_workflow_started?
-      step_run.cancel_ci_workflow!
-    end
+    step_run.cancel_ci_workflow!
   end
 end

--- a/app/jobs/releases/find_build_job.rb
+++ b/app/jobs/releases/find_build_job.rb
@@ -25,7 +25,8 @@ class Releases::FindBuildJob
 
   def perform(step_run_id)
     run = StepRun.find(step_run_id)
-    return unless run.release_platform_run.on_track?
+    return unless run.active?
+
     run.find_build.value!
     run.build_found!
     run.event_stamp!(reason: :build_found_in_store, kind: :notice, data: {version: run.build_version})

--- a/app/jobs/releases/find_workflow_run.rb
+++ b/app/jobs/releases/find_workflow_run.rb
@@ -3,7 +3,7 @@ class Releases::FindWorkflowRun
   include Loggable
 
   queue_as :high
-  sidekiq_options retry: 2
+  sidekiq_options retry: 5
 
   sidekiq_retry_in do |count, exception|
     if exception.is_a?(Installations::Errors::WorkflowRunNotFound)

--- a/app/jobs/releases/find_workflow_run.rb
+++ b/app/jobs/releases/find_workflow_run.rb
@@ -23,7 +23,7 @@ class Releases::FindWorkflowRun
 
   def perform(step_run_id)
     step_run = StepRun.find(step_run_id)
-    return unless step_run.release_platform_run.on_track?
+    return unless step_run.active?
     step_run.ci_start!
   rescue => e
     elog(e)

--- a/app/jobs/releases/upload_artifact.rb
+++ b/app/jobs/releases/upload_artifact.rb
@@ -4,6 +4,7 @@ class Releases::UploadArtifact < ApplicationJob
 
   def perform(step_run_id, artifacts_url)
     run = StepRun.find(step_run_id)
+    return unless run.active?
 
     begin
       run.artifacts_url = artifacts_url

--- a/app/jobs/workflow_processors/workflow_run_job.rb
+++ b/app/jobs/workflow_processors/workflow_run_job.rb
@@ -3,7 +3,7 @@ class WorkflowProcessors::WorkflowRunJob < ApplicationJob
 
   def perform(step_run_id)
     run = StepRun.find(step_run_id)
-    return unless run.release_platform_run.on_track?
+    return unless run.active?
     return unless run.ci_workflow_started?
 
     WorkflowProcessors::WorkflowRun.process(run)

--- a/app/libs/deployments/app_store_connect/release.rb
+++ b/app/libs/deployments/app_store_connect/release.rb
@@ -127,7 +127,7 @@ module Deployments
       end
 
       def update_external_release
-        return unless run.release_platform_run.on_track? && app_store_integration?
+        return unless run.step_run.active? && app_store_integration?
 
         result = find_release
 

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -258,11 +258,11 @@ class DeploymentRun < ApplicationRecord
   end
 
   def promotable?
-    release_platform_run.on_track? && store? && (uploaded? || rollout_started?)
+    step_run.active? && store? && (uploaded? || rollout_started?)
   end
 
   def release_startable?
-    release_platform_run.on_track? && may_engage_release?
+    step_run.active? && may_engage_release?
   end
 
   def rolloutable?
@@ -281,11 +281,11 @@ class DeploymentRun < ApplicationRecord
   end
 
   def app_store_release?
-    step.release? && release_platform_run.on_track? && deployment.app_store?
+    step.release? && step_run.active? && deployment.app_store?
   end
 
   def test_flight_release?
-    release_platform_run.on_track? && deployment.test_flight?
+    step_run.active? && deployment.test_flight?
   end
 
   def reviewable?

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -146,7 +146,6 @@ class StepRun < ApplicationRecord
   delegate :download_url, to: :build_artifact
   scope :not_failed, -> { where.not(status: [:ci_workflow_failed, :ci_workflow_halted, :build_not_found_in_store, :build_unavailable, :deployment_failed]) }
 
-
   def active?
     release_platform_run.on_track? && !cancelled?
   end

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -73,7 +73,7 @@ class StepRun < ApplicationRecord
     cancelled: "cancelled"
   }
 
-  END_STATES = [
+  END_STATES = STATES.slice(
     :ci_workflow_unavailable,
     :ci_workflow_failed,
     :ci_workflow_halted,
@@ -82,7 +82,7 @@ class StepRun < ApplicationRecord
     :deployment_failed,
     :success,
     :cancelled
-  ]
+  ).keys
 
   enum status: STATES
 

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -73,6 +73,17 @@ class StepRun < ApplicationRecord
     cancelled: "cancelled"
   }
 
+  END_STATES = [
+    :ci_workflow_unavailable,
+    :ci_workflow_failed,
+    :ci_workflow_halted,
+    :build_unavailable,
+    :build_not_found_in_store,
+    :deployment_failed,
+    :success,
+    :cancelled
+  ]
+
   enum status: STATES
 
   aasm safe_state_machine_params do
@@ -127,9 +138,7 @@ class StepRun < ApplicationRecord
 
     event :cancel do
       before { Releases::CancelWorkflowRun.perform_later(id) if ci_workflow_started? }
-      transitions from: [:on_track, :ci_workflow_triggered, :ci_workflow_started,
-        :build_ready, :build_found_in_store, :build_available, :deployment_started],
-        to: :cancelled
+      transitions from: (STATES.keys - END_STATES), to: :cancelled
     end
   end
 

--- a/app/views/shared/live_release/_stability.html.erb
+++ b/app/views/shared/live_release/_stability.html.erb
@@ -28,7 +28,7 @@
 
         <li>
           <div class="flex items-center">
-            <% if release.on_track? && release.startable_step?(step) %>
+            <% if release.startable_step?(step) %>
               <%= authz_button_to :blue,
                                   "Move to this step",
                                   start_release_step_run_path(release, step),

--- a/spec/factories/step_runs.rb
+++ b/spec/factories/step_runs.rb
@@ -8,6 +8,14 @@ FactoryBot.define do
     scheduled_at { Time.current }
     status { "on_track" }
 
+    trait :ci_workflow_triggered do
+      status { "ci_workflow_triggered" }
+    end
+
+    trait :ci_workflow_started do
+      status { "ci_workflow_started" }
+    end
+
     trait :ci_workflow_failed do
       status { "ci_workflow_failed" }
     end
@@ -28,8 +36,8 @@ FactoryBot.define do
       status { "ci_workflow_unavailable" }
     end
 
-    trait :ci_workflow_failed do
-      status { "ci_workflow_failed" }
+    trait :ci_workflow_halted do
+      status { "ci_workflow_halted" }
     end
 
     trait :deployment_failed do
@@ -40,8 +48,20 @@ FactoryBot.define do
       status { "build_available" }
     end
 
+    trait :build_unavailable do
+      status { "build_unavailable" }
+    end
+
     trait :build_found_in_store do
       status { "build_found_in_store" }
+    end
+
+    trait :build_not_found_in_store do
+      status { "build_not_found_in_store" }
+    end
+
+    trait :cancelled do
+      status { "cancelled" }
     end
 
     trait :with_build_artifact do

--- a/spec/jobs/releases/find_build_job_spec.rb
+++ b/spec/jobs/releases/find_build_job_spec.rb
@@ -41,7 +41,7 @@ describe Releases::FindBuildJob do
       expect(step_run.reload.build_ready?).to be(true)
     end
 
-    it "does nothing if teh step run is cancelled" do
+    it "does nothing if the step run is cancelled" do
       step_run.update(status: "cancelled")
 
       described_class.new.perform(step_run.id)

--- a/spec/jobs/releases/find_build_job_spec.rb
+++ b/spec/jobs/releases/find_build_job_spec.rb
@@ -40,5 +40,13 @@ describe Releases::FindBuildJob do
 
       expect(step_run.reload.build_ready?).to be(true)
     end
+
+    it "does nothing if teh step run is cancelled" do
+      step_run.update(status: "cancelled")
+
+      described_class.new.perform(step_run.id)
+
+      expect(step_run.reload.cancelled?).to be(true)
+    end
   end
 end

--- a/spec/jobs/releases/upload_artifact_spec.rb
+++ b/spec/jobs/releases/upload_artifact_spec.rb
@@ -26,5 +26,21 @@ describe Releases::UploadArtifact do
       expect(step_run.reload.build_unavailable?).to be(true)
       expect(step_run.build_artifact).not_to be_present
     end
+
+    it "does nothing if the run is not active" do
+      step_run.release_platform_run.update(status: "finished")
+
+      described_class.new.perform(step_run.id, artifacts_url)
+
+      expect(step_run.reload.build_ready?).to be(true)
+    end
+
+    it "does nothing if the step run is cancelled" do
+      step_run.update(status: "cancelled")
+
+      described_class.new.perform(step_run.id, artifacts_url)
+
+      expect(step_run.reload.cancelled?).to be(true)
+    end
   end
 end

--- a/spec/models/step_run_spec.rb
+++ b/spec/models/step_run_spec.rb
@@ -100,7 +100,7 @@ describe StepRun do
       expect(step_run.manually_startable_deployment?(deployment)).to be false
     end
 
-    it "is false when there the step run is cancelled" do
+    it "is false when the step run is cancelled" do
       step = create(:step, :with_deployment, release_platform: release_platform)
       step_run = create(:step_run, :cancelled, step: step)
       deployment = create(:deployment, step: step)
@@ -286,7 +286,7 @@ describe StepRun do
     end
 
     (StepRun::STATES.keys - StepRun::END_STATES).each do |trait|
-      it "cancels previous running step run" do
+      it "cancels previous running step run when #{trait}" do
         allow(Releases::CancelStepRun).to receive(:perform_later)
         previous_step_run = create(:step_run, trait, step: step_run.step,
           release_platform_run: step_run.release_platform_run,
@@ -348,10 +348,7 @@ describe StepRun do
   end
 
   describe "#cancel!" do
-    let(:release_platform) { create(:release_platform) }
-    let(:step) { create(:step, :with_deployment, release_platform: release_platform) }
-    let(:release_platform_run) { create(:release_platform_run, release_platform:) }
-    let(:release) { release_platform_run.release }
+    let(:step) { create(:step, :with_deployment) }
 
     it "cancels the step run" do
       step_run = create(:step_run, step: step)


### PR DESCRIPTION
## Because

If a newer build is being created, the old builds should not be distributed as they may create confusion among the team.

## This addresses

- Cancels the previous running step run when a new step run is created
- Cancels CI workflow for the canceled step run, if needed


