### PR TITLE
Fix retry options for some sidekiq jobs

### DIFF
--- a/app/jobs/deployments/app_store_connect/find_live_release_job.rb
+++ b/app/jobs/deployments/app_store_connect/find_live_release_job.rb
@@ -4,11 +4,11 @@ class Deployments::AppStoreConnect::FindLiveReleaseJob
   extend Backoffable
 
   queue_as :high
-  sidekiq_options retry: 21
+  sidekiq_options retry: 30
 
   sidekiq_retry_in do |count, ex|
     if ex.is_a?(Deployments::AppStoreConnect::Release::ReleaseNotFullyLive)
-      backoff_in(attempt: count, period: :minutes, type: :linear, factor: 60).to_i
+      backoff_in(attempt: count, period: :minutes, type: :linear, factor: 30).to_i
     else
       elog(ex)
       :kill

--- a/app/jobs/deployments/app_store_connect/find_live_release_job.rb
+++ b/app/jobs/deployments/app_store_connect/find_live_release_job.rb
@@ -4,7 +4,7 @@ class Deployments::AppStoreConnect::FindLiveReleaseJob
   extend Backoffable
 
   queue_as :high
-  sidekiq_options retry: 30
+  sidekiq_options retry: 40
 
   sidekiq_retry_in do |count, ex|
     if ex.is_a?(Deployments::AppStoreConnect::Release::ReleaseNotFullyLive)

--- a/app/jobs/deployments/app_store_connect/find_live_release_job.rb
+++ b/app/jobs/deployments/app_store_connect/find_live_release_job.rb
@@ -4,11 +4,11 @@ class Deployments::AppStoreConnect::FindLiveReleaseJob
   extend Backoffable
 
   queue_as :high
-  sidekiq_options retry: 40
+  sidekiq_options retry: 1000
 
-  sidekiq_retry_in do |count, ex|
+  sidekiq_retry_in do |_count, ex|
     if ex.is_a?(Deployments::AppStoreConnect::Release::ReleaseNotFullyLive)
-      backoff_in(attempt: count, period: :minutes, type: :linear, factor: 30).to_i
+      30.minutes.to_i
     else
       elog(ex)
       :kill

--- a/app/jobs/deployments/app_store_connect/update_external_release_job.rb
+++ b/app/jobs/deployments/app_store_connect/update_external_release_job.rb
@@ -4,11 +4,11 @@ class Deployments::AppStoreConnect::UpdateExternalReleaseJob
   extend Backoffable
 
   queue_as :high
-  sidekiq_options retry: 400
+  sidekiq_options retry: 100
 
   sidekiq_retry_in do |count, ex|
     if ex.is_a?(Deployments::AppStoreConnect::Release::ExternalReleaseNotInTerminalState)
-      backoff_in(attempt: count, period: :minutes, type: :linear, factor: 10).to_i
+      backoff_in(attempt: count, period: :minutes, type: :linear, factor: 5).to_i
     else
       elog(ex)
       :kill

--- a/app/jobs/releases/cancel_step_run.rb
+++ b/app/jobs/releases/cancel_step_run.rb
@@ -7,7 +7,7 @@ class Releases::CancelStepRun < ApplicationJob
     step_run = StepRun.find(step_run_id)
     return unless step_run.active?
 
-    Rails.logger.debug "Cancelling step run - #{step_run_id}"
+    Rails.logger.debug { "Cancelling step run - #{step_run_id}" }
     step_run.cancel!
   end
 end

--- a/app/jobs/releases/cancel_step_run.rb
+++ b/app/jobs/releases/cancel_step_run.rb
@@ -7,6 +7,7 @@ class Releases::CancelStepRun < ApplicationJob
     step_run = StepRun.find(step_run_id)
     return unless step_run.active?
 
+    Rails.logger.debug "Cancelling step run - #{step_run_id}"
     step_run.cancel!
   end
 end

--- a/app/jobs/releases/cancel_workflow_run_job.rb
+++ b/app/jobs/releases/cancel_workflow_run_job.rb
@@ -10,7 +10,7 @@ class Releases::CancelWorkflowRunJob < ApplicationJob
     return unless step_run.cancelling?
     raise WorkflowRunNotFound unless step_run.workflow_found?
 
-    Rails.logger.debug "Cancelling workflow for step run - #{step_run_id}"
+    Rails.logger.debug { "Cancelling workflow for step run - #{step_run_id}" }
     step_run.cancel_ci_workflow!
     step_run.cancel!
   end

--- a/app/jobs/releases/cancel_workflow_run_job.rb
+++ b/app/jobs/releases/cancel_workflow_run_job.rb
@@ -10,6 +10,7 @@ class Releases::CancelWorkflowRunJob < ApplicationJob
     return unless step_run.cancelling?
     raise WorkflowRunNotFound unless step_run.workflow_found?
 
+    Rails.logger.debug "Cancelling workflow for step run - #{step_run_id}"
     step_run.cancel_ci_workflow!
     step_run.cancel!
   end

--- a/app/jobs/releases/find_workflow_run.rb
+++ b/app/jobs/releases/find_workflow_run.rb
@@ -3,7 +3,7 @@ class Releases::FindWorkflowRun
   include Loggable
 
   queue_as :high
-  sidekiq_options retry: 500
+  sidekiq_options retry: 25
 
   sidekiq_retry_in do |count, exception|
     if exception.is_a?(Installations::Errors::WorkflowRunNotFound)


### PR DESCRIPTION
Changes:

- Find workflow run to stop after a total of ~60 minutes. 
- Find live release job (post staged rollout) to query more frequently every 30 minutes with no backoff, it stops after ~20 days (this is to account for pauses in the rollout).
- Update external release (wait for review) to stop after a total of ~17 days.