### PR TITLE
Add missing staged rollout notifications

### DIFF
--- a/app/libs/notifiers/slack/builder.rb
+++ b/app/libs/notifiers/slack/builder.rb
@@ -13,6 +13,10 @@ module Notifiers
         submit_for_review: Renderers::SubmitForReview,
         review_approved: Renderers::ReviewApproved,
         staged_rollout_updated: Renderers::StagedRolloutUpdated,
+        staged_rollout_paused: Renderers::StagedRolloutPaused,
+        staged_rollout_resumed: Renderers::StagedRolloutResumed,
+        staged_rollout_halted: Renderers::StagedRolloutHalted,
+        staged_rollout_fully_released: Renderers::StagedRolloutFullyReleased,
         release_scheduled: Renderers::ReleaseScheduled
       }
 

--- a/app/libs/notifiers/slack/renderers/staged_rollout_fully_released.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_fully_released.rb
@@ -1,0 +1,13 @@
+module Notifiers
+  module Slack
+    class Renderers::StagedRolloutFullyReleased < Renderers::Base
+      TEMPLATE_FILE = "staged_rollout_updated.json.erb".freeze
+
+      def main_text
+        "Your staged rollout has been accelerated to a *full release to all users* from stage #{@current_stage} (#{@rollout_percentage}%)."
+      end
+
+      def secondary_text = nil
+    end
+  end
+end

--- a/app/libs/notifiers/slack/renderers/staged_rollout_fully_released.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_fully_released.rb
@@ -4,7 +4,7 @@ module Notifiers
       TEMPLATE_FILE = "staged_rollout_updated.json.erb".freeze
 
       def main_text
-        "Your staged rollout has been accelerated to a *full release to all users* from stage #{@current_stage} (#{@rollout_percentage}%)."
+        "Your staged rollout has been accelerated to a *full release to all users* from stage #{@current_stage} (#{@rollout_percentage}%)"
       end
 
       def secondary_text = nil

--- a/app/libs/notifiers/slack/renderers/staged_rollout_halted.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_halted.rb
@@ -8,7 +8,7 @@ module Notifiers
       end
 
       def secondary_text
-        "You can not change this release from Tramline any more."
+        "You can not change this release from Tramline any more"
       end
     end
   end

--- a/app/libs/notifiers/slack/renderers/staged_rollout_halted.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_halted.rb
@@ -1,0 +1,15 @@
+module Notifiers
+  module Slack
+    class Renderers::StagedRolloutHalted < Renderers::Base
+      TEMPLATE_FILE = "staged_rollout_updated.json.erb".freeze
+
+      def main_text
+        "Staged rollout for the release was *halted* at *#{@current_stage} (#{@rollout_percentage}%)*"
+      end
+
+      def secondary_text
+        "You can not change this release from Tramline any more."
+      end
+    end
+  end
+end

--- a/app/libs/notifiers/slack/renderers/staged_rollout_paused.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_paused.rb
@@ -8,7 +8,7 @@ module Notifiers
       end
 
       def secondary_text
-        "You can choose to *Resume* or *Halt* your release from the live release page."
+        "You can choose to *Resume* or *Halt* your release from the live release page"
       end
     end
   end

--- a/app/libs/notifiers/slack/renderers/staged_rollout_paused.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_paused.rb
@@ -1,0 +1,15 @@
+module Notifiers
+  module Slack
+    class Renderers::StagedRolloutPaused < Renderers::Base
+      TEMPLATE_FILE = "staged_rollout_updated.json.erb".freeze
+
+      def main_text
+        "Staged rollout for the release was *paused* at *#{@current_stage} (#{@rollout_percentage}%)*"
+      end
+
+      def secondary_text
+        "You can choose to *Resume* or *Halt* your release from the live release page."
+      end
+    end
+  end
+end

--- a/app/libs/notifiers/slack/renderers/staged_rollout_resumed.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_resumed.rb
@@ -8,7 +8,7 @@ module Notifiers
       end
 
       def secondary_text
