### PR TITLE
Do not apply commit if the branch has moved further on

### DIFF
--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -206,7 +206,8 @@ module Installations
 
     def head(repo, working_branch_name)
       execute do
-        @client.ref(repo, "heads/#{working_branch_name}")[:object][:sha]
+        obj = @client.ref(repo, "heads/#{working_branch_name}")[:object]
+        obj[:sha] if obj[:type].eql? "commit"
       end
     end
 

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -206,8 +206,7 @@ module Installations
 
     def head(repo, working_branch_name)
       execute do
-        # FIXME: this method is unsupported and could get deprecated, find a way around it
-        @client.commits(repo, sha: working_branch_name).first[:sha]
+        @client.ref(repo, "heads/#{working_branch_name}")[:object][:sha]
       end
     end
 

--- a/app/libs/installations/gitlab/api.rb
+++ b/app/libs/installations/gitlab/api.rb
@@ -17,6 +17,7 @@ module Installations
     MR_MERGE_URL = Addressable::Template.new "https://gitlab.com/api/v4/projects/{project_id}/merge_requests/{merge_request_iid}/merge"
     COMPARE_URL = Addressable::Template.new "https://gitlab.com/api/v4/projects/{project_id}/repository/compare"
     GET_COMMIT_URL = Addressable::Template.new "https://gitlab.com/api/v4/projects/{project_id}/repository/commits/{sha}"
+    GET_BRANCH_URL = Addressable::Template.new "https://gitlab.com/api/v4/projects/{project_id}/repository/branches{branch_name}"
 
     WEBHOOK_PERMISSIONS = {
       push_events: true
@@ -197,6 +198,11 @@ module Installations
       execute(:get, COMPARE_URL.expand(project_id:).to_s, params)
         .dig("commits")
         .then { |commits| Installations::Response::Keys.transform(commits, transforms) }
+    end
+
+    def head(project_id, branch_name)
+      execute(:get, GET_BRANCH_URL.expand(project_id:, branch_name:).to_s, {})
+        .dig("commit", "id")
     end
 
     private

--- a/app/libs/webhook_processors/push.rb
+++ b/app/libs/webhook_processors/push.rb
@@ -43,7 +43,8 @@ class WebhookProcessors::Push
       url: commit_attributes[:url]
     }
 
-    Commit.find_or_create_by!(params).trigger_step_runs
+    commit = Commit.find_or_create_by!(params)
+    commit.trigger_step_runs if commit.applicable?
   end
 
   def stamp_version_changed

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -46,6 +46,12 @@ class Commit < ApplicationRecord
     end
   end
 
+  def applicable?
+    commit_hash == release.latest_commit_hash
+  rescue
+    true
+  end
+
   def run_for(step, release_platform_run)
     step_runs.where(step:, release_platform_run:).last
   end

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -243,6 +243,10 @@ class GithubIntegration < ApplicationRecord
     true
   end
 
+  def branch_head_sha(branch)
+    installation.head(app_config.code_repository_name, branch)
+  end
+
   private
 
   def create_webhook!(url_params)

--- a/app/models/gitlab_integration.rb
+++ b/app/models/gitlab_integration.rb
@@ -208,6 +208,10 @@ class GitlabIntegration < ApplicationRecord
     "https://storage.googleapis.com/tramline-public-assets/gitlab_small.png".freeze
   end
 
+  def branch_head_sha(branch)
+    with_api_retries { installation.head(app_config.code_repository_name, branch) }
+  end
+
   private
 
   # retry once (2 attempts in total)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -241,6 +241,10 @@ class Release < ApplicationRecord
     commits.order(:created_at).last
   end
 
+  def latest_commit_hash
+    vcs_provider.branch_head_sha(release_branch)
+  end
+
   private
 
   def base_tag_name


### PR DESCRIPTION
## Because

When a commit lands and Tramline triggers the workflow run, GitHub does not accept the `sha` of the commit, but triggers the workflow for the branch `HEAD`. In the scenario of multiple commits landing around the same time (race conditions), this can cause duplicate triggers for the same `sha` in GitHub and leave the older step runs in the dangling status of finding the associated workflow run for their commit sha.