### PR TITLE
Allow retrying CI failures from step

### DIFF
--- a/app/controllers/step_runs_controller.rb
+++ b/app/controllers/step_runs_controller.rb
@@ -2,6 +2,7 @@ class StepRunsController < SignedInApplicationController
   before_action :require_write_access!, only: %i[start]
   before_action :set_release
 
+  # FIXME: This action incorrectly consumes a step_id and not a step_run_id as the route suggests
   def start
     step = @release.release_platform.steps.friendly.find(params[:id])
     commit = @release.last_commit

--- a/app/controllers/step_runs_controller.rb
+++ b/app/controllers/step_runs_controller.rb
@@ -1,5 +1,5 @@
 class StepRunsController < SignedInApplicationController
-  before_action :require_write_access!, only: %i[start]
+  before_action :require_write_access!, only: %i[start retry_ci_workflow]
   before_action :set_release
 
   # FIXME: This action incorrectly consumes a step_id and not a step_run_id as the route suggests
@@ -14,8 +14,10 @@ class StepRunsController < SignedInApplicationController
   def retry_ci_workflow
     step_run = @release.step_runs.find(params[:id])
     step_run.retry_ci!
-
     redirect_back fallback_location: root_path, notice: "CI workflow retried!"
+  rescue
+    error = "Failed to retry the CI workflow! Contact support if the issue persists."
+    redirect_back fallback_location: root_path, flash: {error:}
   end
 
   private

--- a/app/controllers/step_runs_controller.rb
+++ b/app/controllers/step_runs_controller.rb
@@ -10,6 +10,13 @@ class StepRunsController < SignedInApplicationController
     redirect_back fallback_location: root_path, notice: "Step successfully started"
   end
 
+  def retry_ci_workflow
+    step_run = @release.step_runs.find(params[:id])
+    step_run.retry_ci!
+
+    redirect_back fallback_location: root_path, notice: "CI workflow retried!"
+  end
+
   private
 
   def set_release

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -93,8 +93,8 @@ module Installations
     end
 
     def retry_workflow!(repo, run_id)
-      execute_custom do |client|
-        client.post(RERUN_FAILED_JOBS_URL.expand(repo:, run_id:).to_s, {})
+      execute_custom do |custom_client|
+        custom_client.post(RERUN_FAILED_JOBS_URL.expand(repo:, run_id:).to_s, {})
       end
     end
 

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -94,7 +94,13 @@ module Installations
 
     def retry_workflow!(repo, run_id)
       execute_custom do |custom_client|
-        custom_client.post(RERUN_FAILED_JOBS_URL.expand(repo:, run_id:).to_s, {})
+        custom_client.post(
+          RERUN_FAILED_JOBS_URL
+            .expand(repo:, run_id:)
+            .to_s
+            .then { |url| URI.decode_www_form_component(url) },
+          {}
+        )
       end
     end
 

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -8,6 +8,7 @@ module Installations
     WEBHOOK_NAME = "web"
     WEBHOOK_EVENTS = %w[push]
     LIST_WORKFLOWS_LIMIT = 99
+    RERUN_FAILED_JOBS_URL = Addressable::Template.new "https://api.github.com/repos/{repo}/actions/runs/{run_id}/rerun-failed-jobs"
 
     def initialize(installation_id)
       @app_name = creds.integrations.github.app_name
@@ -92,13 +93,8 @@ module Installations
     end
 
     def retry_workflow!(repo, run_id)
-      execute do
-        response = HTTP.auth("Bearer #{client.access_token}")
-          .headers(:accept => "application/vnd.github+json", "X-GitHub-Api-Version" => "2022-11-28")
-          .post("https://api.github.com/repos/#{repo}/actions/runs/#{run_id}/rerun-failed-jobs", {})
-        if (error = Octokit::Error.from_response(response))
-          raise error
-        end
+      execute_custom do |client|
+        client.post(RERUN_FAILED_JOBS_URL.expand(repo:, run_id:).to_s, {})
       end
     end
 
@@ -235,6 +231,28 @@ module Installations
       retry
     rescue Octokit::NotFound, Octokit::UnprocessableEntity, Octokit::MethodNotAllowed => e
       raise Installations::Github::Error.handle(e)
