### PR TITLE
Add a status API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,10 +44,6 @@ Rails/DurationArithmetic:
   Exclude:
     - spec/jobs/schedule_train_releases_job_spec.rb
 
-Rails/ApplicationController:
-  Exclude:
-    - app/controllers/api_controller.rb
-
 RSpec:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,10 @@ Rails/DurationArithmetic:
   Exclude:
     - spec/jobs/schedule_train_releases_job_spec.rb
 
+Rails/ApplicationController:
+  Exclude:
+    - app/controllers/api_controller.rb
+
 RSpec:
   Enabled: true
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,6 +21,7 @@ Rails/I18nLocaleTexts:
     - 'app/controllers/release_platforms_controller.rb'
     - 'app/controllers/commits_controller.rb'
     - 'app/controllers/build_queues_controller.rb'
+    - 'app/controllers/accounts/organizations_controller.rb'
     - 'app/mailers/test_mailer.rb'
     - 'app/models/deployment.rb'
     - 'app/models/step.rb'

--- a/app/assets/images/clipboard_check.svg
+++ b/app/assets/images/clipboard_check.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M9 5h-2a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-12a2 2 0 0 0 -2 -2h-2"></path>
+  <path d="M9 3m0 2a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v0a2 2 0 0 1 -2 2h-2a2 2 0 0 1 -2 -2z"></path>
+  <path d="M9 14l2 2l4 -4"></path>
+</svg>

--- a/app/assets/images/clipboard_copy.svg
+++ b/app/assets/images/clipboard_copy.svg
@@ -1,0 +1,7 @@
+<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M9 5h-2a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-12a2 2 0 0 0 -2 -2h-2"></path>
+  <path d="M9 3m0 2a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v0a2 2 0 0 1 -2 2h-2a2 2 0 0 1 -2 -2z"></path>
+  <path d="M9 12h6"></path>
+  <path d="M9 16h6"></path>
+</svg>

--- a/app/controllers/accounts/organizations_controller.rb
+++ b/app/controllers/accounts/organizations_controller.rb
@@ -3,6 +3,18 @@ class Accounts::OrganizationsController < SignedInApplicationController
     @organizations = current_user.organizations
   end
 
+  def edit
+    @organization = current_user.organizations.friendly.find(params[:id])
+  end
+
+  def rotate_api_key
+    if @organization.rotate_api_key
+      redirect_to root_path, notice: "API Updated"
+    else
+      redirect_to root_path, alert: "There was an error: #{@organization.errors.full_messages.to_sentence}"
+    end
+  end
+
   def switch
     session[:active_organization] = params[:id]
     redirect_to :root

--- a/app/controllers/accounts/organizations_controller.rb
+++ b/app/controllers/accounts/organizations_controller.rb
@@ -1,4 +1,6 @@
 class Accounts::OrganizationsController < SignedInApplicationController
+  before_action :require_write_access!, only: %i[edit]
+
   def index
     @organizations = current_user.organizations
   end

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::AppsController < ApiController
 
   def latest_store_version
     app.latest_store_step_run
-      &.then { |sr| {version: sr.first, build: sr.second, created_at: sr.third, platform: sr.fourth} }
+      &.then { |sr| {version: sr.build_version, build: sr.build_number, created_at: sr.created_at, platform: sr.platform} }
   end
 
   def app_param

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -7,15 +7,13 @@ class Api::V1::AppsController < ApiController
   private
 
   def app
-    @app ||=
-      authorized_organization.apps.where(bundle_identifier: app_param)
-        .or(authorized_organization.apps.where(slug: app_param)).sole
+    @app ||= authorized_organization.apps.where(slug: app_param).sole
   end
 
   def latest_store_version
     app
       .latest_computed_store_version
-      .map { |v| {version: v.first, build: v.second, created_at: v.third} }
+      &.map { |v| {version: v.first, build: v.second, created_at: v.third, platform: v.fourth} }
   end
 
   def app_param

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::AppsController < ApiController
   end
 
   def latest_store_version
-    app.latest_store_step_runs.map(&:release_info).group_by(&:platform)
+    app.latest_store_step_runs.map(&:release_info).group_by { _1[:platform] }
   end
 
   def app_param

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -11,9 +11,8 @@ class Api::V1::AppsController < ApiController
   end
 
   def latest_store_version
