### PR TITLE
Add previous successful build notes to workflows

### DIFF
--- a/app/libs/installations/bitrise/api.rb
+++ b/app/libs/installations/bitrise/api.rb
@@ -64,7 +64,8 @@ module Installations
             workflow_id: workflow_id,
             environments: [
               {mapped_to: "versionName", value: inputs[:build_version]},
-              {mapped_to: "versionCode", value: inputs[:version_code]}
+              {mapped_to: "versionCode", value: inputs[:version_code]},
+              {mapped_to: "buildNotes", value: inputs[:build_notes]}
             ]
           },
 

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -74,7 +74,8 @@ module Installations
     def run_workflow!(repo, id, ref, inputs)
       inputs = {
         versionCode: inputs[:version_code],
-        versionName: inputs[:build_version]
+        versionName: inputs[:build_version],
+        buildNotes: inputs[:build_notes]
       }
 
       execute do

--- a/spec/libs/installations/bitrise/api_spec.rb
+++ b/spec/libs/installations/bitrise/api_spec.rb
@@ -70,7 +70,8 @@ describe Installations::Bitrise::Api, type: :integration do
       branch = Faker::Lorem.characters(number: 8)
       inputs = {
         version_code: Faker::Number.number(digits: 4),
-        build_version: Faker::Lorem.characters(number: 8)
+        build_version: Faker::Lorem.characters(number: 8),
+        build_notes: Faker::Lorem.characters(number: 10)
       }
       commit_hash = Faker::Crypto.sha1
       params = {
@@ -81,7 +82,8 @@ describe Installations::Bitrise::Api, type: :integration do
             workflow_id: workflow_id,
             environments: [
               {mapped_to: "versionName", value: inputs[:build_version]},
-              {mapped_to: "versionCode", value: inputs[:version_code]}
+              {mapped_to: "versionCode", value: inputs[:version_code]},
+              {mapped_to: "buildNotes", value: inputs[:build_notes]}
             ]
           },
 


### PR DESCRIPTION
The same build notes we push to slack and build distribution notes are also sent to the CI workflows as params.