+    end
+
+    API_VERSION = "2022-11-28"
+    ACCEPT_HEADER = "application/vnd.github+json"
+
+    def execute_custom
+      execute do
+        token = @client.access_token
+        new_client = HTTP.auth("Bearer #{token}").headers(:accept => ACCEPT_HEADER, "X-GitHub-Api-Version" => API_VERSION)
+
+        response = yield(new_client)
+
+        response_params = {
+          status: response.status,
+          body: response.body,
+          response_headers: response.headers.to_h.with_indifferent_access
+        }
+
+        if (error = Octokit::Error.from_response(response_params))
+          raise error
+        end
+      end
     end
 
     def set_client

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -91,6 +91,17 @@ module Installations
       end
     end
 
+    def retry_workflow!(repo, run_id)
+      execute do
+        response = HTTP.auth("Bearer #{client.access_token}")
+          .headers(:accept => "application/vnd.github+json", "X-GitHub-Api-Version" => "2022-11-28")
+          .post("https://api.github.com/repos/#{repo}/actions/runs/#{run_id}/rerun-failed-jobs", {})
+        if (error = Octokit::Error.from_response(response))
+          raise error
+        end
+      end
+    end
+
     def create_repo_webhook!(repo, url, transforms)
       execute do
         @client.create_hook(

--- a/app/models/bitrise_integration.rb
+++ b/app/models/bitrise_integration.rb
@@ -135,6 +135,10 @@ class BitriseIntegration < ApplicationRecord
     PUBLIC_ICON
   end
 
+  def workflow_retriable?
+    false
+  end
+
   private
 
   def app_config

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -173,6 +173,10 @@ class GithubIntegration < ApplicationRecord
     installation.cancel_workflow!(code_repository_name, ci_ref)
   end
 
+  def retry_workflow_run!(ci_ref)
+    installation.retry_workflow!(code_repository_name, ci_ref)
+  end
+
   def find_workflow_run(workflow_id, branch, commit_sha)
     installation.find_workflow_run(code_repository_name, workflow_id, branch, commit_sha, WORKFLOW_RUN_TRANSFORMATIONS)
   end

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -239,6 +239,10 @@ class GithubIntegration < ApplicationRecord
     PUBLIC_ICON
   end
 
+  def workflow_retriable?
+    true
+  end
+
   private
 
   def create_webhook!(url_params)

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -302,6 +302,10 @@ class StepRun < ApplicationRecord
       .join("\n").presence || "Nothing new"
   end
 
+  def cancel_ci_workflow!
+    ci_cd_provider.cancel_workflow_run!(ci_ref)
+  end
+
   private
 
   def previous_step_run
@@ -347,10 +351,6 @@ class StepRun < ApplicationRecord
     data = {version_code: build_number, build_version: build_version}
     data[:build_notes] = build_notes if organization.build_notes_in_workflow?
     data
-  end
-
-  def cancel_ci_workflow!
-    ci_cd_provider.cancel_workflow_run!(ci_ref)
   end
 
   def workflow_found?

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -330,7 +330,7 @@ class StepRun < ApplicationRecord
   def trigger_workflow_run(retrigger: false)
     update_build_number! unless retrigger
     ci_cd_provider
-      .trigger_workflow_run!(workflow_id, release_branch, workflow_data, commit_hash)
+      .trigger_workflow_run!(workflow_id, release_branch, workflow_inputs, commit_hash)
       .then { |wr| update_ci_metadata!(wr) }
   end
 
@@ -343,7 +343,7 @@ class StepRun < ApplicationRecord
     update!(build_number: release_platform.app.bump_build_number!)
   end
 
-  def workflow_data
+  def workflow_inputs
     data = {version_code: build_number, build_version: build_version}
     data[:build_notes] = build_notes if organization.build_notes_in_workflow?
     data

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -116,7 +116,7 @@ class StepRun < ApplicationRecord
     end
 
     event(:retry_ci, after_commit: -> { WorkflowProcessors::WorkflowRunJob.perform_later(id) }) do
-      before :trigger_workflow_run
+      before :retry_workflow_run
       transitions from: [:ci_workflow_failed, :ci_workflow_halted], to: :ci_workflow_started
     end
 

--- a/app/views/shared/_per_step_metadata.html.erb
+++ b/app/views/shared/_per_step_metadata.html.erb
@@ -22,8 +22,17 @@
       </div>
 
       <% if step_run&.build_version %>
-        <div class="flex flex-col w-full">
+        <div class="flex w-full sm:justify-between">
           <%= render partial: "shared/build_details", locals: { step_run:, with_artifact: false } %>
+          <% if step_run.may_retry_ci? && release.on_track? %>
+            <div>
+              <%= authz_button_to :blue,
+                                  "Retry CI Workflow",
+                                  retry_ci_workflow_release_step_run_path(release, step_run),
+                                  method: :patch,
+                                  data: { turbo_method: :patch, turbo_confirm: "This will re-run the CI workflow. Are you sure?", class: "btn-xs mb-2" } %>
+            </div>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/_per_step_metadata.html.erb
+++ b/app/views/shared/_per_step_metadata.html.erb
@@ -22,7 +22,7 @@
       </div>
 
       <% if step_run&.build_version %>
-        <div class="flex w-full sm:justify-between">
+        <div class="flex flex-col w-full">
           <%= render partial: "shared/build_details", locals: { step_run:, with_artifact: false } %>
         </div>
       <% end %>

--- a/app/views/shared/_per_step_metadata.html.erb
+++ b/app/views/shared/_per_step_metadata.html.erb
@@ -24,15 +24,6 @@
       <% if step_run&.build_version %>
         <div class="flex w-full sm:justify-between">
           <%= render partial: "shared/build_details", locals: { step_run:, with_artifact: false } %>
-          <% if step_run.may_retry_ci? && release.on_track? %>
-            <div>
-              <%= authz_button_to :blue,
-                                  "Retry CI Workflow",
-                                  retry_ci_workflow_release_step_run_path(release, step_run),
-                                  method: :patch,
-                                  data: { turbo_method: :patch, turbo_confirm: "This will re-run the CI workflow. Are you sure?", class: "btn-xs mb-2" } %>
-            </div>
-          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/live_release/_stability.html.erb
+++ b/app/views/shared/live_release/_stability.html.erb
@@ -36,6 +36,16 @@
                                   start_release_step_run_path(release, step),
                                   { class: "btn-xs mb-2" } %>
             <% end %>
+
+            <% if step_run&.may_retry_ci? && release.on_track? %>
+              <%= authz_button_to :blue,
+                                  "Retry CI Workflow",
+                                  retry_ci_workflow_release_step_run_path(release, step_run),
+                                  method: :patch,
+                                  data: { turbo_method: :patch,
+                                          turbo_confirm: "This will re-run the CI workflow. Are you sure?" },
+                                  class: "btn-xs mb-2" %>
+            <% end %>
           </div>
 
           <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
         resources :step_runs, only: [], shallow: false do
           member do
             post :start
+            patch :retry_ci_workflow
           end
 
           resources :deployments, only: [] do

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -69,7 +69,7 @@ namespace :db do
       run.commits&.delete_all
       run.release_metadata&.delete
       run.release_changelog&.delete
-      run.release_changelog&.delete
+      run.pull_requests&.delete_all
       run.release_platform_runs&.delete_all
     end
     train.releases&.delete_all

--- a/spec/models/step_run_spec.rb
+++ b/spec/models/step_run_spec.rb
@@ -262,12 +262,21 @@ describe StepRun do
       expect(Releases::FindWorkflowRun).to have_received(:perform_async).with(id).once
     end
 
+    it "updates build number" do
+      step_run = create(:step_run, build_number: nil)
+      allow(Releases::FindWorkflowRun).to receive(:perform_async)
+
+      expect(step_run.build_number).to be_nil
+      step_run.trigger_ci!
+      expect(step_run.build_number).to_not be_empty
+    end
+
     (StepRun::STATES.keys - StepRun::END_STATES).each do |trait|
       it "cancels previous running step run when #{trait}" do
         allow(Releases::CancelStepRun).to receive(:perform_later)
         previous_step_run = create(:step_run, trait, step: step_run.step,
-          release_platform_run: step_run.release_platform_run,
-          scheduled_at: 10.minutes.before(step_run.scheduled_at))
+                                   release_platform_run: step_run.release_platform_run,
+                                   scheduled_at: 10.minutes.before(step_run.scheduled_at))
 
         step_run.trigger_ci!
 
