### PR TITLE
Update release notes in FAD with step's build notes

### DIFF
--- a/app/libs/deployments/google_firebase/release.rb
+++ b/app/libs/deployments/google_firebase/release.rb
@@ -80,6 +80,7 @@ module Deployments
           added_at: release_info.added_at,
           status: release_info.status,
           external_link: release_info.console_link)
+        provider.update_release_notes(release_info.release, run.step_run.build_notes)
         run.upload!
       end
 

--- a/app/libs/installations/google/firebase/api.rb
+++ b/app/libs/installations/google/firebase/api.rb
@@ -32,6 +32,14 @@ module Installations
       end
     end
 
+    def update_release_notes(release, notes)
+      execute do
+        release = FAD_PUBLISHER::GoogleFirebaseAppdistroV1Release.from_json(release.to_json)
+        release.release_notes = FAD_PUBLISHER::GoogleFirebaseAppdistroV1ReleaseNotes.new(text: notes)
+        fad_client.patch_project_app_release(release.name, release)
+      end
+    end
+
     def get_upload_status(op_name)
       execute do
         fad_client.get_project_app_release_operation(op_name)&.to_h

--- a/app/models/google_firebase_integration.rb
+++ b/app/models/google_firebase_integration.rb
@@ -111,6 +111,10 @@ class GoogleFirebaseIntegration < ApplicationRecord
     end
   end
 
+  def update_release_notes(release, notes)
+    installation.update_release_notes(release, notes)
+  end
+
   def release(release_name, group)
     GitHub::Result.new do
       installation.send_to_group(release_name, group_name(group))

--- a/app/models/google_firebase_integration.rb
+++ b/app/models/google_firebase_integration.rb
@@ -111,9 +111,7 @@ class GoogleFirebaseIntegration < ApplicationRecord
     end
   end
 
-  def update_release_notes(release, notes)
-    installation.update_release_notes(release, notes)
-  end
+  delegate :update_release_notes, to: :installation
 
   def release(release_name, group)
     GitHub::Result.new do


### PR DESCRIPTION
## Because

The testers and stakeholders downloading the builds from FAD would like to know what to test for in that build.

<img width="506" alt="Screenshot 2023-07-27 at 5 10 58 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/58396d91-6cea-4e53-b63f-8abe024f25ae">


