### PR TITLE
Configure notification channel per train

### DIFF
--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -14,6 +14,7 @@
 #
 class AppConfig < ApplicationRecord
   has_paper_trail
+  include Notifiable
 
   MINIMUM_REQUIRED_CONFIG = %i[code_repository]
   FIREBASE_CONFIG_SCHEMA = Rails.root.join("config/schema/firebase_config.json")
@@ -29,11 +30,6 @@ class AppConfig < ApplicationRecord
 
   def ready?
     MINIMUM_REQUIRED_CONFIG.all? { |config| public_send(config).present? } && firebase_ready?
-  end
-
-  def notification_channel_id
-    return if notification_channel.blank?
-    notification_channel["id"]
   end
 
   def code_repository_name

--- a/app/models/concerns/notifiable.rb
+++ b/app/models/concerns/notifiable.rb
@@ -1,0 +1,11 @@
+module Notifiable
+  def notification_channel_id
+    return if notification_channel.blank?
+    notification_channel["id"]
+  end
+
+  def notification_channel_name
+    return if notification_channel.blank?
+    notification_channel["name"]
+  end
+end

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -366,7 +366,6 @@ class StepRun < ApplicationRecord
   def after_trigger_ci
     Releases::FindWorkflowRun.perform_async(id)
     event_stamp!(reason: :ci_triggered, kind: :notice, data: {version: build_version})
-    notify!("Step has been triggered!", :step_started, notification_params)
     Releases::CancelStepRun.perform_later(previous_step_run.id) if previous_step_run&.may_cancel?
   end
 

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -7,6 +7,7 @@
 #  description              :string
 #  kickoff_at               :datetime
 #  name                     :string           not null
+#  notification_channel     :jsonb
 #  release_backmerge_branch :string
 #  release_branch           :string
 #  repeat_duration          :interval
@@ -25,6 +26,7 @@ class Train < ApplicationRecord
   using RefinedString
   extend FriendlyId
   include Rails.application.routes.url_helpers
+  include Notifiable
 
   BRANCHING_STRATEGIES = {
     almost_trunk: "Almost Trunk",
@@ -257,8 +259,8 @@ class Train < ApplicationRecord
 
   def notify!(message, type, params)
     return unless active?
-    return unless app.send_notifications?
-    notification_provider.notify!(config.notification_channel_id, message, type, params)
+    return unless send_notifications?
+    notification_provider.notify!(notification_channel_id, message, type, params)
   end
 
   def notification_params
@@ -269,6 +271,10 @@ class Train < ApplicationRecord
         train_url: train_link
       }
     )
+  end
+
+  def send_notifications?
+    app.notifications_set_up? && notification_channel.present?
   end
 
   private

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -198,7 +198,7 @@ class Train < ApplicationRecord
   end
 
   def manually_startable?
-    startable? && active?
+    startable? && !inactive?
   end
 
   def branching_strategy_name

--- a/app/views/app_configs/edit.html.erb
+++ b/app/views/app_configs/edit.html.erb
@@ -25,30 +25,8 @@
         </div>
 
         <% if @app.notifications_set_up? %>
-          <div>
-            <%= form.label :notification_channel, "Notification Channel", class: "block text-sm font-medium mb-1" %>
-            <%= form.select :notification_channel,
-                            options_for_select(
-                              display_channels(@notification_channels, with_none: true) { |chan| "#" + chan[:name] },
-                              @config.notification_channel.to_json
-                            ),
-                            { class: "form-select w-full" },
-                            { data: { controller: "input-select" } } %>
-
-            <div class="text-sm mt-1">
-              To receive notifications in <strong>private</strong> channels, <code>/invite @Tramline</code> into your
-              private channel and then select it from this list.
-            </div>
-
-            <div class="py-2">
-              <%= authz_link_to :blue,
-                                "Refresh channels",
-                                refresh_channels_app_integration_slack_integration_path(@app,
-                                                                                        @app.notification_provider.integration,
-                                                                                        @app.notification_provider),
-                                method: :post, data: { turbo_method: :post } %>
-            </div>
-          </div>
+          <%= render partial: "shared/notifications_form",
+                     locals: { form:, app: @app, channels: @notification_channels, current: @config.notification_channel } %>
         <% end %>
       </div>
     </section>
