### PR TITLE
Update build test notes in testFlight

### DIFF
--- a/app/jobs/deployments/app_store_connect/update_build_notes_job.rb
+++ b/app/jobs/deployments/app_store_connect/update_build_notes_job.rb
@@ -1,0 +1,7 @@
+class Deployments::AppStoreConnect::UpdateBuildNotesJob < ApplicationJob
+  queue_as :high
+
+  def perform(deployment_run_id)
+    Deployments::AppStoreConnect::Release.update_build_notes!(DeploymentRun.find(deployment_run_id))
+  end
+end

--- a/app/jobs/deployments/app_store_connect/update_build_notes_job.rb
+++ b/app/jobs/deployments/app_store_connect/update_build_notes_job.rb
@@ -2,6 +2,9 @@ class Deployments::AppStoreConnect::UpdateBuildNotesJob < ApplicationJob
   queue_as :high
 
   def perform(deployment_run_id)
-    Deployments::AppStoreConnect::Release.update_build_notes!(DeploymentRun.find(deployment_run_id))
+    run = DeploymentRun.find(deployment_run_id)
+    return unless run.test_flight_release?
+
+    Deployments::AppStoreConnect::Release.update_build_notes!(run)
   end
 end

--- a/app/jobs/deployments/google_firebase/update_build_notes_job.rb
+++ b/app/jobs/deployments/google_firebase/update_build_notes_job.rb
@@ -1,0 +1,10 @@
+class Deployments::GoogleFirebase::UpdateBuildNotesJob < ApplicationJob
+  queue_as :high
+
+  def perform(deployment_run_id, release)
+    run = DeploymentRun.find(deployment_run_id)
+    return unless run.google_firebase_integration?
+
+    Deployments::GoogleFirebase::Release.update_build_notes!(run, release)
+  end
+end

--- a/app/libs/deployments/google_firebase/release.rb
+++ b/app/libs/deployments/google_firebase/release.rb
@@ -17,6 +17,10 @@ module Deployments
         new(deployment_run).update_upload_status!(op_name)
       end
 
+      def self.update_build_notes!(deployment_run, release)
+        new(deployment_run).update_build_notes!(release)
+      end
+
       def self.start_release!(deployment_run)
         new(deployment_run).start_release!
       end
@@ -80,8 +84,12 @@ module Deployments
           added_at: release_info.added_at,
           status: release_info.status,
           external_link: release_info.console_link)
-        provider.update_release_notes(release_info.release, run.step_run.build_notes)
         run.upload!
+        Deployments::GoogleFirebase::UpdateBuildNotesJob.perform_later(run.id, release_info.release)
+      end
+
+      def update_build_notes!(release)
+        provider.update_release_notes(release, run.step_run.build_notes)
       end
 
       def start_release!

--- a/app/libs/installations/apple/app_store_connect/api.rb
+++ b/app/libs/installations/apple/app_store_connect/api.rb
@@ -13,7 +13,7 @@ module Installations
 
     GROUPS_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/groups"
     FIND_APP_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}"
-    FIND_BUILD_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/builds/{build_number}"
+    BUILD_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/builds/{build_number}"
     FIND_LATEST_BUILD_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/builds/latest"
     ADD_BUILD_TO_GROUP_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/groups/{group_id}/add_build"
     APP_CURRENT_STATUS = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/current_status"
@@ -39,9 +39,18 @@ module Installations
     end
 
     def find_build(build_number, transforms)
-      execute(:get, FIND_BUILD_URL.expand(bundle_id:, build_number:).to_s, {})
+      execute(:get, BUILD_URL.expand(bundle_id:, build_number:).to_s, {})
         .then { |response| Installations::Response::Keys.transform([response], transforms) }
         .first
+    end
+
+    def update_build_beta_notes(build_number, notes)
+      params = {
+        json: {
+          notes: notes
+        }
+      }
+      execute(:patch, BUILD_URL.expand(bundle_id:, build_number:).to_s, params)
     end
 
     def find_latest_build(transforms)

--- a/app/models/app_store_integration.rb
+++ b/app/models/app_store_integration.rb
@@ -140,6 +140,10 @@ class AppStoreIntegration < ApplicationRecord
     GitHub::Result.new { build_info(installation.find_latest_build(BUILD_TRANSFORMATIONS)) }
   end
 
+  def update_release_notes(build_number, notes)
+    installation.update_build_beta_notes(build_number, notes)
+  end
+
   def latest_build_number
     result = find_latest_build
     if result.ok?


### PR DESCRIPTION
## Because

The testers and stakeholders downloading the builds from TestFlight would like to know what to test for in that build.

Depends on: https://github.com/tramlinehq/applelink/pull/26

- Updates build notes for both TF and FAD in a separate job so as to not disrupt the release steps