### PR TITLE
Gracefully handle apps in draft mode on Play Store

### DIFF
--- a/app/libs/installations/google/play_developer/error.rb
+++ b/app/libs/installations/google/play_developer/error.rb
@@ -56,6 +56,12 @@ module Installations
         code: 400,
         message_matcher: /Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI/,
         decorated_reason: :app_review_rejected
+      },
+      {
+        status: "INVALID_ARGUMENT",
+        code: 400,
+        message_matcher: /Only releases with status draft may be created on draft app/i,
+        decorated_reason: :release_on_draft_app
       }
     ]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
           invalid_api_package: "the build artifact being invalid for the store"
           apks_not_allowed: "the build artifact being an apk, which is not accepted by the store"
           app_review_rejected: "the build needs to be uploaded manually on Google Play Console UI as a previous build was rejected by the store"
+          release_on_draft_app: "the app is in draft mode, please make a manual release to a public channel (alpha, beta, production) before releasing from Tramline"
       deployment:
         integration_type:
           app_store: "App Store (production)"

--- a/db/migrate/20230823144922_add_app_draft_flag.rb
+++ b/db/migrate/20230823144922_add_app_draft_flag.rb
@@ -1,0 +1,5 @@
+class AddAppDraftFlag < ActiveRecord::Migration[7.0]
+  def change
+    add_column :apps, :is_draft, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_17_135023) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_23_144922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -76,6 +76,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_17_135023) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "external_id"
+    t.boolean "is_draft"
     t.index ["organization_id"], name: "index_apps_on_organization_id"
     t.index ["platform", "bundle_identifier", "organization_id"], name: "index_apps_on_platform_and_bundle_id_and_org_id", unique: true
   end


### PR DESCRIPTION
Tramline / Play Store APIs cannot release to non-internal channels on Play Store without users making a manual release on the dashboard first.
