### PR TITLE
Avoid bumping train versions until successful release

### DIFF
--- a/app/helpers/trains_helper.rb
+++ b/app/helpers/trains_helper.rb
@@ -6,7 +6,7 @@ module TrainsHelper
 
   def start_release_text(train, major: false)
     manual = train.automatic? ? "manual " : ""
-    "Start #{manual}release #{train.next_release_version(major)}"
+    "Start #{manual}release #{train.next_version(major)}"
   end
 
   def release_schedule(train)

--- a/app/helpers/trains_helper.rb
+++ b/app/helpers/trains_helper.rb
@@ -5,8 +5,10 @@ module TrainsHelper
   end
 
   def start_release_text(train, major: false)
-    manual = train.automatic? ? "manual " : ""
-    "Start #{manual}release #{train.next_version(major)}"
+    text = train.automatic? ? "Manually start " : "Start "
+    text += major ? "major " : "minor "
+    text += "release "
+    text + train.next_version(major)
   end
 
   def release_schedule(train)

--- a/app/libs/triggers/release.rb
+++ b/app/libs/triggers/release.rb
@@ -49,7 +49,6 @@ class Triggers::Release
     train.releases.create!(
       scheduled_at: starting_time,
       branch_name: release_branch,
-      release_version: train.version_current,
       has_major_bump: major_release?,
       is_automatic: automatic
     )

--- a/app/libs/webhook_processors/push.rb
+++ b/app/libs/webhook_processors/push.rb
@@ -13,7 +13,6 @@ class WebhookProcessors::Push
       return unless release.committable?
 
       release.close_pre_release_prs
-      bump_version!
       release.start!
       create_commit!
     end
@@ -23,14 +22,6 @@ class WebhookProcessors::Push
 
   attr_reader :release, :commit_attributes
   delegate :train, to: :release
-
-  def bump_version!
-    return unless release.version_bump_required?
-    return if release.step_runs.none?
-
-    train.bump_fix!
-    stamp_version_changed
-  end
 
   def create_commit!
     params = {
@@ -43,15 +34,6 @@ class WebhookProcessors::Push
       url: commit_attributes[:url]
     }
 
-    commit = Commit.find_or_create_by!(params)
-    commit.trigger_step_runs if commit.applicable?
-  end
-
-  def stamp_version_changed
-    release.event_stamp_now!(
-      reason: :version_changed,
-      kind: :notice,
-      data: {version: train.version_current}
-    )
+    Commit.find_or_create_by!(params).trigger_step_runs
   end
 end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -69,7 +69,7 @@ class Commit < ApplicationRecord
   end
 
   def trigger_step_runs_for(platform_run)
-    platform_run.update_version
+    platform_run.bump_version
 
     platform_run.release_platform.ordered_steps_until(platform_run.current_step_number).each do |step|
       Triggers::StepRun.call(step, self, platform_run)
@@ -77,6 +77,8 @@ class Commit < ApplicationRecord
   end
 
   def trigger_step_runs
+    return unless applicable?
+
     release_platform_runs.have_not_reached_production.each do |run|
       trigger_step_runs_for(run)
     end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -26,7 +26,7 @@ class Release < ApplicationRecord
   using RefinedString
 
   self.implicit_order_column = :scheduled_at
-  # self.ignored_columns += ["release_version"]
+  self.ignored_columns += ["release_version"]
 
   belongs_to :train
   has_one :release_metadata, dependent: :destroy, inverse_of: :release
@@ -256,7 +256,7 @@ class Release < ApplicationRecord
       release_platform_runs.create!(
         code_name: Haikunator.haikunate(100),
         scheduled_at:,
-        release_version: train.version_current,
+        release_version: original_release_version,
         release_platform: release_platform
       )
     end
@@ -275,8 +275,7 @@ class Release < ApplicationRecord
   end
 
   def set_version
-    new_version = train.bump_release!(has_major_bump)
-    self.original_release_version = new_version
+    self.original_release_version = train.next_version(has_major_bump)
   end
 
   def set_default_release_metadata
