### PR TITLE
Create unique release tags if necessary

### DIFF
--- a/app/jobs/release_platform_runs/create_tag_job.rb
+++ b/app/jobs/release_platform_runs/create_tag_job.rb
@@ -1,14 +1,8 @@
 class ReleasePlatformRuns::CreateTagJob < ApplicationJob
   queue_as :high
 
-  def perform(platform_run_id, tag_name)
+  def perform(platform_run_id)
     run = ReleasePlatformRun.find(platform_run_id)
-
-    begin
-      run.update(tag_name:)
-      run.create_tag!(tag_name)
-    rescue Installations::Errors::TagReferenceAlreadyExists
-      self.class.perform_later(release_platform_run_id, run.unique_tag_name)
-    end
+    run.create_tag!
   end
 end

--- a/app/jobs/release_platform_runs/create_tag_job.rb
+++ b/app/jobs/release_platform_runs/create_tag_job.rb
@@ -1,8 +1,9 @@
-class ReleasePlatformRuns::CreateTagJob < ApplicationJob
-  queue_as :high
+module ReleasePlatformRuns
+  class CreateTagJob < ApplicationJob
+    queue_as :high
 
-  def perform(platform_run_id)
-    run = ReleasePlatformRun.find(platform_run_id)
-    run.create_tag!
+    def perform(platform_run_id)
+      ReleasePlatformRun.find(platform_run_id).create_tag!
+    end
   end
 end

--- a/app/jobs/release_platform_runs/create_tag_job.rb
+++ b/app/jobs/release_platform_runs/create_tag_job.rb
@@ -1,0 +1,14 @@
+class ReleasePlatformRuns::CreateTagJob < ApplicationJob
+  queue_as :high
+
+  def perform(platform_run_id, tag_name)
+    run = ReleasePlatformRun.find(platform_run_id)
+
+    begin
+      run.update(tag_name:)
+      run.create_tag!(tag_name)
+    rescue Installations::Errors::TagReferenceAlreadyExists
+      self.class.perform_later(release_platform_run_id, run.unique_tag_name)
+    end
+  end
+end

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -143,8 +143,15 @@ module Installations
     # creates a lightweight tag and a GitHub release simultaneously
     def create_release!(repo, tag_name, branch_name)
       execute do
+        raise Installations::Errors::TagReferenceAlreadyExists if tag_exists?(repo, tag_name)
         @client.create_release(repo, tag_name, target_commitish: branch_name, generate_release_notes: false)
       end
+    end
+
+    def tag_exists?(repo, tag_name)
+      @client.ref(repo, "tags/#{tag_name}").present?
+    rescue Octokit::NotFound
+      false
     end
 
     def create_pr!(repo, to, from, title, body)

--- a/app/libs/triggers/post_release/almost_trunk.rb
+++ b/app/libs/triggers/post_release/almost_trunk.rb
@@ -42,13 +42,7 @@ class Triggers::PostRelease
     end
 
     def create_tag
-      GitHub::Result.new do
-        train.create_release!(release.branch_name)
-      rescue Installations::Errors::TagReferenceAlreadyExists
-        logger.debug("Release finalization: did not create tag, since #{train.tag_name} already existed")
-      rescue Installations::Errors::TaggedReleaseAlreadyExists
-        logger.debug("Release finalization: skipping since tagged release for #{train.tag_name} already exists!")
-      end
+      GitHub::Result.new { release.create_release! }
     end
 
     def pr_title

--- a/app/libs/triggers/post_release/parallel_branches.rb
+++ b/app/libs/triggers/post_release/parallel_branches.rb
@@ -39,13 +39,7 @@ class Triggers::PostRelease
     end
 
     def create_tag
-      GitHub::Result.new do
-        train.create_release!(release.branch_name)
-      rescue Installations::Errors::TagReferenceAlreadyExists
-        logger.debug("Release finalization: did not create tag, since #{train.tag_name} already existed")
-      rescue Installations::Errors::TaggedReleaseAlreadyExists
-        logger.debug("Release finalization: skipping since tagged release for #{train.tag_name} already exists!")
-      end
+      GitHub::Result.new { release.create_release! }
     end
 
     def pr_title

