### PR TITLE
Retries around some Google Play Store errors

### DIFF
--- a/app/libs/installations/google/play_developer/api.rb
+++ b/app/libs/installations/google/play_developer/api.rb
@@ -140,7 +140,7 @@ module Installations
 
     def execute
       yield if block_given?
-    rescue ::Google::Apis::ServerError, ::Google::Apis::ClientError => e
+    rescue ::Google::Apis::ServerError, ::Google::Apis::ClientError, ::Google::Apis::AuthorizationError => e
       raise Installations::Google::PlayDeveloper::Error.new(e)
     end
 

--- a/app/libs/installations/google/play_developer/error.rb
+++ b/app/libs/installations/google/play_developer/error.rb
@@ -30,6 +30,12 @@ module Installations
       {
         status: "PERMISSION_DENIED",
         code: 403,
+        message_matcher: /Unauthorized/,
+        decorated_reason: :unauthorized
+      },
+      {
+        status: "PERMISSION_DENIED",
+        code: 403,
         message_matcher: /Google Play Android Developer API has not been used in project/,
         decorated_reason: :api_disabled
       },
@@ -37,7 +43,13 @@ module Installations
         status: "FAILED_PRECONDITION",
         code: 400,
         message_matcher: /This Edit has been deleted/,
-        decorated_reason: :duplicate_build_upload
+        decorated_reason: :duplicate_call
+      },
+      {
+        status: "FAILED_PRECONDITION",
+        code: 400,
+        message_matcher: /This edit has expired/,
+        decorated_reason: :timeout
       },
       {
         status: "PERMISSION_DENIED",

--- a/app/models/app_store_integration.rb
+++ b/app/models/app_store_integration.rb
@@ -208,6 +208,8 @@ class AppStoreIntegration < ApplicationRecord
 
   def channel_data
     installation.current_app_status(CHANNEL_DATA_TRANSFORMATIONS)
+  rescue Installations::Apple::AppStoreConnect::Error => e
+    elog(e)
   end
 
   def build_channels(with_production:)


### PR DESCRIPTION
- Handle intermittent unauthorized errors from Play Store
- Add retry for edit expired, deleted, and unauthorized errors
- Ensure refreshing external apps does not throw 500 on error