-    app
-      .latest_computed_store_version
-      &.map { |v| {version: v.first, build: v.second, created_at: v.third, platform: v.fourth} }
+    app.latest_store_step_run
+      &.then { |sr| {version: sr.first, build: sr.second, created_at: sr.third, platform: sr.fourth} }
   end
 
   def app_param

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::AppsController < ApiController
   end
 
   def latest_store_version
-    app.latest_store_step_runs.map(&:release_info)
+    app.latest_store_step_runs.map(&:release_info).group_by(&:platform)
   end
 
   def app_param

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -1,0 +1,24 @@
+class Api::V1::AppsController < ApiController
+  def show
+    head :not_found and return if app.blank?
+    render json: {latest: latest_store_version}, status: :ok
+  end
+
+  private
+
+  def app
+    @app ||=
+      authorized_organization.apps.where(bundle_identifier: app_param)
+        .or(authorized_organization.apps.where(slug: app_param)).sole
+  end
+
+  def latest_store_version
+    app
+      .latest_computed_store_version
+      .map { |v| {version: v.first, build: v.second, created_at: v.third} }
+  end
+
+  def app_param
+    params.require(:app_id)
+  end
+end

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::AppsController < ApiController
   def show
-    head :not_found and return if app.blank?
     render json: {latest: latest_store_version}, status: :ok
   end
 
@@ -11,8 +10,7 @@ class Api::V1::AppsController < ApiController
   end
 
   def latest_store_version
-    app.latest_store_step_run
-      &.then { |sr| {version: sr.build_version, build: sr.build_number, created_at: sr.created_at, platform: sr.platform} }
+    app.latest_store_step_runs.map(&:release_info)
   end
 
   def app_param

--- a/app/controllers/api/v1/pings_controller.rb
+++ b/app/controllers/api/v1/pings_controller.rb
@@ -1,15 +1,8 @@
 class Api::V1::PingsController < ApiController
-  skip_before_action :authenticate, only: [:show]
-
-  rescue_from ActionController::ParameterMissing do
-    head :bad_request
-  end
-
-  rescue_from ActiveRecord::RecordNotFound do
-    head :not_found
-  end
+  skip_before_action :authorized_organization?
+  skip_before_action :authenticate
 
   def show
-    render json: { status: "ok" }, status: :ok
+    render json: {status: "ok"}, status: :ok
   end
 end

--- a/app/controllers/api/v1/pings_controller.rb
+++ b/app/controllers/api/v1/pings_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::PingsController < ApiController
+  skip_before_action :authenticate, only: [:show]
+
+  rescue_from ActionController::ParameterMissing do
+    head :bad_request
+  end
+
+  rescue_from ActiveRecord::RecordNotFound do
+    head :not_found
+  end
+
+  def show
+    render json: { status: "ok" }, status: :ok
+  end
+end

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::ReleasesController < ApiController
   def show
-    head :not_found and return if release.blank?
     render json: {releases: all_versions}, status: :ok
   end
 
@@ -14,8 +13,8 @@ class Api::V1::ReleasesController < ApiController
 
   def all_versions
     release
-      .all_completed_versions
-      .map { |v| {version: v.first, build: v.second, created_at: v.third} }
+      .all_completed_step_runs
+      .map { |run| run.slice(:build_version, :build_number, :updated_at, :platform) }
   end
 
   def release_param

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -1,13 +1,15 @@
 class Api::V1::ReleasesController < ApiController
   def show
     head :not_found and return if release.blank?
-    render json: {versions: all_versions}, status: :ok
+    render json: {releases: all_versions}, status: :ok
   end
 
   private
 
   def release
-    @release ||= Release.where(branch_name: release_param).or(Release.where(id: release_param)).sole
+    @release ||=
+      authorized_organization.releases.where(branch_name: release_param)
+        .or(authorized_organization.releases.where(id: release_param)).sole
   end
 
   def all_versions

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -12,10 +12,7 @@ class Api::V1::ReleasesController < ApiController
   end
 
   def all_versions
-    release
-      .all_store_step_runs
-      .map(&:release_info)
-      .group_by(&:platform)
+    release.all_store_step_runs.map(&:release_info).group_by { _1[:platform] }
   end
 
   def release_param

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -12,9 +12,7 @@ class Api::V1::ReleasesController < ApiController
   end
 
   def all_versions