@@ -91,7 +69,7 @@
             <%= form.label :firebase_android_config, "Android App", class: "block text-sm font-medium mb-1" %>
             <%= form.select :firebase_android_config,
                             options_for_select(
-                              display_channels(@firebase_android_apps) { |app| "#{app[:display_name]} #{app[:app_id]}"},
+                              display_channels(@firebase_android_apps) { |app| "#{app[:display_name]} #{app[:app_id]}" },
                               @config.firebase_android_config.to_json
                             ),
                             { class: "form-select" },

--- a/app/views/shared/_notifications_form.html.erb
+++ b/app/views/shared/_notifications_form.html.erb
@@ -1,0 +1,24 @@
+<div>
+  <%= form.label :notification_channel, "Notification Channel", class: "block text-sm font-medium mb-1" %>
+  <%= form.select :notification_channel,
+                  options_for_select(
+                    display_channels(channels, with_none: true) { |chan| "#" + chan[:name] },
+                    current.to_json
+                  ),
+                  { class: "form-select w-full" },
+                  { data: { controller: "input-select" } } %>
+
+  <div class="text-sm mt-4">
+    To receive notifications in <strong>private</strong> channels, <code>/invite @Tramline</code> into your
+    private channel and then select it from this list.
+  </div>
+
+  <div class="mt-4">
+    <%= authz_link_to :neutral,
+                      "Refresh channels",
+                      refresh_channels_app_integration_slack_integration_path(app,
+                                                                              app.notification_provider.integration,
+                                                                              app.notification_provider),
+                      class: "btn-xs", method: :post, data: { turbo_method: :post } %>
+  </div>
+</div>

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -94,7 +94,7 @@
           </div>
         </div>
 
-        <div class="text-sm mt-2">
+        <div class="text-sm mt-4">
           <p>
             Tramline increments the version name for every release build created, which guarantees that every build can
             be
@@ -112,6 +112,15 @@
       <% end %>
     </div>
   </div>
+
+  <% if app.notifications_set_up? %>
+    <div class="border-t border-dashed border-slate-200 pt-8 mt-8"></div>
+    <div class="text-xl text-slate-600 font-medium mt-2 mb-4">Notifications</div>
+    <div class="grid gap-x-5 md:grid-cols-2">
+      <%= render partial: "shared/notifications_form",
+                 locals: { form:, app: @app, channels: @notification_channels, current: @current_notification_channel } %>
+    </div>
+  <% end %>
 
   <div class="border-t border-dashed border-slate-200 pt-8 mt-8"></div>
 
@@ -163,16 +172,19 @@
     <% end %>
 
     <% if train.persisted? %>
-      <div class="text-xl text-slate-600 font-medium mt-8">Release Schedule</div>
-      <div class="block text-sm font-medium mt-8 mb-1">
-        <%= release_schedule(train) %>
-      </div>
+      <% if train.automatic? %>
+        <div class="border-t border-dashed border-slate-200 pt-8 mt-8"></div>
+        <div class="text-xl text-slate-600 mt-2 font-medium">Release Schedule</div>
+        <div class="block text-sm mt-4">
+          <%= release_schedule(train) %>
+        </div>
+      <% end %>
     <% else %>
       <%= render partial: "release_schedule_form", locals: { form: } %>
     <% end %>
   </div>
 
-  <div class="mt-10">
+  <div class="mt-12">
     <%= form.authz_submit :blue, train.persisted? ? "Update Train" : "Create Train" %>
   </div>
 <% end %>
