### PR TITLE
Enhance Play Store release notes and notifications

### DIFF
--- a/app/libs/notifiers/slack/renderers/base.rb
+++ b/app/libs/notifiers/slack/renderers/base.rb
@@ -37,4 +37,16 @@ class Notifiers::Slack::Renderers::Base
   end
 
   def safe_string(s) = escape_javascript(s)
+
+  def google_managed_publishing_text
+    "- If managed publishing is disabled, this update will auto-start the rollout upon approval by Google."
+  end
+
+  def google_unmanaged_publishing_text
+    "- If managed publishing is enabled, you'll need to manually release this update through the Play Store."
+  end
+
+  def apple_publishing_text
+    "- Releases from Tramline are always manually released, you can start the release to users once it is approved from the Live Release page."
+  end
 end

--- a/app/libs/notifiers/slack/renderers/deployment_finished.rb
+++ b/app/libs/notifiers/slack/renderers/deployment_finished.rb
@@ -6,6 +6,10 @@ module Notifiers
       def sanitized_build_notes
         safe_string("*Build notes*\n```#{@build_notes}```")
       end
+
+      def sanitized_release_notes
+        safe_string(":spiral_note_pad: *What's New*\n\n```#{@release_notes}```")
+      end
     end
   end
 end

--- a/app/libs/notifiers/slack/renderers/review_approved.rb
+++ b/app/libs/notifiers/slack/renderers/review_approved.rb
@@ -3,14 +3,6 @@ module Notifiers
     class Renderers::ReviewApproved < Renderers::Base
       TEMPLATE_FILE = "review_approved.json.erb".freeze
 
-      def google_managed_publishing_text
-        "- If managed publishing is disabled, this update will auto-start the rollout upon approval by Google."
-      end
-
-      def google_unmanaged_publishing_text
-        "- If managed publishing is enabled, you'll need to manually release this update through the Play Store."
-      end
-
       def apple_publishing_text
         "- Releases from Tramline are always manually released, you can start the release to users from the Live Release page."
       end

--- a/app/libs/notifiers/slack/renderers/staged_rollout_updated.rb
+++ b/app/libs/notifiers/slack/renderers/staged_rollout_updated.rb
@@ -13,9 +13,25 @@ module Notifiers
 
       def secondary_text
         if @is_fully_released
-          "View your release on the Play Console."
+          "View your release on the #{store}."
         else
-          "You can choose to *Pause* or *Release to 100%*."
+          action_text
+        end
+      end
+
+      def store
+        if @is_app_store_production
+          "App Store"
+        elsif @is_play_store_production
+          "Play Console"
+        end
+      end
+
+      def action_text
+        if @is_app_store_production
+          "You can choose to *Pause*, *Halt*, or *Release to 100%*."
+        elsif @is_play_store_production
+          "You can choose to *Increase*, *Halt*, or *Release to 100%*."
         end
       end
     end

--- a/app/libs/notifiers/slack/renderers/submit_for_review.rb
+++ b/app/libs/notifiers/slack/renderers/submit_for_review.rb
@@ -4,19 +4,7 @@ module Notifiers
       TEMPLATE_FILE = "submit_for_review.json.erb".freeze
 
       def sanitized_release_notes
-        safe_string(":spiral_note_pad: What's New\n\n```#{@release_notes}```")
-      end
-
-      def google_managed_publishing_text
-        "- If managed publishing is disabled, this update will auto-start the rollout upon approval by Google."
-      end
-
-      def google_unmanaged_publishing_text
-        "- If managed publishing is enabled, you'll need to manually release this update through the Play Store."
-      end
-
-      def apple_publishing_text
-        "- Releases from Tramline are always manually released, you can start the release to users once it is approved from the Live Release page."
+        safe_string(":spiral_note_pad: *What's New*\n\n```#{@release_notes}```")
       end
     end
   end

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -93,6 +93,10 @@ class Deployment < ApplicationRecord
     build_artifact_channel["is_internal"]
   end
 
+  def requires_review?
+    google_play_store_integration? && deployment_channel.in?(%w[production beta alpha])
+  end
+
   def integration_type
     return :app_store if app_store?
     return :testflight if test_flight?
@@ -125,7 +129,8 @@ class Deployment < ApplicationRecord
           is_app_store_production: app_store?,
           deployment_channel_type: integration_type&.to_s&.titleize,
           deployment_channel: build_artifact_channel,
-          deployment_channel_asset_link: integration&.public_icon_img
+          deployment_channel_asset_link: integration&.public_icon_img,
+          requires_review: requires_review?
         }
       )
   end

--- a/app/models/google_play_store_integration.rb
+++ b/app/models/google_play_store_integration.rb
@@ -45,15 +45,15 @@ class GooglePlayStoreIntegration < ApplicationRecord
     Installations::Google::PlayDeveloper::Api.new(app.bundle_identifier, access_key)
   end
 
-  def rollout_release(channel, build_number, version, rollout_percentage, release_metadata)
+  def rollout_release(channel, build_number, version, rollout_percentage, release_notes)
     GitHub::Result.new do
-      installation.create_release(channel, build_number, version, rollout_percentage, release_notes(release_metadata))
+      installation.create_release(channel, build_number, version, rollout_percentage, release_notes)
     end
   end
 
-  def create_draft_release(channel, build_number, version, release_metadata)
+  def create_draft_release(channel, build_number, version, release_notes)
     GitHub::Result.new do
-      installation.create_draft_release(channel, build_number, version, release_notes(release_metadata))
+      installation.create_draft_release(channel, build_number, version, release_notes)
     end
   end
 