-    release
-      .all_completed_step_runs
-      .map { |run| run.slice(:build_version, :build_number, :updated_at, :platform) }
+    release.all_store_step_runs.map(&:release_info)
   end
 
   def release_param

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -14,7 +14,6 @@ class Api::V1::ReleasesController < ApiController
     release
       .all_completed_versions
       .map { |v| {version: v[:build_version], build: v[:build_number], created_at: v[:created_at]} }
-      .sort_by(&:created_at)
   end
 
   def release_param

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -12,7 +12,10 @@ class Api::V1::ReleasesController < ApiController
   end
 
   def all_versions
-    release.all_store_step_runs.map(&:release_info)
+    release
+      .all_store_step_runs
+      .map(&:release_info)
+      .group_by(&:platform)
   end
 
   def release_param

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::ReleasesController < ApiController
   def all_versions
     release
       .all_completed_versions
-      .map { |v| {version: v[:build_version], build: v[:build_number], created_at: v[:created_at]} }
+      .map { |v| {version: v.first, build: v.second, created_at: v.third} }
   end
 
   def release_param

--- a/app/controllers/api/v1/releases_controller.rb
+++ b/app/controllers/api/v1/releases_controller.rb
@@ -1,0 +1,23 @@
+class Api::V1::ReleasesController < ApiController
+  def show
+    head :not_found and return if release.blank?
+    render json: {versions: all_versions}, status: :ok
+  end
+
+  private
+
+  def release
+    @release ||= Release.where(branch_name: release_param).or(Release.where(id: release_param)).sole
+  end
+
+  def all_versions
+    release
+      .all_completed_versions
+      .map { |v| {version: v[:build_version], build: v[:build_number], created_at: v[:created_at]} }
+      .sort_by(&:created_at)
+  end
+
+  def release_param
+    params.require(:release_id)
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,8 @@
+class ApiController < ActionController::Base
+  before_action :authenticate
+  skip_before_action :verify_authenticity_token
+
+  def current_user
+    nil
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,4 +1,4 @@
-class ApiController < ActionController::Base
+class ApiController < ApplicationController
   before_action :authorized_organization?
   before_action :authenticate
   skip_before_action :verify_authenticity_token

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -7,7 +7,7 @@ class ApiController < ActionController::Base
     head :bad_request
   end
 
-  rescue_from ActiveRecord::RecordNotFound do
+  rescue_from ActiveRecord::RecordNotFound, ActiveRecord::SoleRecordExceeded do
     head :not_found
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,8 +1,27 @@
 class ApiController < ActionController::Base
+  before_action :authorized_organization?
   before_action :authenticate
   skip_before_action :verify_authenticity_token
 
-  def current_user
-    nil
+  rescue_from ActionController::ParameterMissing do
+    head :bad_request
+  end
+
+  rescue_from ActiveRecord::RecordNotFound do
+    head :not_found
+  end
+
+  def authorized_organization?
+    head(:unauthorized) if authorized_organization.blank?
+  end
+
+  def authenticate
+    authenticate_or_request_with_http_token do |token, _options|
+      ActiveSupport::SecurityUtils.secure_compare(token, authorized_organization.api_key)
+    end
+  end
+
+  def authorized_organization
+    @organization ||= Accounts::Organization.where(id: request.headers["HTTP_X_TRAMLINE_ACCOUNT_ID"]).first
   end
 end

--- a/app/helpers/clipboard_helper.rb
+++ b/app/helpers/clipboard_helper.rb
@@ -1,0 +1,12 @@
+module ClipboardHelper
+  DEFAULT_BUTTON_STYLES = "text-gray-500 absolute bottom-0 top-6 right-0 flex items-center cursor-pointer "
+  def copy_to_clipboard_button(target, styles: "")
+    content_tag(:button,
+      type: "button",
+      data: {action: "clipboard#copy", clipboard_target: target},
+      tabindex: "-1",
+      class: DEFAULT_BUTTON_STYLES + styles) do
+      inline_svg("clipboard_copy.svg", classname: "inline-flex w-5")
+    end
+  end
+end

--- a/app/helpers/password_helper.rb
+++ b/app/helpers/password_helper.rb
@@ -1,6 +1,7 @@
 module PasswordHelper
