### PR TITLE
Configuration of automatic distribution across channels in release step

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -99,7 +99,8 @@ class StepsController < SignedInApplicationController
       :description,
       :ci_cd_channel,
       :release_suffix,
-      :kind
+      :kind,
+      :auto_deploy
     )
   end
 

--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -6,4 +6,12 @@ module StepsHelper
   def platform_subtitle(app, step)
     "For the #{step.release_platform.display_attr(:platform)} platform" if app.cross_platform?
   end
+
+  def auto_deploy_status_badge(step)
+    step.auto_deploy? ? "" : "Manual Distribution"
+  end
+
+  def auto_deploy_status(step)
+    step.auto_deploy? ? "ON" : "OFF"
+  end
 end

--- a/app/javascript/controllers/list_position_controller.js
+++ b/app/javascript/controllers/list_position_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["position"]
+  static targets = ["position", "showCheckbox"]
 
   static values = {
     initial: Number,
@@ -12,6 +12,11 @@ export default class extends Controller {
     for (let posTarget of this.positionTargets) {
       posTarget.value = position
       position++
+    }
+    if (position > 2 && this.hasShowCheckboxTarget) {
+      this.showCheckboxTarget.hidden = false
+    } else {
+      this.showCheckboxTarget.hidden = true
     }
   }
 }

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -251,6 +251,7 @@ class StepRun < ApplicationRecord
     return finish! if finished_deployments?
     return unless deployment.next
     return if deployment.next.production_channel?
+    return unless step.auto_deploy?
 
     # trigger the next deployment if available
     trigger_deployment(deployment.next)

--- a/app/views/shared/_per_step_metadata.html.erb
+++ b/app/views/shared/_per_step_metadata.html.erb
@@ -5,6 +5,7 @@
         <h3 class="text-lg font-bold text-slate-800"><%= step.name %></h3>
         <%= status_badge "##{step.step_number}", %w[text-xs ml-2], :neutral %>
         <%= status_badge step.kind&.humanize, %w[text-xs ml-2], :neutral %>
+        <%= status_badge auto_deploy_status_badge(step), %w[text-xs ml-2], :neutral %>
       </div>
 
       <% if editable %>

--- a/app/views/steps/_new_deployments.html.erb
+++ b/app/views/steps/_new_deployments.html.erb
@@ -69,5 +69,14 @@
     </template>
 
     <div data-nested-form-ext-target="target"></div>
+
+    <% if @step.release? %>
+      <div hidden class="mt-4" data-list-position-target="showCheckbox">
+        <div class="flex gap-x-2">
+          <%= form.check_box :auto_deploy %>
+          <%= form.label :auto_deploy, "Automate distribution to all non-production distribution channels without any manual approval", class: "block text-sm font-medium mb-1" %>
+        </div>
+      </div>
+    <% end %>
   </ul>
 </div>

--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -19,7 +19,7 @@
 
       <% if @step.deployments.size > 1 %>
         <div class="text-sm mt-1">
-          Automatic distribution to all non-production distribution channels without any manual approval is <mark><%= @step.auto_deploy? ? "ON" : "OFF" %></mark>
+          Automatic distribution to all non-production distribution channels without any manual approval is <mark><%= auto_deploy_status(@step) %></mark>
         </div>
       <% end %>
 

--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -10,14 +10,22 @@
 
     <%= render 'form', form: form %>
 
-    <div class="mb-8 w-1/2 2xl:w-1/3">
-      <div class="sm:flex sm:justify-between sm:items-center mt-8 mb-2 pb-5">
+    <div class="mb-8">
+      <div class="sm:flex sm:justify-between sm:items-center mt-8">
         <p class="font-bold text-xl">
           <%= Deployment.display.pluralize %>
         </p>
       </div>
 
-      <%= render partial: "shared/deployments", locals: { step: @step, show_deployment_status: false } %>
+      <% if @step.deployments.size > 1 %>
+        <div class="text-sm mt-1">
+          Automatic distribution to all non-production distribution channels without any manual approval is <mark><%= @step.auto_deploy? ? "ON" : "OFF" %></mark>
+        </div>
+      <% end %>
+
+      <div class="sm:w-1/2 2xl:w-1/3 mt-4">
+        <%= render partial: "shared/deployments", locals: { step: @step, show_deployment_status: false } %>
+      </div>
     </div>
 
     <div class="mt-5">

--- a/db/migrate/20230817092613_add_auto_deployment_flag_for_steps.rb
+++ b/db/migrate/20230817092613_add_auto_deployment_flag_for_steps.rb
@@ -1,0 +1,5 @@
+class AddAutoDeploymentFlagForSteps < ActiveRecord::Migration[7.0]
+  def change
+    add_column :steps, :auto_deploy, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_10_055850) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_17_092613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -451,6 +451,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_10_055850) do
     t.datetime "updated_at", null: false
     t.string "release_suffix"
     t.string "kind"
+    t.boolean "auto_deploy", default: true
     t.index ["ci_cd_channel", "release_platform_id"], name: "index_steps_on_ci_cd_channel_and_release_platform_id", unique: true
     t.index ["release_platform_id"], name: "index_steps_on_release_platform_id"
     t.index ["step_number", "release_platform_id"], name: "index_steps_on_step_number_and_release_platform_id", unique: true

--- a/spec/factories/steps.rb
+++ b/spec/factories/steps.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     sequence(:ci_cd_channel) { |n| Faker::Lorem.word + n.to_s }
     release_suffix { "qa-staging" }
     kind { "review" }
+    auto_deploy { true }
 
     trait :release do
       kind { "release" }

--- a/spec/models/step_run_spec.rb
+++ b/spec/models/step_run_spec.rb
@@ -180,6 +180,18 @@ describe StepRun do
       expect(Triggers::Deployment).not_to have_received(:call).with(step_run: step_run, deployment: prod_deployment)
     end
 
+    it "does not trigger the next deployment if step is not auto deploy" do
+      allow(Triggers::Deployment).to receive(:call)
+      step = create(:step, :release, :with_deployment, auto_deploy: false)
+      regular_deployment = step.deployments.first
+      another_regular_deployment = create(:deployment, step: step)
+      step_run = create(:step_run, :build_available, step: step)
+
+      step_run.finish_deployment!(regular_deployment)
+
+      expect(Triggers::Deployment).not_to have_received(:call).with(step_run: step_run, deployment: another_regular_deployment)
+    end
+
     it "automatically finishes the release if the release step has completed" do
       repo_integration = instance_double(Installations::Github::Api)
       allow(Installations::Github::Api).to receive(:new).and_return(repo_integration)


### PR DESCRIPTION
## Because

Users might not want to run all deployments in a release step automatically.

- Allows disabling automatic distribution with no manual trigger for all deployments in the release step (not just the production channel)
- Automatic distribution to non-production channels is true by default
- Automatic distribution can only be disabled for the release step


Step create:

<img width="1351" alt="Screenshot 2023-08-17 at 6 26 14 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/1692e868-56b2-4204-97e9-a35905a279ae">


Step edit:

<img width="774" alt="Screenshot 2023-08-17 at 6 24 39 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/0d47f24a-bde2-470f-85c1-3d926967d5b2">

Step show:

<img width="674" alt="Screenshot 2023-08-17 at 6 24 47 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/d1523dcc-72dc-46c0-8894-782d3871a871">