@@ -279,12 +288,65 @@ describe StepRun do
       it "does not cancel previous step run when #{trait}" do
         allow(Releases::CancelStepRun).to receive(:perform_later)
         previous_step_run = create(:step_run, trait, step: step_run.step,
-          release_platform_run: step_run.release_platform_run,
-          scheduled_at: 10.minutes.before(step_run.scheduled_at))
+                                   release_platform_run: step_run.release_platform_run,
+                                   scheduled_at: 10.minutes.before(step_run.scheduled_at))
 
         step_run.trigger_ci!
 
         expect(Releases::CancelStepRun).not_to have_received(:perform_later).with(previous_step_run.id)
+      end
+    end
+  end
+
+  describe "#retry_ci!" do
+    let(:step_run) { create(:step_run, :ci_workflow_failed, build_number: "1") }
+    let(:providable) { instance_double(GithubIntegration) }
+
+    before do
+      allow(step_run).to receive(:ci_cd_provider).and_return(providable)
+    end
+
+    context "retriable" do
+      it "retries the same workflow run" do
+        allow(WorkflowProcessors::WorkflowRunJob).to receive(:perform_later)
+        allow(providable).to receive(:workflow_retriable?).and_return(true)
+        allow(providable).to receive(:retry_workflow_run!)
+
+        step_run.retry_ci!
+
+        expect(providable).to have_received(:retry_workflow_run!)
+      end
+
+      it "does not update the build number" do
+        allow(WorkflowProcessors::WorkflowRunJob).to receive(:perform_later)
+        allow(providable).to receive(:workflow_retriable?).and_return(true)
+        allow(providable).to receive(:retry_workflow_run!)
+
+        expect(step_run.build_number).to eq("1")
+        step_run.retry_ci!
+        expect(step_run.build_number).to eq("1")
+      end
+    end
+
+    context "non-retriable" do
+      it "triggers a new workflow run" do
+        allow(WorkflowProcessors::WorkflowRunJob).to receive(:perform_later)
+        allow(providable).to receive(:workflow_retriable?).and_return(false)
+        allow(providable).to receive(:trigger_workflow_run!)
+
+        step_run.retry_ci!
+
+        expect(providable).to have_received(:trigger_workflow_run!)
+      end
+
+      it "does not update the build number" do
+        allow(WorkflowProcessors::WorkflowRunJob).to receive(:perform_later)
+        allow(providable).to receive(:workflow_retriable?).and_return(false)
+        allow(providable).to receive(:trigger_workflow_run!)
+
+        expect(step_run.build_number).to eq("1")
+        step_run.retry_ci!
+        expect(step_run.build_number).to eq("1")
       end
     end
   end