-  def password_visibility_toggle_button
-    button_styles = "text-gray-500 absolute bottom-0 top-8 right-0 pr-3 flex items-center cursor-pointer"
+  DEFAULT_BUTTON_STYLES = "text-gray-500 absolute bottom-0 top-8 right-0 flex items-center cursor-pointer "
+  def password_toggle_button(styles: "")
+    button_styles = DEFAULT_BUTTON_STYLES + styles
     visibility_target = {"password-visibility-target": "icon"}
 
     content_tag(:button, type: "button", data: {action: "password-visibility#toggle"}, tabindex: -1, class: button_styles) do

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -20,3 +20,6 @@ application.register("nested-form", NestedForm)
 
 import PasswordVisibility from "stimulus-password-visibility"
 application.register("password-visibility", PasswordVisibility)
+
+import Clipboard from "stimulus-clipboard"
+application.register("clipboard", Clipboard)

--- a/app/models/accounts/organization.rb
+++ b/app/models/accounts/organization.rb
@@ -26,7 +26,7 @@ class Accounts::Organization < ApplicationRecord
 
   encrypts :api_key, deterministic: true
 
-  after_create :generate_api_key
+  after_create :rotate_api_key
 
   validates :name, presence: true
 
@@ -51,10 +51,6 @@ class Accounts::Organization < ApplicationRecord
   end
 
   def rotate_api_key
-    update(api_key: generate_api_key)
-  end
-
-  def generate_api_key
-    SecureRandom.hex
+    update(api_key: SecureRandom.hex)
   end
 end

--- a/app/models/accounts/organization.rb
+++ b/app/models/accounts/organization.rb
@@ -3,6 +3,7 @@
 # Table name: organizations
 #
 #  id         :uuid             not null, primary key
+#  api_key    :string
 #  created_by :string           not null
 #  name       :string           not null
 #  slug       :string           indexed
@@ -22,6 +23,10 @@ class Accounts::Organization < ApplicationRecord
 
   enum status: {active: "active", dormant: "dormant", guest: "guest"}
 
+  encrypts :api_key, deterministic: true
+
+  after_create :generate_api_key
+
   validates :name, presence: true
 
   friendly_id :name, use: :slugged
@@ -38,5 +43,13 @@ class Accounts::Organization < ApplicationRecord
 
   def owner
     users.includes(:memberships).where(memberships: {role: "owner"}).sole
+  end
+
+  def rotate_api_key
+    update(api_key: generate_api_key)
+  end
+
+  def generate_api_key
+    SecureRandom.hex
   end
 end

--- a/app/models/accounts/organization.rb
+++ b/app/models/accounts/organization.rb
@@ -19,6 +19,7 @@ class Accounts::Organization < ApplicationRecord
   has_many :memberships, dependent: :delete_all, inverse_of: :organization
   has_many :users, through: :memberships, dependent: :delete_all
   has_many :apps, -> { sequential }, dependent: :destroy, inverse_of: :organization
+  has_many :releases, through: :apps
   has_many :invites, dependent: :destroy
 
   enum status: {active: "active", dormant: "dormant", guest: "guest"}

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -99,7 +99,7 @@ class App < ApplicationRecord
     trains.first if trains.size == 1
   end
 
-  def latest_computed_store_version
+  def latest_store_step_run
     deployment_runs
       .ready
       .includes(:step_run, :deployment)
@@ -107,7 +107,6 @@ class App < ApplicationRecord
       .sort_by(&:updated_at)
       .last
       &.step_run
-      &.then { [_1.build_version, _1.build_number, _1.created_at, _1.release_platform_run.platform] }
   end
 
   # NOTE: fetches and uses latest build numbers from the stores, if added,

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -92,14 +92,12 @@ class App < ApplicationRecord
     trains.first if trains.size == 1
   end
 
-  def latest_store_step_run
+  def latest_store_step_runs
     deployment_runs
-      .ready
-      .includes(:step_run, :deployment)
-      .select(&:production_channel?)
-      .sort_by(&:updated_at)
-      .last
-      &.step_run
+      .reached_production
+      .group_by(&:platform)
+      .to_h { |platform, runs| [platform, runs.max_by(&:updated_at)&.step_run] }
+      .values
   end
 
   # NOTE: fetches and uses latest build numbers from the stores, if added,

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -107,7 +107,7 @@ class App < ApplicationRecord
       .sort_by(&:updated_at)
       .last
       &.step_run