--- a/app/libs/triggers/post_release/release_back_merge.rb
+++ b/app/libs/triggers/post_release/release_back_merge.rb
@@ -50,13 +50,7 @@ class Triggers::PostRelease
     end
 
     def create_tag
-      GitHub::Result.new do
-        train.create_release!(release.branch_name)
-      rescue Installations::Errors::TagReferenceAlreadyExists
-        logger.debug("Release finalization: did not create tag, since #{train.tag_name} already existed")
-      rescue Installations::Errors::TaggedReleaseAlreadyExists
-        logger.debug("Release finalization: skipping since tagged release for #{train.tag_name} already exists!")
-      end
+      GitHub::Result.new { release.create_release! }
     end
 
     def release_pr_title

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -1,0 +1,18 @@
+module Taggable
+  # returns a sticky but unique tag name
+  # tries to optimize for the most readable tag name
+  #
+  # for eg.
+  # v1.0.0-android-0cf2849
+  # v1.0.0-android-0cf2849-1691092406
+  # v1.0.0-android-0cf2849-1691092492
+  # ...and so on
+  #
+  # note: avoids appending increasing numbers to avoid keeping state
+  # note: relies on last_commit and base_tag_name methods
+  def unique_tag_name(currently)
+    sha = last_commit.short_sha
+    return [base_tag_name, "-", sha].join if currently.end_with?(base_tag_name)
+    [base_tag_name, "-", sha, "-", Time.now.to_i].join
+  end
+end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -102,14 +102,11 @@ class Release < ApplicationRecord
     end
   end
 
-  # TODO: Remove this accessor, once the migration is complete
-  attr_accessor :in_data_migration_mode
-
-  before_create :set_version, unless: :in_data_migration_mode
-  after_create :set_default_release_metadata, unless: :in_data_migration_mode
-  after_create :create_platform_runs, unless: :in_data_migration_mode
-  after_commit -> { Releases::PreReleaseJob.perform_later(id) }, on: :create, unless: :in_data_migration_mode
-  after_commit -> { Releases::FetchCommitLogJob.perform_later(id) }, on: :create, unless: :in_data_migration_mode
+  before_create :set_version
+  after_create :set_default_release_metadata
+  after_create :create_platform_runs
+  after_commit -> { Releases::PreReleaseJob.perform_later(id) }, on: :create
+  after_commit -> { Releases::FetchCommitLogJob.perform_later(id) }, on: :create
 
   attr_accessor :has_major_bump
 

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -143,6 +143,8 @@ class Release < ApplicationRecord
     branch_name
   end
 
+  # recursively attempt to create a release until a unique one gets created
+  # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
   def create_release!(tag_name = base_tag_name)
     train.create_release!(release_branch, tag_name)
     update!(tag_name:)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -10,6 +10,7 @@
 #  scheduled_at             :datetime
 #  status                   :string           not null
 #  stopped_at               :datetime
+#  tag_name                 :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  train_id                 :uuid             not null, indexed
@@ -18,6 +19,7 @@ class Release < ApplicationRecord
   has_paper_trail
   include AASM
   include Passportable
+  include Taggable
   include ActionView::Helpers::DateHelper
   include Rails.application.routes.url_helpers
   using RefinedString
@@ -233,13 +235,6 @@ class Release < ApplicationRecord
 
   def last_commit
     commits.order(:created_at).last
-  end
-
-  def unique_tag_name(currently)
-    tag_parts = currently.split("-")
-    sha = last_commit.short_sha
-    return [base_tag_name, "-", sha, "-", Time.now.to_i].join if tag_parts.size.between?(2, 3)
-    [base_tag_name, "-", sha].join
   end
 
   private