@@ -180,9 +192,8 @@
 <div class="grid md:grid-cols-2 gap-x-11 pb-5 mt-8">
   <% @train.release_platforms.each do |release_platform| %>
     <section>
-      <div class="text-2xl font-bold mt-8 mb-4 pt-4 border-t border-dashed">
-        <%= steps_heading(release_platform) %>
-      </div>
+      <div class="border-t border-solid border-slate-200 pt-8 mt-8"></div>
+      <div class="text-2xl font-bold mb-4 mt-2"><%= steps_heading(release_platform) %></div>
       <% if release_platform.steps.size > 0 && release_platform.persisted? %>
         <div>
           <%= render partial: "shared/step_tree_viz", locals: { train: @train, release_platform:, editable: true } %>

--- a/app/views/trains/_release_schedule_form.html.erb
+++ b/app/views/trains/_release_schedule_form.html.erb
@@ -24,7 +24,6 @@
                             step: 1,
                             min: 1,
                             default: nil,
-                            value: 1,
                             data: { action: 'domain--release-schedule-help#change',
                                     domain__release_schedule_help_target: "nextDateNumber" } %>
       <%= form.select :repeat_duration_unit,

--- a/app/views/trains/show.html.erb
+++ b/app/views/trains/show.html.erb
@@ -86,8 +86,19 @@
           </span>
         <% end %>
 
-        <% mt.with_description("Release schedule") do %>
+        <% mt.with_description("Release Schedule") do %>
           <%= release_schedule(@train) %>
+        <% end %>
+
+        <% mt.with_description("Notification Channel") do %>
+          <% if @train.send_notifications? %>
+            <div class="inline-flex align-text-top">
+              <span class="pr-2"><%= image_tag("integrations/logo_#{@app.notification_provider}.png", width: 18) %></span>
+              <%= @train.notification_channel_name %>
+            </div>
+          <% else %>
+            None (notifications will not be sent)
+          <% end %>
         <% end %>
       <% end %>
     </article>

--- a/db/data/20230804123240_backfill_tag_names.rb
+++ b/db/data/20230804123240_backfill_tag_names.rb
@@ -2,6 +2,8 @@
 
 class BackfillTagNames < ActiveRecord::Migration[7.0]
   def up
+    return
+
     ActiveRecord::Base.transaction do
       Release.where(tag_name: nil).each do |release|
         release.update!(tag_name: release.send(:base_tag_name))

--- a/db/data/20230810062236_backfill_train_notification_channels.rb
+++ b/db/data/20230810062236_backfill_train_notification_channels.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillTrainNotificationChannels < ActiveRecord::Migration[7.0]
+  def up
+    ActiveRecord::Base.transaction do
+      Train.where(notification_channel: nil).each do |train|
+        train.update!(notification_channel: train.app.config.notification_channel) if train.app.notifications_set_up?
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230804123240)
+DataMigrate::Data.define(version: 20230810062236)

--- a/db/migrate/20230810055850_add_notification_channel_to_train.rb
+++ b/db/migrate/20230810055850_add_notification_channel_to_train.rb
@@ -1,0 +1,5 @@
+class AddNotificationChannelToTrain < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trains, :notification_channel, :jsonb, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_03_132100) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_10_055850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -386,8 +386,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_03_132100) do
     t.datetime "stopped_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "is_automatic", default: false
     t.string "tag_name"
+    t.boolean "is_automatic", default: false
     t.index ["train_id"], name: "index_releases_on_train_id"
   end
 
@@ -473,6 +473,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_03_132100) do
     t.datetime "updated_at", null: false
     t.datetime "kickoff_at"
     t.interval "repeat_duration"
+    t.jsonb "notification_channel"
     t.index ["app_id"], name: "index_trains_on_app_id"
   end
 


### PR DESCRIPTION
## Because

Not all release trains need to notify the same set of stakeholders

## This addresses

- Allows configuring notification channel per train (default to app)
- Allows removing notifications per train (set notification channel to none)
- Temporarily remove step start notification
