### PR TITLE
Add a deep link to install build on phone for deployment notifs

### DIFF
--- a/app/models/app_store_integration.rb
+++ b/app/models/app_store_integration.rb
@@ -226,7 +226,7 @@ class AppStoreIntegration < ApplicationRecord
     "app_store"
   end
 
-  def deep_link(_release, _platform:)
+  def deep_link(_, _)
     "itms-beta://beta.itunes.apple.com/v1/app/#{app.external_id}"
   end
 

--- a/app/models/app_store_integration.rb
+++ b/app/models/app_store_integration.rb
@@ -226,6 +226,10 @@ class AppStoreIntegration < ApplicationRecord
     "app_store"
   end
 
+  def deep_link(_release, _platform:)
+    "itms-beta://beta.itunes.apple.com/v1/app/#{app.external_id}"
+  end
+
   def build_info(build_info)
     TestFlightInfo.new(build_info.merge(external_link: APP_STORE_CONNECT_URL_TEMPLATE.expand(app_id: app.external_id, external_id: build_info[:external_id]).to_s))
   end

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -338,7 +338,7 @@ class DeploymentRun < ApplicationRecord
       .merge(
         {
           project_link: external_release&.external_link.presence || deployment.project_link,
-          deep_link: provider.deep_link(external_release.external_id, platform: release_platform.platform)
+          deep_link: provider.deep_link(external_release&.external_id, platform: release_platform.platform)
         }
       )
   end

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -319,7 +319,7 @@ class DeploymentRun < ApplicationRecord
   end
 
   def provider
-    integration.providable
+    integration&.providable
   end
 
   def fail_with_error(error)
@@ -338,7 +338,7 @@ class DeploymentRun < ApplicationRecord
       .merge(
         {
           project_link: external_release&.external_link.presence || deployment.project_link,
-          deep_link: provider.deep_link(external_release&.external_id, platform: release_platform.platform)
+          deep_link: provider&.deep_link(external_release&.external_id, release_platform.platform)
         }
       )
   end

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -337,7 +337,8 @@ class DeploymentRun < ApplicationRecord
       .merge(step_run.notification_params)
       .merge(
         {
-          project_link: external_release&.external_link.presence || deployment.project_link
+          project_link: external_release&.external_link.presence || deployment.project_link,
+          deep_link: provider.deep_link(external_release.external_id, platform: release_platform.platform)
         }
       )
   end

--- a/app/models/google_firebase_integration.rb
+++ b/app/models/google_firebase_integration.rb
@@ -132,6 +132,10 @@ class GoogleFirebaseIntegration < ApplicationRecord
     PUBLIC_ICON
   end
 
+  def deep_link(release, platform:)
+    "https://appdistribution.firebase.google.com/testerapps/#{fetch_app_id(platform)}/releases/#{release_name(release)}"
+  end
+
   class ReleaseInfo
     def initialize(release_info)
       raise ArgumentError, "release_info must be a Hash" unless release_info.is_a?(Hash)
@@ -183,6 +187,10 @@ class GoogleFirebaseIntegration < ApplicationRecord
 
   def group_name(group)
     group.split("/").last
+  end
+
+  def release_name(release)
+    release.split("/").last
   end
 
   def correct_key

--- a/app/models/google_firebase_integration.rb
+++ b/app/models/google_firebase_integration.rb
@@ -132,7 +132,7 @@ class GoogleFirebaseIntegration < ApplicationRecord
     PUBLIC_ICON
   end
 
-  def deep_link(release, platform:)
+  def deep_link(release, platform)
     "https://appdistribution.firebase.google.com/testerapps/#{fetch_app_id(platform)}/releases/#{release_name(release)}"
   end
 

--- a/app/models/google_play_store_integration.rb
+++ b/app/models/google_play_store_integration.rb
@@ -155,6 +155,10 @@ class GooglePlayStoreIntegration < ApplicationRecord
     installation.find_latest_build_number
   end
 
+  def deep_link
+    nil
+  end
+
   private
 
   def project_id

--- a/app/models/google_play_store_integration.rb
+++ b/app/models/google_play_store_integration.rb
@@ -155,7 +155,7 @@ class GooglePlayStoreIntegration < ApplicationRecord
     installation.find_latest_build_number
   end
 
-  def deep_link
+  def deep_link(_, _)
     nil
   end
 