--- a/app/models/release_metadata.rb
+++ b/app/models/release_metadata.rb
@@ -20,9 +20,6 @@ class ReleaseMetadata < ApplicationRecord
   DEFAULT_RELEASE_NOTES = "The latest version contains bug fixes and performance improvements."
   PLAINTEXT_REGEX = /\A[!@#$%^&*()_+\-=\[\]{};':"\\|,.\/?\s\p{Alnum}\p{P}\p{Zs}\p{Emoji_Presentation}]+\z/
 
-  # TODO: Remove this accessor, once the migration is complete
-  attr_accessor :in_data_migration_mode
-
   validates :release_notes, format: {with: PLAINTEXT_REGEX, message: :no_special_characters, multiline: true}, length: {maximum: 4000}
-  validates :promo_text, format: {with: PLAINTEXT_REGEX, message: :no_special_characters, allow_blank: true, multiline: true}, length: {maximum: 170}, unless: :in_data_migration_mode
+  validates :promo_text, format: {with: PLAINTEXT_REGEX, message: :no_special_characters, allow_blank: true, multiline: true}, length: {maximum: 170}
 end

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -182,6 +182,8 @@ class ReleasePlatformRun < ApplicationRecord
     app.refresh_external_app
   end
 
+  # recursively attempt to create a release tag until a unique one gets created
+  # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
   def create_tag!(tag_name = base_tag_name)
     train.create_tag!(tag_name, last_commit.commit_hash)
     update!(tag_name:)
@@ -189,7 +191,7 @@ class ReleasePlatformRun < ApplicationRecord
     create_tag!(unique_tag_name(tag_name))
   end
 
-  # Play store does not have constraints around version name
+  # Play Store does not have constraints around version name
   # App Store requires a higher version name than that of the previously approved version name
   # and so a version bump is required for iOS once the build has been approved as well
   def version_bump_required?

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -12,6 +12,7 @@
 #  scheduled_at             :datetime         not null
 #  status                   :string           not null
 #  stopped_at               :datetime
+#  tag_name                 :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  release_id               :uuid
@@ -170,18 +171,18 @@ class ReleasePlatformRun < ApplicationRecord
       .then { |ids| Passport.where(stampable_id: ids).order(event_timestamp: :desc).limit(limit) }
   end
 
-  def tag_name
-    "v#{release_version}-#{platform}"
-  end
-
   def tag_url
     train.vcs_provider&.tag_url(app.config&.code_repository_name, tag_name)
   end
 
   def on_finish!
-    train.vcs_provider.create_tag!(tag_name, last_commit.commit_hash)
+    ReleasePlatformRuns::CreateTagJob.perform_later(id, base_tag_name)
     event_stamp!(reason: :finished, kind: :success, data: {version: release_version})
     app.refresh_external_app
+  end
+
+  def create_tag!(name)
+    train.create_tag!(name, last_commit.commit_hash)
   end
 
   # Play store does not have constraints around version name
@@ -215,7 +216,16 @@ class ReleasePlatformRun < ApplicationRecord
       .pluck(:message)
   end
 
+  def unique_tag_name
+    return if tag_name.blank?
+    [tag_name, "-", SecureRandom.hex(3)].join
+  end
+
   private
+
+  def base_tag_name
+    "v#{release_version}-#{platform}"
+  end
 
   def started_store_release?
     latest_store_release.present?

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -184,19 +184,19 @@ class Train < ApplicationRecord
   end
 
   def create_release!(branch_name, tag_name)
-    return false unless activated?
+    return false unless active?
     vcs_provider.create_release!(tag_name, branch_name)
   end
 
   delegate :create_tag!, to: :vcs_provider
 
   def create_branch!(from, to)
-    return false unless activated?
+    return false unless active?
     vcs_provider.create_branch!(from, to)
   end
 
   def notify!(message, type, params)
-    return unless activated?
+    return unless active?
     return unless app.send_notifications?
     notification_provider.notify!(config.notification_channel_id, message, type, params)
   end
@@ -246,9 +246,5 @@ class Train < ApplicationRecord
     unless release_platforms.all?(&:valid_steps?)
       errors.add(:release_platforms, "there should be one release step")
     end
-  end
-
-  def activated?
-    !Rails.env.test? && active?
   end
 end

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -183,11 +183,7 @@ class Train < ApplicationRecord
     branching_strategy == "parallel_working"
   end
 
-  def tag_name
-    "v#{version_current}"
-  end
-
-  def create_release!(branch_name)
+  def create_release!(branch_name, tag_name)
     return false unless activated?
     vcs_provider.create_release!(tag_name, branch_name)
   end

--- a/app/views/shared/live_release/_finalize.html.erb
+++ b/app/views/shared/live_release/_finalize.html.erb
@@ -56,16 +56,18 @@
               </div>
             </li>
 
-            <li class="flex items-center justify-between py-3 border-t border-indigo-200">
-              <div>Release Tag</div>
-              <div class="flex items-center whitespace-nowrap">
-                <%= image_tag("git_tag.svg", width: 20, class: "inline-flex mr-2") %>
-                <div class="font-mono text-slate-800">
-                  <%= link_to_external finalize_metadata.dig(:release_tag),
-                                       finalize_metadata.dig(:release_tag_url) %>
+            <% if finalize_metadata.dig(:release_tag).present? %>
+              <li class="flex items-center justify-between py-3 border-t border-indigo-200">
+                <div>Release Tag</div>
+                <div class="flex items-center whitespace-nowrap">
+                  <%= image_tag("git_tag.svg", width: 20, class: "inline-flex mr-2") %>
+                  <div class="font-mono text-slate-800">
+                    <%= link_to_external finalize_metadata.dig(:release_tag),
+                                         finalize_metadata.dig(:release_tag_url) %>
+                  </div>
                 </div>
-              </div>
-            </li>
+              </li>
+            <% end %>
 
             <% release.release_platform_runs.each do |run| %>
               <% last_deployment_run = run.last_good_step_run&.deployment_runs.last %>

--- a/app/views/shared/live_release/_stability.html.erb
+++ b/app/views/shared/live_release/_stability.html.erb
@@ -16,7 +16,9 @@
     <section class="my-4">
       <div class="flex flex-wrap justify-between items-center px-5 py-3 bg-indigo-50 border border-indigo-100 rounded-sm text-left">
         <div class="text-slate-800 font-semibold">This release was completed and is now locked.</div>
-        <%= link_to_external release.tag_name, release.tag_url, class: "underline text-slate-500" %>
+        <% if release.tag_name.present? %>
+          <%= link_to_external release.tag_name, release.tag_url, class: "underline text-slate-500" %>
+        <% end %>
       </div>
     </section>
   <% end %>

--- a/db/data/20230703163258_add_release_version_to_release_platform_runs.rb
+++ b/db/data/20230703163258_add_release_version_to_release_platform_runs.rb
@@ -2,6 +2,8 @@
 
 class AddReleaseVersionToReleasePlatformRuns < ActiveRecord::Migration[7.0]
   def up
+    return
+
     ReleasePlatformRun.where(release_version: nil).each do |run|
       run.update!(release_version: run.release.attributes["release_version"])
     end

--- a/db/data/20230804123240_backfill_tag_names.rb
+++ b/db/data/20230804123240_backfill_tag_names.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class BackfillTagNames < ActiveRecord::Migration[7.0]
+  def up
+    ActiveRecord::Base.transaction do
+      Release.where(tag_name: nil).each do |release|
+        release.update!(tag_name: release.send(:base_tag_name))
+      end
+
+      ReleasePlatformRun.where(tag_name: nil).each do |platform_run|
+        platform_run.update!(tag_name: platform_run.send(:base_tag_name))
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20230804123240_backfill_tag_names.rb
+++ b/db/data/20230804123240_backfill_tag_names.rb
@@ -8,7 +8,7 @@ class BackfillTagNames < ActiveRecord::Migration[7.0]
       end
 
       ReleasePlatformRun.where(tag_name: nil).each do |platform_run|
-        platform_run.update!(tag_name: platform_run.send(:base_tag_name))
+        platform_run.update!(tag_name: platform_run.send(:base_tag_name)) if platform_run.app.cross_platform?
       end
     end
   end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230703163258)