@@ -292,11 +291,17 @@ class Release < ApplicationRecord
   end
 
   def on_stop!
+    update_train_version if stopped_after_partial_finish?
     notify!("Release has stopped!", :release_stopped, notification_params)
   end
 
   def on_finish!
+    update_train_version
     event_stamp!(reason: :finished, kind: :success, data: {version: release_version})
     notify!("Release has finished!", :release_ended, notification_params.merge(finalize_phase_metadata))
+  end
+
+  def update_train_version
+    train.update!(version_current: release_version)
   end
 end

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -40,7 +40,7 @@ class ReleasePlatformRun < ApplicationRecord
   scope :sequential, -> { order("release_platform_runs.created_at ASC") }
   scope :have_not_reached_production, -> { on_track.reject(&:production_release_happened?) }
 
-  STAMPABLE_REASONS = %w[finished]
+  STAMPABLE_REASONS = %w[version_changed finished]
 
   STATES = {
     created: "created",
@@ -84,8 +84,20 @@ class ReleasePlatformRun < ApplicationRecord
     end
   end
 
-  def update_version
-    update(release_version: train.version_current) if version_bump_required?
+  def bump_version
+    return unless version_bump_required?
+
+    semverish = release_version.to_semverish
+    self.release_version = semverish.bump!(:patch).to_s if semverish.proper?
+    self.release_version = semverish.bump!(:minor).to_s if semverish.partial?
+
+    save!
+
+    event_stamp!(
+      reason: :version_changed,
+      kind: :notice,
+      data: {version: release_version}
+    )
   end
 
   def metadata_editable?

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -216,11 +216,16 @@ class Train < ApplicationRecord
     version_current.ver_bump(bump_term)
   end
 
+  # TODO: remove
   def next_release_version(has_major_bump = false)
-    return next_version(has_major_bump) if has_major_bump || releases.any?
+    if has_major_bump || releases.any?
+      return next_version(has_major_bump)
+    end
+
     version_current
   end
 
+  # TODO: remove
   def bump_release!(has_major_bump = false)
     if has_major_bump || releases.any?
       self.version_current = next_version(has_major_bump)
@@ -230,6 +235,7 @@ class Train < ApplicationRecord
     version_current
   end
 
+  # TODO: remove
   def bump_fix!
     if releases.any?
       semverish = version_current.to_semverish
@@ -312,7 +318,7 @@ class Train < ApplicationRecord
   end
 
   def set_current_version
-    self.version_current = version_seeded_with.ver_bump(:minor)
+    self.version_current = version_seeded_with
   end
 
   def set_default_status

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -216,37 +216,6 @@ class Train < ApplicationRecord
     version_current.ver_bump(bump_term)
   end
 
-  # TODO: remove
-  def next_release_version(has_major_bump = false)
-    if has_major_bump || releases.any?
-      return next_version(has_major_bump)
-    end
-
-    version_current
-  end
-
-  # TODO: remove
-  def bump_release!(has_major_bump = false)
-    if has_major_bump || releases.any?
-      self.version_current = next_version(has_major_bump)
-      save!
-    end
-
-    version_current
-  end
-
-  # TODO: remove
-  def bump_fix!
-    if releases.any?
-      semverish = version_current.to_semverish
-      self.version_current = semverish.bump!(:patch).to_s if semverish.proper?
-      self.version_current = semverish.bump!(:minor).to_s if semverish.partial?
-      save!
-    end
-
-    version_current
-  end
-
   def pre_release_prs?
     branching_strategy == "parallel_working"
   end

--- a/config/locales/passport/en.yml
+++ b/config/locales/passport/en.yml
@@ -7,11 +7,11 @@ en:
       created_html: 'Started a new release <span class="emphasize">%{version}</span>'
       release_branch_created_html: 'Created a release branch <span class="emphasize">%{release_branch}</span> from <span class="emphasize">%{working_branch}</span>'
       kickoff_pr_succeeded_html: 'Kickoff PR created and merged <a class="emphasize-link" href="%{url}">#%{number}</a>'
-      version_changed_html: 'Updated the release version to <span class="emphasize">%{version}</span>'
       finalizing_html: 'Finalizing the release with version <span class="emphasize">%{version}</span>'
       finalize_failed_html: 'Failed to finalize the release with version <span class="emphasize">%{version}</span>'
       finished_html: 'Finished the release with version <span class="emphasize">%{version}</span>'
     release_platform_run:
+      version_changed_html: 'Updated the release version to <span class="emphasize">%{version}</span>'
       finished_html: 'Finished the platform release with version <span class="emphasize">%{version}</span>'
     step_run:
       created_html: 'Started the step <span class="emphasize">%{name}</span> for <span class="emphasize">%{sha}</span>'

--- a/spec/libs/webhook_processors/push_spec.rb
+++ b/spec/libs/webhook_processors/push_spec.rb
@@ -33,6 +33,7 @@ describe WebhookProcessors::Push do
         [:with_app_store, :with_production_channel],
         [:with_app_store, :with_phased_release]].each do |test_case|
         test_case_help = test_case.join(", ").humanize.downcase