--- a/app/models/slack_integration.rb
+++ b/app/models/slack_integration.rb
@@ -147,6 +147,10 @@ class SlackIntegration < ApplicationRecord
     nil
   end
 
+  def deep_link(_, _)
+    nil
+  end
+
   private
 
   def get_all_channels(cursor = nil, channels = [])

--- a/app/views/notifiers/slack/deployment_finished.json.erb
+++ b/app/views/notifiers/slack/deployment_finished.json.erb
@@ -47,6 +47,22 @@
       ]
     },
     <% end %>
+    <% if @deployment_channel_asset_link && @deep_link %>
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "image",
+          "image_url": "<%= @deployment_channel_asset_link %>",
+          "alt_text": "console"
+        },
+        {
+          "type": "mrkdwn",
+          "text": "<<%= @deep_link %>|Install on phone>"
+        }
+      ]
+    },
+    <% end %>
     <% if @artifact_download_link %>
     {
       "type": "context",

--- a/spec/factories/integrations.rb
+++ b/spec/factories/integrations.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :integration do
     association :app, factory: [:app, :android]
-    association :providable, factory: :github_integration
-    category { "version_control" }
+    association :providable, factory: [:slack_integration, :without_callbacks_and_validations]
+    category { "build_channel" }
 
     trait :with_google_play_store do
       association :app, factory: [:app, :android]

--- a/spec/models/deployment_run_spec.rb
+++ b/spec/models/deployment_run_spec.rb
@@ -132,6 +132,7 @@ describe DeploymentRun do
     before do
       allow_any_instance_of(described_class).to receive(:provider).and_return(providable_dbl)
       allow(providable_dbl).to receive(:deploy!)
+      allow(providable_dbl).to receive(:deep_link)
     end
 
     it "does nothing if deployment is not slack" do
@@ -284,6 +285,7 @@ describe DeploymentRun do
         repo_integration = instance_double(Installations::Github::Api)
         allow(Installations::Github::Api).to receive(:new).and_return(repo_integration)
         allow(repo_integration).to receive(:create_tag!)
+        allow(providable_dbl).to receive(:deep_link)
       end
 
       it "fully promotes to the store" do

--- a/spec/models/staged_rollout_spec.rb
+++ b/spec/models/staged_rollout_spec.rb
@@ -80,6 +80,7 @@ describe StagedRollout do
 
       before do
         allow_any_instance_of(DeploymentRun).to receive(:provider).and_return(providable_dbl)
+        allow(providable_dbl).to receive(:deep_link)
       end
 
       it "transitions state" do
@@ -116,6 +117,7 @@ describe StagedRollout do
 
       before do
         allow_any_instance_of(DeploymentRun).to receive(:provider).and_return(providable_dbl)
+        allow(providable_dbl).to receive(:deep_link)
       end
 
       it "halts the release in store" do
@@ -170,6 +172,7 @@ describe StagedRollout do
 
     before do
       allow_any_instance_of(DeploymentRun).to receive(:provider).and_return(providable_dbl)
+      allow(providable_dbl).to receive(:deep_link)
     end
 
     it "completes the rollout if no more stages left" do
@@ -272,6 +275,7 @@ describe StagedRollout do
 
       before do
         allow_any_instance_of(DeploymentRun).to receive(:provider).and_return(providable_dbl)
+        allow(providable_dbl).to receive(:deep_link)
       end
 
       it "transitions state" do
@@ -324,6 +328,7 @@ describe StagedRollout do
 
       before do
         allow_any_instance_of(DeploymentRun).to receive(:provider).and_return(providable_dbl)
+        allow(providable_dbl).to receive(:deep_link)
       end
 
       it "transitions state" do
@@ -374,6 +379,7 @@ describe StagedRollout do
 
     before do
       allow_any_instance_of(DeploymentRun).to receive(:provider).and_return(providable_dbl)
+      allow(providable_dbl).to receive(:deep_link)
     end
 
     [:created, :completed, :stopped, :failed, :fully_released, :paused].each do |trait|
@@ -442,6 +448,7 @@ describe StagedRollout do
 
     before do
       allow_any_instance_of(DeploymentRun).to receive(:provider).and_return(providable_dbl)
+      allow(providable_dbl).to receive(:deep_link)
     end
 
     [:created, :started, :completed, :stopped, :failed, :fully_released].each do |trait|


### PR DESCRIPTION
- for FAD, TestFlight, and AppStore

## Because

It allows testers and other stakeholders to get the build on their phone directly from the Slack notification