### PR TITLE
Allow distribution to internal groups in TestFlight

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -111,10 +111,6 @@ module ApplicationHelper
       .tap { |list| with_none ? list.unshift(["None", nil]) : nil }
   end
 
-  def deployment_channel_name(chan)
-    chan[:is_internal] ? chan[:name] + " (Internal)" : chan[:name]
-  end
-
   def time_format(timestamp, with_year: false)
     return unless timestamp
     timestamp.strftime("%b #{timestamp.day.ordinalize}#{", %Y" if with_year} at %-l:%M %P")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -111,6 +111,10 @@ module ApplicationHelper
       .tap { |list| with_none ? list.unshift(["None", nil]) : nil }
   end
 
+  def deployment_channel_name(chan)
+    chan[:is_internal] ? chan[:name] + " (Internal)" : chan[:name]
+  end
+
   def time_format(timestamp, with_year: false)
     return unless timestamp
     timestamp.strftime("%b #{timestamp.day.ordinalize}#{", %Y" if with_year} at %-l:%M %P")

--- a/app/helpers/deployments_helper.rb
+++ b/app/helpers/deployments_helper.rb
@@ -1,7 +1,11 @@
 module DeploymentsHelper
+  def deployment_channel_name(chan)
+    chan["is_internal"] ? chan["name"] + " (Internal)" : chan["name"]
+  end
+
   def show_deployment(deployment)
     display = deployment.display_attr(:integration_type)
-    display += " • #{deployment.deployment_channel_name}" if deployment.display_channel?
+    display += " • #{deployment_channel_name(deployment.build_artifact_channel)}" if deployment.display_channel?
     display
   end
 end

--- a/app/helpers/deployments_helper.rb
+++ b/app/helpers/deployments_helper.rb
@@ -1,7 +1,7 @@
 module DeploymentsHelper
   def show_deployment(deployment)
     display = deployment.display_attr(:integration_type)
-    display += " • #{deployment.build_artifact_channel["name"]}" if deployment.display_channel?
+    display += " • #{deployment.deployment_channel_name}" if deployment.display_channel?
     display
   end
 end

--- a/app/libs/deployments/app_store_connect/release.rb
+++ b/app/libs/deployments/app_store_connect/release.rb
@@ -71,6 +71,7 @@ module Deployments
         :app_store?,
         :staged_rollout_config,
         :release_metadata,
+        :internal_channel?,
         to: :run
 
       def kickoff!
@@ -82,6 +83,8 @@ module Deployments
         return unless test_flight_release?
 
         Deployments::AppStoreConnect::UpdateBuildNotesJob.perform_later(run.id)
+
+        return run.complete! if internal_channel?
 
         result = provider.release_to_testflight(deployment_channel, build_number)
 

--- a/app/libs/installations/apple/app_store_connect/api.rb
+++ b/app/libs/installations/apple/app_store_connect/api.rb
@@ -27,7 +27,7 @@ module Installations
     HALT_LIVE_ROLLOUT_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/release/live/rollout/halt"
     COMPLETE_LIVE_ROLLOUT_URL = Addressable::Template.new "#{ENV["APPLELINK_URL"]}/apple/connect/v1/apps/{bundle_id}/release/live/rollout/complete"
 
-    def external_groups(transforms)
+    def beta_groups(transforms)
       execute(:get, GROUPS_URL.expand(bundle_id:).to_s, {params: {internal: false}})
         .then { |responses| Installations::Response::Keys.transform(responses, transforms) }
     end

--- a/app/libs/notifiers/slack/renderers/base.rb
+++ b/app/libs/notifiers/slack/renderers/base.rb
@@ -1,5 +1,6 @@
 class Notifiers::Slack::Renderers::Base
   include Rails.application.routes.url_helpers
+  include DeploymentsHelper
 
   NOTIFIERS_RELATIVE_PATH = "app/views/notifiers/slack".freeze
   ROOT_PATH = Rails.root.join(NOTIFIERS_RELATIVE_PATH)
@@ -27,5 +28,10 @@ class Notifiers::Slack::Renderers::Base
 
   def template_file
     File.read(File.join(ROOT_PATH, self.class::TEMPLATE_FILE))
+  end
+
+  def deployment_channel
+    return unless @deployment_channel
+    deployment_channel_name(@deployment_channel)
   end
 end