+DataMigrate::Data.define(version: 20230804123240)

--- a/db/migrate/20230803132100_add_tag_name_to_release_platform_runs.rb
+++ b/db/migrate/20230803132100_add_tag_name_to_release_platform_runs.rb
@@ -1,0 +1,5 @@
+class AddTagNameToReleasePlatformRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column :release_platform_runs, :tag_name, :string
+  end
+end

--- a/db/migrate/20230803132100_add_tag_name_to_release_platform_runs.rb
+++ b/db/migrate/20230803132100_add_tag_name_to_release_platform_runs.rb
@@ -1,5 +1,6 @@
 class AddTagNameToReleasePlatformRuns < ActiveRecord::Migration[7.0]
   def change
+    add_column :releases, :tag_name, :string
     add_column :release_platform_runs, :tag_name, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -386,6 +386,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_03_132100) do
     t.datetime "stopped_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "tag_name"
     t.index ["train_id"], name: "index_releases_on_train_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_26_115100) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_03_132100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -351,6 +351,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_115100) do
     t.datetime "stopped_at"
     t.string "original_release_version"
     t.uuid "release_id"
+    t.string "tag_name"
     t.index ["release_platform_id"], name: "index_release_platform_runs_on_release_platform_id"
   end
 

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -54,4 +54,43 @@ describe Release do
       expect(run.ready_to_be_finalized?).to be(false)
     end
   end