--- a/spec/models/step_run_spec.rb
+++ b/spec/models/step_run_spec.rb
@@ -268,15 +268,15 @@ describe StepRun do
 
       expect(step_run.build_number).to be_nil
       step_run.trigger_ci!
-      expect(step_run.build_number).to_not be_empty
+      expect(step_run.build_number).not_to be_empty
     end
 
     (StepRun::STATES.keys - StepRun::END_STATES).each do |trait|
       it "cancels previous running step run when #{trait}" do
         allow(Releases::CancelStepRun).to receive(:perform_later)
         previous_step_run = create(:step_run, trait, step: step_run.step,
-                                   release_platform_run: step_run.release_platform_run,
-                                   scheduled_at: 10.minutes.before(step_run.scheduled_at))
+          release_platform_run: step_run.release_platform_run,
+          scheduled_at: 10.minutes.before(step_run.scheduled_at))
 
         step_run.trigger_ci!
 
@@ -288,8 +288,8 @@ describe StepRun do
       it "does not cancel previous step run when #{trait}" do
         allow(Releases::CancelStepRun).to receive(:perform_later)
         previous_step_run = create(:step_run, trait, step: step_run.step,
-                                   release_platform_run: step_run.release_platform_run,
-                                   scheduled_at: 10.minutes.before(step_run.scheduled_at))
+          release_platform_run: step_run.release_platform_run,
+          scheduled_at: 10.minutes.before(step_run.scheduled_at))
 
         step_run.trigger_ci!
 
@@ -306,7 +306,7 @@ describe StepRun do
       allow(step_run).to receive(:ci_cd_provider).and_return(providable)
     end
 
-    context "retriable" do
+    context "when retriable" do
       it "retries the same workflow run" do
         allow(WorkflowProcessors::WorkflowRunJob).to receive(:perform_later)
         allow(providable).to receive(:workflow_retriable?).and_return(true)
@@ -328,7 +328,7 @@ describe StepRun do
       end
     end
 
-    context "non-retriable" do
+    context "when non-retriable" do
       it "triggers a new workflow run" do
         allow(WorkflowProcessors::WorkflowRunJob).to receive(:perform_later)
         allow(providable).to receive(:workflow_retriable?).and_return(false)


### PR DESCRIPTION
**Closes:** #337 

* For any step run failure retry the same run (on GitHub)
* Does not update any other metadata, other than status

![Screenshot 2023-08-17 at 5 00 17 PM](https://github.com/tramlinehq/tramline/assets/50663/9032f343-dc67-46a1-ae53-86eb171c655e)
