### PR TITLE
Make GitHub CI triggers tramlinehq/deploy-action compatible

### DIFF
--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -72,12 +72,14 @@ module Installations
       end
     end
 
-    def run_workflow!(repo, id, ref, inputs)
-      inputs = {
-        versionCode: inputs[:version_code],
-        versionName: inputs[:build_version],
-        buildNotes: inputs[:build_notes]
-      }.compact
+    def run_workflow!(repo, id, ref, inputs, commit_hash)
+      inputs =
+        inputs
+          .slice(:version_code, :build_notes)
+          .merge(version_name: inputs[:build_version], commit_ref: commit_hash)
+          .compact
+          .to_json
+          .then { {"tramline-input" => _1} }
 
       execute do
         @client

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -182,8 +182,8 @@ class GithubIntegration < ApplicationRecord
     installation.list_workflows(code_repository_name, WORKFLOWS_TRANSFORMATIONS)
   end
 
-  def trigger_workflow_run!(ci_cd_channel, ref, inputs, _commit_hash = nil)
-    raise WorkflowRun unless installation.run_workflow!(code_repository_name, ci_cd_channel, ref, inputs)
+  def trigger_workflow_run!(ci_cd_channel, branch_name, inputs, commit_hash = nil)
+    raise WorkflowRun unless installation.run_workflow!(code_repository_name, ci_cd_channel, branch_name, inputs, commit_hash)
   end
 
   def cancel_workflow_run!(ci_ref)


### PR DESCRIPTION
Send inputs as JSON expecting https://github.com/tramlinehq/deploy-action on the other end. 

This allows two things:

1. We can add new data to our payload later without disrupting the users
2. We can pass in a commit ref to always trigger against the correct SHA