+
+  describe "#create_release!" do
+    let(:train) { create(:train, :active) }
+    let(:release_platform) { create(:release_platform, train:) }
+    let(:step) { create(:step, release_platform:) }
+    let(:release) { create(:release, train:) }
+    let(:release_platform_run) { create(:release_platform_run, :on_track, release:, release_platform:) }
+
+    it "saves a new tag with the base name" do
+      allow_any_instance_of(GithubIntegration).to receive(:create_release!)
+      commit = create(:commit, :without_trigger, release:)
+      create(:step_run, release_platform_run:, commit:)
+
+      release.create_release!
+      expect(release.tag_name).to eq("v1.2.3")
+    end
+
+    it "saves base name + last commit sha" do
+      raise_times(GithubIntegration, Installations::Errors::TaggedReleaseAlreadyExists, :create_release!, 1)
+      commit = create(:commit, :without_trigger, release:)
+      create(:step_run, release_platform_run:, commit:)
+
+      release.create_release!
+      expect(release.tag_name).to eq("v1.2.3-#{commit.short_sha}")
+    end
+
+    it "saves base name + last commit sha + time" do
+      raise_times(GithubIntegration, Installations::Errors::TaggedReleaseAlreadyExists, :create_release!, 2)
+
+      freeze_time do
+        now = Time.now.to_i
+        commit = create(:commit, :without_trigger, release:)
+        create(:step_run, release_platform_run:, commit:)
+
+        release.create_release!
+        expect(release.tag_name).to eq("v1.2.3-#{commit.short_sha}-#{now}")
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,8 @@ require "rspec/rails"
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
+
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,16 @@
+module TestHelpers
+  def raise_times(instance, exception, method, max_exceptions = 1)
+    exception_raised_count = 0
+
+    allow_any_instance_of(instance).to receive(method) do
+      if exception_raised_count < max_exceptions
+        exception_raised_count += 1
+        raise exception.new
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include TestHelpers
+end


### PR DESCRIPTION
- Recursively create new unique tags if they are already present on both platform and release level
- Do not create platform tags in single-platform releases
- Store tag names
- Backfill tag names from original tag naming scheme