+
         it "bumps the patch version for train version #{test_case_help} in rollout mode" do
           deployment = create(:deployment, *test_case, step: step)
           step_run = create(:step_run, release_platform_run:, step:)

--- a/spec/libs/webhook_processors/push_spec.rb
+++ b/spec/libs/webhook_processors/push_spec.rb
@@ -20,13 +20,6 @@ describe WebhookProcessors::Push do
     let(:release_platform_run) { create(:release_platform_run, release_platform:, release:, release_version: train.version_current) }
     let(:step) { create(:step, :release, :with_deployment, release_platform:) }
 
-    it "does not bump the patch version for first commit" do
-      described_class.process(release, commit_attributes)
-
-      expect(train.reload.version_current).to eq("1.6.0")
-      expect(release_platform_run.reload.release_version).to eq("1.6.0")
-    end
-
     context "when production deployment has happened" do
       [[:with_google_play_store, :with_production_channel],
         [:with_google_play_store, :with_staged_rollout],

--- a/spec/models/release_platform_run_spec.rb
+++ b/spec/models/release_platform_run_spec.rb
@@ -84,10 +84,10 @@ describe ReleasePlatformRun do
       _step_run_3 = create(:step_run, commit:, step: steps.third, status: "on_track", release_platform_run:)
 
       expectation = {
-        steps.first => { in_progress: false, done: true, failed: false },
-        steps.second => { in_progress: false, done: false, failed: true },
-        steps.third => { in_progress: true, done: false, failed: false },
-        steps.fourth => { not_started: true }
+        steps.first => {in_progress: false, done: true, failed: false},
+        steps.second => {in_progress: false, done: false, failed: true},
+        steps.third => {in_progress: true, done: false, failed: false},
+        steps.fourth => {not_started: true}
       }
 
       expect(release_platform_run.overall_movement_status).to eq(expectation)
@@ -104,8 +104,8 @@ describe ReleasePlatformRun do
       _step_run_2 = create(:step_run, commit: commit_2, step: steps.second, status: "success", release_platform_run:)
 
       expectation = {
-        steps.first => { in_progress: false, done: false, failed: true },
-        steps.second => { in_progress: false, done: true, failed: false }
+        steps.first => {in_progress: false, done: false, failed: true},
+        steps.second => {in_progress: false, done: true, failed: false}
       }
 
       expect(release_platform_run.overall_movement_status).to eq(expectation)
@@ -155,8 +155,7 @@ describe ReleasePlatformRun do
     it "is false when it has step run and production deployment run has not started rollout" do
       release_step_run = create(:step_run, step: release_step, release_platform_run:)
       create(:deployment_run, deployment: production_deployment, step_run: release_step_run)
-      train.bump_fix!
-      release_platform_run.update!(release_version: train.version_current)
+      release_platform_run.bump_version
       expect(release_platform_run).not_to be_hotfix
     end
 
@@ -271,7 +270,6 @@ describe ReleasePlatformRun do
       [:with_google_play_store, :with_staged_rollout],
       [:with_app_store, :with_production_channel],
       [:with_app_store, :with_phased_release]].each do |test_case|
