### PR TITLE
Add configuration for manual trigger of release step

### DIFF
--- a/app/controllers/trains_controller.rb
+++ b/app/controllers/trains_controller.rb
@@ -103,7 +103,8 @@ class TrainsController < SignedInApplicationController
       :build_queue_wait_time_unit,
       :build_queue_wait_time_value,
       :release_schedule_enabled,
-      :continuous_backmerge_enabled
+      :continuous_backmerge_enabled,
+      :manual_release
     )
   end
 
@@ -132,7 +133,8 @@ class TrainsController < SignedInApplicationController
       :repeat_duration_value,
       :repeat_duration_unit,
       :release_schedule_enabled,
-      :continuous_backmerge_enabled
+      :continuous_backmerge_enabled,
+      :manual_release
     )
   end
 

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -178,8 +178,8 @@ class ReleasePlatformRun < ApplicationRecord
   end
 
   def next_step
-    return steps.first if step_runs.empty?
-    last_commit&.step_runs&.joins(:step)&.order(:step_number)&.last&.step&.next
+    return steps.first if step_runs.empty? || last_commit.blank?
+    last_commit.step_runs.joins(:step).order(:step_number).last.step.next
   end
 
   def running_step?
@@ -187,13 +187,14 @@ class ReleasePlatformRun < ApplicationRecord
   end
 
   def last_run_for(step)
-    last_commit&.step_runs&.where(step: step)&.last
+    return if last_commit.blank?
+    last_commit.step_runs.where(step: step).last
   end
 
   def current_step_number
     return if steps.blank?
     return 1 if running_steps.blank?
-    running_steps.order(:step_number).last&.step_number
+    running_steps.order(:step_number).last.step_number
   end
 
   def last_commit

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -179,7 +179,7 @@ class ReleasePlatformRun < ApplicationRecord
 
   def next_step
     return steps.first if step_runs.empty?
-    step_runs.joins(:step).order(:step_number).last.step.next
+    last_commit&.step_runs&.joins(:step)&.order(:step_number)&.last&.step&.next
   end
 
   def running_step?
@@ -187,13 +187,13 @@ class ReleasePlatformRun < ApplicationRecord
   end
 
   def last_run_for(step)
-    step_runs.where(step: step).last
+    last_commit&.step_runs&.where(step: step)&.last
   end
 
   def current_step_number
     return if steps.blank?
     return 1 if running_steps.blank?
-    running_steps.order(:step_number).last.step_number
+    running_steps.order(:step_number).last&.step_number
   end
 
   def last_commit

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -10,6 +10,7 @@
 #  build_queue_wait_time    :interval
 #  description              :string
 #  kickoff_at               :datetime
+#  manual_release           :boolean          default(FALSE)
 #  name                     :string           not null
 #  notification_channel     :jsonb
 #  release_backmerge_branch :string

--- a/app/views/trains/_build_queue_form.html.erb
+++ b/app/views/trains/_build_queue_form.html.erb
@@ -3,8 +3,7 @@
   <div class="text-xl text-slate-600 font-medium mt-2">Build Queue (optional)</div>
 
   <div class="text-sm mt-1 mb-6">
-    All commits on the release branch are auto-applied by default.
-    You can override this behaviour through build queue triggers.
+    Control when commits are applied to trigger new builds in your release.<br/>By default, commits on the release branch are auto-applied.
   </div>
 
   <div data-controller="domain--build-queue-help toggle-switch"

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -174,6 +174,7 @@
     <%= render partial: "release_schedule_form", locals: { form: } %>
     <%= render partial: "build_queue_form", locals: { form: } %>
     <%= render partial: "backmerge_config_form", locals: { form: } %>
+    <%= render partial: "manual_release_form", locals: { form: } %>
   </div>
 
   <div class="mt-12">

--- a/app/views/trains/_manual_release_form.html.erb
+++ b/app/views/trains/_manual_release_form.html.erb
@@ -1,22 +1,22 @@
-<article hidden data-branching-selector-target="backmerge">
+<article>
   <div class="border-t border-dashed border-slate-200 pt-8 mt-8"></div>
-  <div class="text-xl text-slate-600 font-medium mt-2">Release Backmerge Configuration (optional)</div>
+  <div class="text-xl text-slate-600 font-medium mt-2">Manual Release Trigger (optional)</div>
   <div class="text-sm mt-1 mb-6">
-    Enable continuous backmerging of release branch commits into the working branch as they arrive.<br/> By default, merge happens at the end of the release.
+    Always require a manual trigger for the release step of the train.<br/>By default, the release step will be auto-triggered if it has run before in the release.
   </div>
   <section data-controller="toggle-switch"
-           data-toggle-switch-on-label-value="Continuous Backmerge enabled"
-           data-toggle-switch-off-label-value="Continuous Backmerge disabled">
+           data-toggle-switch-on-label-value="Manual Release enabled"
+           data-toggle-switch-off-label-value="Manual Release disabled">
 
     <div class="flex items-center">
       <div class="form-switch">
-        <%= form.check_box :continuous_backmerge_enabled,
-                           { id: "release-backmerge-switch",
+        <%= form.check_box :manual_release,
+                           { id: "manual-release-switch",
                              class: "sr-only",
                              data: { action: "toggle-switch#change",
                                      toggle_switch_target: "checkbox" } },
                            "true", "false" %>
-        <label class="bg-slate-400" for="release-backmerge-switch">
+        <label class="bg-slate-400" for="manual-release-switch">
           <span class="bg-white shadow-sm" aria-hidden="true"></span>
           <span class="sr-only">Switch label</span>
         </label>

--- a/db/migrate/20230911074926_add_manual_release_flag_to_train.rb
+++ b/db/migrate/20230911074926_add_manual_release_flag_to_train.rb
@@ -1,0 +1,5 @@
+class AddManualReleaseFlagToTrain < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trains, :manual_release, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_125708) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_074926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -498,6 +498,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_125708) do
     t.interval "build_queue_wait_time"
     t.integer "build_queue_size", limit: 2
     t.string "backmerge_strategy", default: "on_finalize", null: false
+    t.boolean "manual_release", default: false
     t.index ["app_id"], name: "index_trains_on_app_id"
   end
 

--- a/spec/factories/trains.rb
+++ b/spec/factories/trains.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     release_backmerge_branch { "main" }
     status { "draft" }
     build_queue_enabled { false }
+    manual_release { false }
 
     trait :draft do
       status { "draft" }


### PR DESCRIPTION
Currently, the release step is manually triggered the first time it is run.

But, subsequent runs of the release step are automatic when a new commit lands.

This config allows users to always have a manual trigger for the release step so they can control the distribution of their non-internal builds better.

<img width="692" alt="Screenshot 2023-09-11 at 2 58 02 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/d4cc7541-4efc-4140-9ae5-5ada07c89cec">
