### PR TITLE
Allow starting deployment out of order in hotfix mode

### DIFF
--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -206,7 +206,7 @@ class StepRun < ApplicationRecord
   def manually_startable_deployment?(deployment)
     return false if deployment.first?
     return false if step.review?
-    startable_deployment?(deployment) && last_deployment_run&.released?
+    startable_deployment?(deployment) && (last_deployment_run&.released? || release_platform_run.hotfix?)
   end
 
   def last_deployment_run


### PR DESCRIPTION
## Because

Users don't want to wait for the beta review to go through before starting production when in hotfix mode