-        "You can choose to *Pause* or *Halt* your release from the live release page."
+        "You can choose to *Pause* or *Halt* your release from the live release page"
       end
     end
   end

--- a/app/libs/notifiers/slack/renderers/staged_rollout_resumed.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_resumed.rb
@@ -1,0 +1,15 @@
+module Notifiers
+  module Slack
+    class Renderers::StagedRolloutResumed < Renderers::Base
+      TEMPLATE_FILE = "staged_rollout_updated.json.erb".freeze
+
+      def main_text
+        "Staged rollout for the release was *resumed* at *#{@current_stage} (#{@rollout_percentage}%)*"
+      end
+
+      def secondary_text
+        "You can choose to *Pause* or *Halt* your release from the live release page."
+      end
+    end
+  end
+end

--- a/app/libs/notifiers/slack/renderers/staged_rollout_updated.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_updated.rb
@@ -2,11 +2,6 @@ module Notifiers
   module Slack
     class Renderers::StagedRolloutUpdated < Renderers::Base
       TEMPLATE_FILE = "staged_rollout_updated.json.erb".freeze
-      def initialize(**params)
-        super(**params)
-        @main_text = main_text
-        @secondary_text = secondary_text
-      end
 
       def main_text
         if @is_fully_released

--- a/app/models/staged_rollout.rb
+++ b/app/models/staged_rollout.rb
@@ -140,6 +140,7 @@ class StagedRollout < ApplicationRecord
     deployment_run.on_halt_release! do |result|
       if result.ok?
         halt!
+        notify!("Release was halted!", :staged_rollout_halted, notification_params)
       else
         elog(result.error)
       end
@@ -152,6 +153,7 @@ class StagedRollout < ApplicationRecord
     deployment_run.on_fully_release! do |result|
       if result.ok?
         full_rollout!
+        notify!("Staged rollout was accelerated to a full rollout!", :staged_rollout_fully_released, notification_params)
       else
         elog(result.error)
       end
@@ -164,6 +166,7 @@ class StagedRollout < ApplicationRecord
     deployment_run.on_pause_release! do |result|
       if result.ok?
         pause!
+        notify!("Staged rollout was paused!", :staged_rollout_paused, notification_params)
       else
         elog(result.error)
       end
@@ -175,7 +178,10 @@ class StagedRollout < ApplicationRecord
 
     deployment_run.on_resume_release! do |result|
       if result.ok?
-        resume! unless completed?
+        unless completed?
+          resume!
+          notify!("Staged rollout was resumed!", :staged_rollout_resumed, notification_params)
+        end
       else
         elog(result.error)
       end

--- a/app/views/notifiers/slack/staged_rollout_updated.json.erb
+++ b/app/views/notifiers/slack/staged_rollout_updated.json.erb
@@ -18,16 +18,18 @@
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "<%= @main_text %>"
+        "text": "<%= main_text %>"
       }
     },
+    <% if secondary_text.present? %>
     {
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "<%= @secondary_text %>"
+        "text": "<%= secondary_text %>"
       }
     },
+    <% end %>
     {
       "type": "divider"
     },


### PR DESCRIPTION
Pause:
<img width="624" alt="Screenshot 2023-08-31 at 9 43 58 AM" src="https://github.com/tramlinehq/tramline/assets/1309111/a65dccda-72c9-4332-93bf-1f7e3e04e27c">

Resume:
<img width="625" alt="Screenshot 2023-08-31 at 9 44 51 AM" src="https://github.com/tramlinehq/tramline/assets/1309111/a2a623fc-7df8-4680-bd70-ccb8de3ce409">

Halt:
<img width="632" alt="Screenshot 2023-08-31 at 9 45 50 AM" src="https://github.com/tramlinehq/tramline/assets/1309111/a51401d2-e257-4e07-8f8b-3a4e60c0b808">

Fully release:
<img width="629" alt="Screenshot 2023-08-31 at 9 45 24 AM" src="https://github.com/tramlinehq/tramline/assets/1309111/cea01d42-d5f4-484e-a2b6-3c3ac4c34ca4">