-
       test_case_help = test_case.join(", ").humanize.downcase
 
       it "updates the minor version if the current version is a partial semver with #{test_case_help}" do

--- a/spec/models/release_platform_run_spec.rb
+++ b/spec/models/release_platform_run_spec.rb
@@ -163,8 +163,7 @@ describe ReleasePlatformRun do
     it "is true when it has step run and production deployment run has started rollout" do
       release_step_run = create(:step_run, step: release_step, release_platform_run:)
       create(:deployment_run, :rollout_started, deployment: production_deployment, step_run: release_step_run)
-      train.bump_fix!
-      release_platform_run.update!(release_version: train.version_current)
+      release_platform_run.bump_version
       expect(release_platform_run).to be_hotfix
     end
 
@@ -258,6 +257,50 @@ describe ReleasePlatformRun do
         create(:deployment_run, :ready_to_release, deployment: production_deployment, step_run: release_step_run)
         expect(release_platform_run).to be_version_bump_required
       end
+    end
+  end
+
+  describe "#bump_version" do
+    let(:app) { create(:app, :android) }
+    let(:train) { create(:train, app:) }
+    let(:release_platform) { create(:release_platform, train:) }
+    let(:release_step) { create(:step, :release, :with_deployment, release_platform:) }
+    let(:production_deployment) { create(:deployment, :with_google_play_store, :with_staged_rollout, step: release_step) }
+    let(:release) { create(:release, train:) }
+
+    it "updates the minor version if the current version is a partial semver" do
+      release_version = "1.2"
+      release_platform_run = create(:release_platform_run, :on_track, release_platform:, release:, release_version:)
+      step_run = create(:step_run, step: release_step, release_platform_run:)
+      create(:deployment_run, :rollout_started, deployment: production_deployment, step_run: step_run)
+
+      release_platform_run.bump_version
+      release_platform_run.reload
+
+      expect(release_platform_run.release_version).to eq("1.3")
+    end
+
+    it "updates the patch version if the current version is a proper semver" do
+      release_version = "1.2.3"
+      release_platform_run = create(:release_platform_run, :on_track, release_platform:, release:, release_version:)
+      step_run = create(:step_run, step: release_step, release_platform_run:)
+      create(:deployment_run, :rollout_started, deployment: production_deployment, step_run: step_run)
+
+      release_platform_run.bump_version
+      release_platform_run.reload
+
+      expect(release_platform_run.release_version).to eq("1.2.4")
+    end
+
+    it "does not do anything if no production deployments in rollout" do
+      release_version = "1.2.3"
+      release_platform_run = create(:release_platform_run, :on_track, release_platform:, release:, release_version:)
+      step_run = create(:step_run, step: release_step, release_platform_run:)
+      create(:deployment_run, step_run: step_run)
+
+      expect {
+        release_platform_run.bump_version
+      }.not_to change { release_platform_run.release_version }
     end
   end
 

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -18,7 +18,6 @@ describe Release do
       end
 
       it "major bump: sets the original_release_version to next version of the train" do
-        puts ver
         train = create(:train, version_seeded_with: ver)
         run = build(:release, original_release_version: nil, train:)
         run.has_major_bump = true

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -5,6 +5,31 @@ describe Release do
     expect(create(:release)).to be_valid
   end
 