-      &.pluck(:build_version, :build_number, :created_at)
+      &.then { [_1.build_version, _1.build_number, _1.created_at, _1.release_platform_run.platform] }
   end
 
   # NOTE: fetches and uses latest build numbers from the stores, if added,

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -150,6 +150,7 @@ class DeploymentRun < ApplicationRecord
   scope :matching_runs_for, ->(integration) { includes(:deployment).where(deployments: {integration: integration}) }
   scope :has_begun, -> { where.not(status: :created) }
   scope :not_failed, -> { where.not(status: [:failed, :failed_prepare_release]) }
+  scope :ready, -> { where(status: [:rollout_started, :released]) }
 
   after_commit -> { create_stamp!(data: stamp_data) }, on: :create
 

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -82,6 +82,8 @@ class DeploymentRun < ApplicationRecord
     failed: "failed"
   }
 
+  READY_STATES = [STATES[:rollout_started], STATES[:ready_to_release]]
+
   enum status: STATES
   enum failure_reason: {
     review_failed: "review_failed",
@@ -150,7 +152,7 @@ class DeploymentRun < ApplicationRecord
   scope :matching_runs_for, ->(integration) { includes(:deployment).where(deployments: {integration: integration}) }
   scope :has_begun, -> { where.not(status: :created) }
   scope :not_failed, -> { where.not(status: [:failed, :failed_prepare_release]) }
-  scope :ready, -> { where(status: [:rollout_started, :released]) }
+  scope :ready, -> { where(status: READY_STATES) }
 
   after_commit -> { create_stamp!(data: stamp_data) }, on: :create
 

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -55,7 +55,7 @@ class DeploymentRun < ApplicationRecord
     :internal_channel?,
     to: :deployment
   delegate :release_metadata, :train, to: :release
-  delegate :release_version, to: :release_platform_run
+  delegate :release_version, :platform, to: :release_platform_run
 
   STAMPABLE_REASONS = %w[
     created

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -128,14 +128,13 @@ class Release < ApplicationRecord
 
   def self.for_branch(branch_name) = find_by(branch_name:)
 
-  def all_completed_versions
+  def all_completed_step_runs
     deployment_runs
       .ready
       .includes(:step_run, :deployment)
-      .select(&:production_channel?)
+      .filter(&:production_channel?)
       .map(&:step_run)
       .sort_by(&:updated_at)
-      .pluck(:build_version, :build_number, :created_at)
   end
 
   def unmerged_commits

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -131,9 +131,10 @@ class Release < ApplicationRecord
   def all_completed_versions
     deployment_runs
       .ready
-      .includes(:step_run)
+      .includes(:step_run, :deployment)
       .select(&:production_channel?)
       .map(&:step_run)
+      .sort_by(&:updated_at)
       .pluck(:build_version, :build_number, :created_at)
   end
 

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -128,11 +128,9 @@ class Release < ApplicationRecord
 
   def self.for_branch(branch_name) = find_by(branch_name:)
 
-  def all_completed_step_runs
+  def all_store_step_runs
     deployment_runs
-      .ready
-      .includes(:step_run, :deployment)
-      .filter(&:production_channel?)
+      .reached_production
       .map(&:step_run)
       .sort_by(&:updated_at)
   end

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -257,7 +257,7 @@ class ReleasePlatformRun < ApplicationRecord
   # and so a version bump is required for iOS once the build has been approved as well
   def version_bump_required?
     return latest_deployed_store_release&.rollout_started? if release_platform.android?
-    latest_deployed_store_release&.status&.in? [DeploymentRun::STATES[:rollout_started], DeploymentRun::STATES[:ready_to_release]]
+    latest_deployed_store_release&.status&.in? DeploymentRun::READY_STATES
   end
 
   def hotfix?

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -164,7 +164,7 @@ class StepRun < ApplicationRecord
   attr_accessor :current_user
   attr_accessor :artifacts_url
 
-  delegate :release_platform, :release, to: :release_platform_run
+  delegate :release_platform, :release, :platform, to: :release_platform_run
   delegate :release_branch, to: :release
   delegate :train, to: :release_platform
   delegate :app, :ci_cd_provider, :unzip_artifact?, :notify!, to: :train

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -331,6 +331,10 @@ class StepRun < ApplicationRecord
     trigger_ci!
   end
 
+  def release_info
+    slice(:build_version, :build_number, :updated_at, :platform)
+  end
+
   private
 
   def previous_step_run

--- a/app/views/accounts/organizations/edit.html.erb
+++ b/app/views/accounts/organizations/edit.html.erb
@@ -1,0 +1,36 @@
+<%= render PageComponent.new(breadcrumb: breadcrumb(:team), title: "Settings: #{@organization.name} 🧑‍🦰") do |page| %>
+  <div class="mb-8">
+    <h2 class="text-2xl text-slate-800 font-bold">API Settings</h2>
+    <span class="text-sm text-slate-400">Use these credentials to make API calls to Tramline. See the available APIs here.</span>
+  </div>
+
+  <div class="flex flex-col gap-y-8">
+    <div data-controller="clipboard" data-clipboard-success-content-value="copied!">
+      <div class="relative w-1/3">
+        <label class="block text-sm font-medium mb-1" for="account_id">Account ID</label>
+        <input type="text"
+               id="account_id"
+               readonly
+               value="<%= @organization.id %>"
+               data-clipboard-target="source"
+               class="form-input w-full"/>
+        <%= copy_to_clipboard_button("button", styles: "mr-3") %>
+      </div>
+    </div>
+
+    <div data-controller="password-visibility clipboard" data-clipboard-success-content-value="copied!">
+      <div class="relative w-1/3">
+        <label class="block text-sm font-medium mb-1" for="api_key">API Key</label>
+        <input type="password"
+               id="api_key"
+               readonly
+               value="<%= @organization.api_key %>"
+               data-clipboard-target="source"
+               data-password-visibility-target="input"
+               class="form-input w-full"/>
+        <%= password_toggle_button(styles: "mr-3") %>
+        <%= copy_to_clipboard_button("button", styles: "mr-10") %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/accounts/organizations/edit.html.erb
+++ b/app/views/accounts/organizations/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageComponent.new(breadcrumb: breadcrumb(:team), title: "Settings: #{@organization.name} 🧑‍🦰") do |page| %>
   <div class="mb-8">
     <h2 class="text-2xl text-slate-800 font-bold">API Settings</h2>
-    <span class="text-sm text-slate-400">Use these credentials to make API calls to Tramline. See all the available APIs here.</span>
+    <span class="text-sm text-slate-400">Use these credentials to make API calls to Tramline. See all the available APIs <%= link_to_external "here", "https://docs.tramline.app/api", class: "underline" %>.</span>
   </div>
 
   <div class="flex flex-col gap-y-8">

--- a/app/views/accounts/organizations/edit.html.erb
+++ b/app/views/accounts/organizations/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageComponent.new(breadcrumb: breadcrumb(:team), title: "Settings: #{@organization.name} 🧑‍🦰") do |page| %>
   <div class="mb-8">
     <h2 class="text-2xl text-slate-800 font-bold">API Settings</h2>
-    <span class="text-sm text-slate-400">Use these credentials to make API calls to Tramline. See the available APIs here.</span>
+    <span class="text-sm text-slate-400">Use these credentials to make API calls to Tramline. See all the available APIs here.</span>
   </div>
 
   <div class="flex flex-col gap-y-8">

--- a/app/views/authentication/registrations/new.html.erb
+++ b/app/views/authentication/registrations/new.html.erb
@@ -46,7 +46,7 @@
                                data: { password_visibility_target: "input"},
                                placeholder: "Minimum #{@minimum_password_length} characters",
                                class: "form-input w-full" %>
-          <%= password_toggle_button %>
+          <%= password_toggle_button(styles: "mr-3") %>
         </div>
       </div>
 
@@ -59,7 +59,7 @@
                                data: { password_visibility_target: "input"},
                                autocomplete: "new-password",
                                class: "form-input w-full" %>
-          <%= password_toggle_button %>
+          <%= password_toggle_button(styles: "mr-3") %>
         </div>
       </div>
 

--- a/app/views/authentication/registrations/new.html.erb
+++ b/app/views/authentication/registrations/new.html.erb
@@ -46,7 +46,7 @@
                                data: { password_visibility_target: "input"},
                                placeholder: "Minimum #{@minimum_password_length} characters",
                                class: "form-input w-full" %>
-          <%= password_visibility_toggle_button %>
+          <%= password_toggle_button %>
         </div>
       </div>
 
@@ -59,7 +59,7 @@
                                data: { password_visibility_target: "input"},
                                autocomplete: "new-password",
                                class: "form-input w-full" %>
-          <%= password_visibility_toggle_button %>
+          <%= password_toggle_button %>
         </div>
       </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,7 +10,8 @@
 
       <!-- Header: Right side -->
       <div class="flex items-center space-x-3">
-        <% if subscribed_org? %><%= status_badge("Subscriber", :routine) %><% end %>
+        <% if subscribed_org? %><%= status_badge("Subscriber", :routine) %>
+        <% end %>
         <hr class="w-px h-6 bg-slate-200"/>
         <div class="relative inline-flex" data-controller="reveal" data-reveal-away-value="true">
           <button
@@ -35,6 +36,14 @@
             </div>
 
             <ul>
+              <% if writer? %>
+                <li>
+                  <%= link_to "Settings",
+                              edit_accounts_organization_path(current_organization),
+                              "data-turbo": false,
+                              class: "font-medium text-sm text-indigo-500 hover:text-indigo-600 flex items-center py-1 px-3" %>
+                </li>
+              <% end %>
               <li>
                 <%= link_to "Team",
                             accounts_organization_team_path(current_organization),

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -23,3 +23,4 @@ pin "stimulus-rails-nested-form", to: "https://ga.jspm.io/npm:stimulus-rails-nes
 pin "stimulus-use", to: "https://ga.jspm.io/npm:stimulus-use@0.51.3/dist/index.js"
 pin "hotkeys-js", to: "https://ga.jspm.io/npm:hotkeys-js@3.10.1/dist/hotkeys.esm.js"
 pin "stimulus-password-visibility", to: "https://ga.jspm.io/npm:stimulus-password-visibility@2.1.1/dist/stimulus-password-visibility.mjs"
+pin "stimulus-clipboard", to: "https://ga.jspm.io/npm:stimulus-clipboard@4.0.1/dist/stimulus-clipboard.mjs"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
   end
 
   namespace :accounts do
-    resources :organizations, only: [:index] do
+    resources :organizations, only: [:edit, :update, :index] do
       member do
         get :switch
       end
@@ -167,11 +167,12 @@ Rails.application.routes.draw do
     resource :settings, only: [:index]
   end
 
-  namespace :api, defaults: { format: "json" } do
+  namespace :api, defaults: {format: "json"} do
     namespace :v1, path: "v1" do
       get "ping", to: "pings#show"
+      get "releases/*release_id", to: "releases#show"
       scope :apps do
-        get :status, to: "apps#status"
+        get :status, to: "releases#show"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,9 +171,7 @@ Rails.application.routes.draw do
     namespace :v1, path: "v1" do
       get "ping", to: "pings#show"
       get "releases/*release_id", to: "releases#show"
-      scope :apps do
-        get :status, to: "releases#show"
-      end
+      get "apps/*app_id", to: "apps#show"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,6 +167,15 @@ Rails.application.routes.draw do
     resource :settings, only: [:index]
   end
 
+  namespace :api, defaults: { format: "json" } do
+    namespace :v1, path: "v1" do
+      get "ping", to: "pings#show"
+      scope :apps do
+        get :status, to: "apps#status"
+      end
+    end
+  end
+
   scope :github do
     get :callback, controller: "integration_listeners/github", as: :github_callback
     post "/events/:train_id", to: "integration_listeners/github#events", as: :github_events

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
   end
 
   namespace :accounts do
-    resources :organizations, only: [:edit, :update, :index] do
+    resources :organizations, only: [:edit, :index] do
       member do
         get :switch
       end

--- a/db/migrate/20230912130953_add_api_key_to_organization.rb
+++ b/db/migrate/20230912130953_add_api_key_to_organization.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToOrganization < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :api_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_11_074926) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_12_130953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -287,6 +287,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_074926) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "subscribed", default: false
+    t.string "api_key"
     t.index ["slug"], name: "index_organizations_on_slug", unique: true
     t.index ["status"], name: "index_organizations_on_status"
   end


### PR DESCRIPTION
Add two API endpoints under the v1 scheme:

* apps API fetches latest production store deployment across the app trains
* releases API fetches the all the released store version for the specific release (works on branch or id)

Additionally, a `ping` API for testing