### PR TITLE
Decouple step creation and trigger CI

### DIFF
--- a/app/jobs/releases/trigger_workflow_run_job.rb
+++ b/app/jobs/releases/trigger_workflow_run_job.rb
@@ -1,0 +1,12 @@
+class Releases::TriggerWorkflowRunJob < ApplicationJob
+  include Loggable
+
+  queue_as :high
+
+  def perform(step_run_id)
+    step_run = StepRun.find(step_run_id)
+    return unless step_run.active?
+
+    step_run.trigger_ci!
+  end
+end

--- a/app/libs/triggers/step_run.rb
+++ b/app/libs/triggers/step_run.rb
@@ -14,7 +14,6 @@ class Triggers::StepRun
     release_platform_run
       .step_runs
       .create!(step:, scheduled_at: Time.current, commit:, build_version:, sign_required: false)
-      .trigger_ci!
   end
 
   private

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -38,6 +38,7 @@ class StepRun < ApplicationRecord
   validates :step_id, uniqueness: {scope: :commit_id}
 
   after_commit -> { create_stamp!(data: stamp_data) }, on: :create
+  after_commit -> { Releases::TriggerWorkflowRunJob.perform_later(id) }, on: :create
 
   STAMPABLE_REASONS = %w[
     created


### PR DESCRIPTION
## Because

Triggering of CI workflow now involves some expensive checks against the stores to ensure build number viability. This causes a large gap between a commit event coming in and the commit showing up on the UI for the user.