@@ -176,16 +176,5 @@ class GooglePlayStoreIntegration < ApplicationRecord
 
   def project_id
     JSON.parse(json_key)["project_id"]&.split("-")&.third
-  end
-
-  def release_notes(release_metadata)
-    return [] if release_metadata.blank?
-
-    release_metadata.map do |rd|
-      {
-        language: rd.locale,
-        text: rd.release_notes
-      }
-    end
   end
 end

--- a/app/views/notifiers/slack/deployment_finished.json.erb
+++ b/app/views/notifiers/slack/deployment_finished.json.erb
@@ -18,9 +18,18 @@
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "New *<%= @deployment_channel_type %>* build *<%= @build_number %>* is now available to *<%= deployment_channel_display_name %>* :sparkles:"
+        "text": "New *<%= @deployment_channel_type %>* build *<%= @release_version %> (<%= @build_number %>)* is now available to *<%= deployment_channel_display_name %>* :sparkles:"
       }
     },
+    <% if @is_production_channel %>
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "<%= sanitized_release_notes %>"
+      }
+    },
+    <% else %>
     {
       "type": "section",
       "text": {
@@ -28,6 +37,29 @@
         "text": "<%= sanitized_build_notes %>"
       }
     },
+    <% end %>
+    <% if @requires_review %>
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "plain_text",
+          "text": "<%= google_managed_publishing_text %>",
+          "emoji": false
+        }
+      ]
+    },
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "plain_text",
+          "text": "<%= google_unmanaged_publishing_text %>",
+          "emoji": false
+        }
+      ]
+    },
+    <% end %>
     {
       "type": "divider"
     },

--- a/app/views/notifiers/slack/review_approved.json.erb
+++ b/app/views/notifiers/slack/review_approved.json.erb
@@ -21,28 +21,6 @@
         "text": "*<%= @app_name %> (<%= @app_platform %>)* <%= @release_version %> (<%= @build_number %>) has been approved by the store to distribute to <%= @deployment_channel_type %> (<%= deployment_channel_display_name %>)! :tada:"
       }
     },
-    <% if @is_play_store_production %>
-    {
-      "type": "context",
-      "elements": [
-        {
-          "type": "plain_text",
-          "text": "<%= google_managed_publishing_text %>",
-          "emoji": false
-        }
-      ]
-    },
-    {
-      "type": "context",
-      "elements": [
-        {
-          "type": "plain_text",
-          "text": "<%= google_unmanaged_publishing_text %>",
-          "emoji": false
-        }
-      ]
-    },
-    <% end %>
     <% if @is_app_store_production %>
     {
       "type": "context",

--- a/app/views/notifiers/slack/staged_rollout_updated.json.erb
+++ b/app/views/notifiers/slack/staged_rollout_updated.json.erb
@@ -30,6 +30,28 @@
       }
     },
     <% end %>
+    <% if @is_play_store_production %>
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "plain_text",
+          "text": "<%= google_managed_publishing_text %>",
+          "emoji": false
+        }
+      ]
+    },
+    {
+      "type": "context",
+      "elements": [
+        {
+          "type": "plain_text",
+          "text": "<%= google_unmanaged_publishing_text %>",
+          "emoji": false
+        }
+      ]
+    },
+    <% end %>
     {
       "type": "divider"
     },

--- a/app/views/notifiers/slack/submit_for_review.json.erb
+++ b/app/views/notifiers/slack/submit_for_review.json.erb
@@ -28,28 +28,6 @@
         "text": "<%= sanitized_release_notes %>"
       }
     },
-    <% if @is_play_store_production %>
-    {
-      "type": "context",
-      "elements": [
-        {
-          "type": "plain_text",
-          "text": "<%= google_managed_publishing_text %>",
-          "emoji": false
-        }
-      ]
-    },
-    {
-      "type": "context",
-      "elements": [
-        {
-          "type": "plain_text",
-          "text": "<%= google_unmanaged_publishing_text %>",
-          "emoji": false
-        }
-      ]
-    },
-    <% end %>
     <% if @is_app_store_production %>
     {
       "type": "context",

--- a/spec/models/deployment_run_spec.rb
+++ b/spec/models/deployment_run_spec.rb
@@ -303,7 +303,7 @@ describe DeploymentRun do
               anything,
               anything,
               full_release_value,
-              [run.step_run.release.release_metadata]
+              anything
             )
         )
         expect(run.reload.released?).to be(true)

--- a/spec/models/staged_rollout_spec.rb
+++ b/spec/models/staged_rollout_spec.rb
@@ -190,7 +190,7 @@ describe StagedRollout do
       rollout.move_to_next_stage!
       expect(providable_dbl).to(
         have_received(:rollout_release)
-          .with(anything, anything, anything, 1, [release_metadata])
+          .with(anything, anything, anything, 1, anything)
       )
       expect(rollout.reload.started?).to be(true)
     end
@@ -202,7 +202,7 @@ describe StagedRollout do
       rollout.move_to_next_stage!
       expect(providable_dbl).to(
         have_received(:rollout_release)
-          .with(anything, anything, anything, 100, [release_metadata])
+          .with(anything, anything, anything, 100, anything)
       )
     end
 


### PR DESCRIPTION
- send build notes to non-production channels
- adds publishing helper text to deployment finished notification
- adds publishing helper text to all staged rollout notifications
- adds publishing helper text for all channels that require review
- adds version name to deployment finished notification
- removes submit for review and review approved notifications