### PR TITLE
Do not create tag again once created for a release

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -147,6 +147,7 @@ class Release < ApplicationRecord
   # recursively attempt to create a release until a unique one gets created
   # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
   def create_release!(tag_name = base_tag_name)
+    return if self.tag_name.present?
     train.create_release!(release_branch, tag_name)
     update!(tag_name:)
   rescue Installations::Errors::TagReferenceAlreadyExists, Installations::Errors::TaggedReleaseAlreadyExists

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -185,6 +185,7 @@ class ReleasePlatformRun < ApplicationRecord
   # recursively attempt to create a release tag until a unique one gets created
   # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
   def create_tag!(tag_name = base_tag_name)
+    return if self.tag_name.present?
     train.create_tag!(tag_name, last_commit.commit_hash)
     update!(tag_name:)
   rescue Installations::Errors::TagReferenceAlreadyExists


### PR DESCRIPTION
Due to the previous fix for unique tags in https://github.com/tramlinehq/tramline/pull/501, retry of finalization was created multiple tags for each retry.