+  describe "#set_version" do
+    {"1.2.3" => {major: "2.0.0", minor: "1.3.0"},
+     "1.2" => {major: "2.0", minor: "1.3"}}.each do |ver, expect|
+      it "minor bump: sets the original_release_version to next version of the train" do
+        train = create(:train, version_seeded_with: ver)
+        run = build(:release, original_release_version: nil, train:)
+
+        expect(run.original_release_version).to be_nil
+        run.save!
+        expect(run.original_release_version).to eq(expect[:minor])
+      end
+
+      it "major bump: sets the original_release_version to next version of the train" do
+        puts ver
+        train = create(:train, version_seeded_with: ver)
+        run = build(:release, original_release_version: nil, train:)
+        run.has_major_bump = true
+
+        expect(run.original_release_version).to be_nil
+        run.save!
+        expect(run.original_release_version).to eq(expect[:major])
+      end
+    end
+  end
+
   describe ".create" do
     it "creates the release metadata with default locale" do
       run = create(:release)
@@ -91,6 +116,40 @@ describe Release do
         release.create_release!
         expect(release.tag_name).to eq("v1.2.3-#{commit.short_sha}-#{now}")
       end
+    end
+  end
+
+  describe "#stop!" do
+    it "updates the train version if partially finished" do
+      train = create(:train, version_seeded_with: "9.59.3")
+      run = create(:release, :partially_finished, train:)
+
+      run.stop!
+      train.reload
+
+      expect(train.version_current).to eq("9.60.0")
+    end
+
+    it "does not update the train version if properly stopped" do
+      train = create(:train, version_seeded_with: "9.59.3")
+      run = create(:release, :post_release_started, train:)
+
+      run.stop!
+      train.reload
+
+      expect(train.version_current).to eq("9.59.3")
+    end
+  end
+
+  describe "#finish!" do
+    it "updates the train version" do
+      train = create(:train, version_seeded_with: "9.59.3")
+      run = create(:release, :post_release_started, train:)
+
+      run.finish!
+      train.reload
+
+      expect(train.version_current).to eq("9.60.0")
     end
   end
 end

--- a/spec/models/train_spec.rb
+++ b/spec/models/train_spec.rb
@@ -5,65 +5,14 @@ describe Train do
     expect(create(:train)).to be_valid
   end
 
-  describe "#bump_fix!" do
-    it "updates the minor version if the current version is a partial semver" do
-      train = create(:train, version_seeded_with: "1.2")
-      _run = create(:release, train:)
+  describe "#set_current_version" do
+    it "sets it to the version_seeded_with" do
+      ver = "1.2.3"
+      train = build(:train, version_seeded_with: ver)
 
-      train.bump_fix!
-      train.reload
-
-      expect(train.version_current).to eq("1.4")
-    end
-
-    it "updates the patch version if the current version is a proper semver" do
-      train = create(:train, version_seeded_with: "1.2.1")
-      _run = create(:release, train:)
-
-      train.bump_fix!
-      train.reload
-
-      expect(train.version_current).to eq("1.3.1")
-    end
-
-    it "does not do anything if there are no runs" do
-      train = create(:train, version_seeded_with: "1.2.1")
-
-      train.bump_fix!
-      train.reload
-
-      expect(train.version_current).to eq("1.3.0")
-    end
-  end
-
-  describe "#bump_release!" do
-    it "updates the minor version" do
-      train = create(:train, version_seeded_with: "1.2.1")
-      _run = create(:release, train:)
-
-      train.bump_release!
-      train.reload
-
-      expect(train.version_current).to eq("1.4.0")
-    end
-
-    it "updates the major version if a greater major version is specified" do
-      train = create(:train, version_seeded_with: "1.2.1")
-      _run = create(:release, train:)
-
-      train.bump_release!(true)
-      train.reload
-
-      expect(train.version_current).to eq("2.0.0")
-    end
-
-    it "does not do anything if there are no runs" do
-      train = create(:train, version_seeded_with: "1.2.1")
-
-      train.bump_release!
-      train.reload
-
-      expect(train.version_current).to eq("1.3.0")
+      expect(train.version_current).to be_nil
+      train.save!
+      expect(train.version_current).to eq(ver)
     end
   end
 


### PR DESCRIPTION
- Bump if partially finished (in case of cross-platform apps)
- Do not train current version from an increment