### PR TITLE
Release backmerge improvements

### DIFF
--- a/app/libs/notifiers/slack/builder.rb
+++ b/app/libs/notifiers/slack/builder.rb
@@ -13,7 +13,8 @@ module Notifiers
         submit_for_review: Renderers::SubmitForReview,
         review_approved: Renderers::ReviewApproved,
         staged_rollout_updated: Renderers::StagedRolloutUpdated,
-        release_scheduled: Renderers::ReleaseScheduled
+        release_scheduled: Renderers::ReleaseScheduled,
+        backmerge_failed: Renderers::BackmergeFailed
       }
 
       class RendererNotFound < ArgumentError; end

--- a/app/libs/notifiers/slack/renderers/backmerge_failed.rb
+++ b/app/libs/notifiers/slack/renderers/backmerge_failed.rb
@@ -1,0 +1,19 @@
+module Notifiers
+  module Slack
+    class Renderers::BackmergeFailed < Renderers::Base
+      TEMPLATE_FILE = "backmerge_failed.json.erb".freeze
+
+      def failure_text
+        ":exclamation: Automatic backmerge failed for <#{@commit_url}|#{@commit_sha}> due to a merge conflict."
+      end
+
+      def sanitized_commit_message
+        safe_string("```#{@commit_message}```")
+      end
+
+      def action_text
+        "#{@commit_author} needs to merge this change to the working branch `#{working_branch}` manually."
+      end
+    end
+  end
+end

--- a/app/libs/triggers/release_backmerge.rb
+++ b/app/libs/triggers/release_backmerge.rb
@@ -23,6 +23,7 @@ class Triggers::ReleaseBackmerge
       elog(res.error)
       commit.update!(backmerge_failure: true)
       release.event_stamp!(reason: :backmerge_failure, kind: :error, data: {commit_url: commit.url, commit_sha: commit.short_sha})
+      commit.notify!("Backmerge to the working branch failed", :backmerge_failed, commit.notification_params)
     end
   end
 

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -132,6 +132,10 @@ class GithubIntegration < ApplicationRecord
     "https://github.com/#{repo}/releases/tag/#{tag_name}"
   end
 
+  def compare_url(to_branch, from_branch)
+    "https://github.com/#{code_repository_name}/compare/#{to_branch}..#{from_branch}"
+  end
+
   def installation
     API.new(installation_id)
   end

--- a/app/models/gitlab_integration.rb
+++ b/app/models/gitlab_integration.rb
@@ -145,6 +145,10 @@ class GitlabIntegration < ApplicationRecord
     "https://gitlab.com/#{repo}/-/tags/#{tag_name}"
   end
 
+  def compare_url(to_branch, from_branch)
+    "https://gitlab.com/tramline/ueno/-/compare/#{to_branch}...#{from_branch}?straight=true"
+  end
+
   def installation
     Installations::Gitlab::Api.new(oauth_access_token)
   end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -131,6 +131,10 @@ class Release < ApplicationRecord
     all_commits.where(backmerge_failure: true)
   end
 
+  def compare_url
+    vcs_provider.compare_url(train.working_branch, release_branch)
+  end
+
   def version_ahead?(other)
     return false if self == other
     release_version.to_semverish >= other.release_version.to_semverish

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -291,7 +291,8 @@ class Train < ApplicationRecord
       {
         train_name: name,
         train_current_version: version_current,
-        train_url: train_link
+        train_url: train_link,
+        working_branch:
       }
     )
   end

--- a/app/views/notifiers/slack/backmerge_failed.json.erb
+++ b/app/views/notifiers/slack/backmerge_failed.json.erb
@@ -1,0 +1,83 @@
+{
+  "blocks": [
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "image",
+          "image_url": "<%= @platform_public_img %>",
+          "alt_text": "app"
+        },
+        {
+          "type": "mrkdwn",
+          "text": "*<%= @app_name %> (<%= @app_platform %>)* <%= @release_version %>"
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "<%= failure_text %>"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "<%= sanitized_commit_message %>"
+      }
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "<%= action_text %>"
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "image",
+          "image_url": "https://storage.googleapis.com/tramline-public-assets/tramline-small.png",
+          "alt_text": "tramline"
+        },
+        {
+          "type": "mrkdwn",
+          "text": "<<%= @release_url %>|Live release>"
+        }
+      ]
+    },
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "image",
+          "image_url": "<%= @vcs_public_icon_img %>",
+          "alt_text": "vcs"
+        },
+        {
+          "type": "mrkdwn",
+          "text": "<<%= @release_branch_url %>|Release branch – <%= @release_branch %>>"
+        }
+      ]
+    },
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "plain_text",
+          "text": "Release train: <%= @train_name %>",
+          "emoji": true
+        }
+      ]
+    },
+    {
+      "type": "divider"
+    }
+  ]
+}

--- a/app/views/shared/live_release/_finalize.html.erb
+++ b/app/views/shared/live_release/_finalize.html.erb
@@ -51,6 +51,7 @@
     <span class="text-sm text-slate-500">
       You have <%= release.unmerged_commits.size %> commits that were not automatically merged by Tramline.
       Please ensure that those changes have been manually merged back on <code><%= release.train.working_branch %>.</code>
+      You can see the current diff between the branches <%= link_to_external "here", release.compare_url, class: "underline" %>.
     </span>
   <% end %>
 


### PR DESCRIPTION
- Notification for backmerge failure

<img width="612" alt="Screenshot 2023-09-06 at 3 04 49 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/1d30a7e9-1b78-41a8-9512-5151aca623cf">


- Add a helpful link to do a proper diff between the working branch and the release branch when there are unmerged commits