--- a/app/models/app_store_integration.rb
+++ b/app/models/app_store_integration.rb
@@ -39,7 +39,8 @@ class AppStoreIntegration < ApplicationRecord
 
   CHANNELS_TRANSFORMATIONS = {
     id: :id,
-    name: :name
+    name: :name,
+    is_internal: :internal
   }
 
   BUILD_TRANSFORMATIONS = {
@@ -209,9 +210,9 @@ class AppStoreIntegration < ApplicationRecord
     sliced =
       cache.fetch(build_channels_cache_key, expires_in: 1.hour) do
         installation
-          .external_groups(CHANNELS_TRANSFORMATIONS)
+          .beta_groups(CHANNELS_TRANSFORMATIONS)
           .push(PROD_CHANNEL)
-          .map { |channel| channel.slice(:id, :name, :is_production) }
+          .map { |channel| channel.slice(:id, :name, :is_internal, :is_production) }
       end
 
     return sliced if with_production

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -82,11 +82,19 @@ class Deployment < ApplicationRecord
   end
 
   def deployment_channel_name
-    build_artifact_channel["name"]
+    if internal_channel?
+      build_artifact_channel["name"] + " (Internal)"
+    else
+      build_artifact_channel["name"]
+    end
   end
 
   def production_channel?
     store? && build_artifact_channel["is_production"]
+  end
+
+  def internal_channel?
+    build_artifact_channel["is_internal"]
   end
 
   def integration_type

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -82,11 +82,7 @@ class Deployment < ApplicationRecord
   end
 
   def deployment_channel_name
-    if internal_channel?
-      build_artifact_channel["name"] + " (Internal)"
-    else
-      build_artifact_channel["name"]
-    end
+    build_artifact_channel["name"]
   end
 
   def production_channel?
@@ -128,7 +124,7 @@ class Deployment < ApplicationRecord
           is_play_store_production: production_channel? && google_play_store_integration?,
           is_app_store_production: app_store?,
           deployment_channel_type: integration_type&.to_s&.titleize,
-          deployment_channel_name: deployment_channel_name,
+          deployment_channel: build_artifact_channel,
           deployment_channel_asset_link: integration&.public_icon_img
         }
       )

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -52,6 +52,7 @@ class DeploymentRun < ApplicationRecord
     :google_firebase_integration?,
     :production_channel?,
     :release_platform,
+    :internal_channel?,
     to: :deployment
   delegate :release_metadata, to: :release
   delegate :release_version, to: :release_platform_run

--- a/app/views/notifiers/slack/deployment_finished.json.erb
+++ b/app/views/notifiers/slack/deployment_finished.json.erb
@@ -18,7 +18,7 @@
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "New *<%= @deployment_channel_type %>* build *<%= @build_number %>* is now available to *<%= @deployment_channel_name %>* :sparkles:"
+        "text": "New *<%= @deployment_channel_type %>* build *<%= @build_number %>* is now available to *<%= deployment_channel %>* :sparkles:"
       }
     },
     {
@@ -116,7 +116,7 @@
         },
         {
           "type": "plain_text",
-          "text": "Deployment: <%= @deployment_channel_type %> + <%= @deployment_channel_name %>",
+          "text": "Deployment: <%= @deployment_channel_type %> + <%= deployment_channel %>",
           "emoji": true
         }
       ]

--- a/app/views/notifiers/slack/staged_rollout_updated.json.erb
+++ b/app/views/notifiers/slack/staged_rollout_updated.json.erb
@@ -100,7 +100,7 @@
         },
         {
           "type": "plain_text",
-          "text": "Deployment: <%= @deployment_channel_type %> + <%= @deployment_channel_name %>",
+          "text": "Deployment: <%= @deployment_channel_type %> + <%= deployment_channel %>",
           "emoji": true
         }
       ]

--- a/app/views/notifiers/slack/submit_for_review.json.erb
+++ b/app/views/notifiers/slack/submit_for_review.json.erb
@@ -18,7 +18,7 @@
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "*<%= @app_name %> (<%= @app_platform %>)* <%= @train_current_version %> has been submitted for review to <%= @deployment_channel_type %> (<%= @deployment_channel_name %>)! :tada:"
+        "text": "*<%= @app_name %> (<%= @app_platform %>)* <%= @train_current_version %> has been submitted for review to <%= @deployment_channel_type %> (<%= deployment_channel %>)! :tada:"
       }
     },
     {
@@ -106,7 +106,7 @@
         },
         {
           "type": "plain_text",
-          "text": "Deployment: <%= @deployment_channel_type %> + <%= @deployment_channel_name %>",
+          "text": "Deployment: <%= @deployment_channel_type %> + <%= deployment_channel %>",
           "emoji": true
         }
       ]

--- a/app/views/steps/_deployment.html.erb
+++ b/app/views/steps/_deployment.html.erb
@@ -21,7 +21,7 @@
 
       <div class="flex-grow w-1/2">
         <%= form.select :build_artifact_channel,
-                        options_for_select(display_channels(@selected_build_channels) { |chan| chan[:name] }),
+                        options_for_select(display_channels(@selected_build_channels) { |chan| deployment_channel_name(chan) }),
                         { class: "block form-select" },
                         { data: { dropdown_stream_target: "dynamicSelect",
                                   action: "dropdown-stream#showElementOnDynamicSelectChange domain--staged-rollout-help#clear",


### PR DESCRIPTION
- it simply uploads the build notes and marks the deployment as a success
- assumes that the internal distribution channel `hasAccessToAllBuilds` in TestFlight

Even though we do not "distribute", this has value still since the build notes get added to the build and the user has visibility into who they want to send the build for testing.

Dependent on: https://github.com/tramlinehq/applelink/pull/27
