### PR TITLE
Allow deployments to be soft-deleted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,3 +109,5 @@ group :test do
   gem "simplecov"
   gem "webmock"
 end
+
+gem "discard", "~> 1.3"

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ gem "google-apis-firebase_v1beta1", "~> 0.35.0"
 gem "initials", "~> 0.4.3"
 gem "rack-attack", "~> 6.7"
 gem "june-analytics-ruby", "~> 2.4"
+gem "discard", "~> 1.3"
 
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]
@@ -109,5 +110,3 @@ group :test do
   gem "simplecov"
   gem "webmock"
 end
-
-gem "discard", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
     diff-lcs (1.5.0)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
+    discard (1.3.0)
+      activerecord (>= 4.2, < 8)
     docile (1.4.0)
     dogstatsd-ruby (5.5.0)
     domain_name (0.5.20190701)
@@ -612,6 +614,7 @@ DEPENDENCIES
   debug
   device_detector (~> 1.0)
   devise (~> 4.8)
+  discard (~> 1.3)
   dogstatsd-ruby (~> 5.5)
   dotenv-rails (~> 2.7)
   down (~> 5.3)

--- a/app/libs/queries/builds.rb
+++ b/app/libs/queries/builds.rb
@@ -50,7 +50,7 @@ class Queries::Builds
 
   def android_all
     selected_android_records.to_a.map do |record|
-      deployments = record.step_run.step.deployments
+      deployments = record.step_run.deployment_runs.map(&:deployment)
       attributes =
         record
           .attributes

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -5,6 +5,7 @@
 #  id                     :uuid             not null, primary key
 #  build_artifact_channel :jsonb            indexed => [integration_id, step_id]
 #  deployment_number      :integer          default(0), not null, indexed => [step_id]
+#  discarded_at           :datetime         indexed
 #  is_staged_rollout      :boolean          default(FALSE)
 #  staged_rollout_config  :decimal(, )      default([]), is an Array
 #  created_at             :datetime         not null
@@ -15,6 +16,7 @@
 class Deployment < ApplicationRecord
   has_paper_trail
   include Displayable
+  include Discard::Model
 
   self.implicit_order_column = :deployment_number
 
@@ -46,7 +48,7 @@ class Deployment < ApplicationRecord
   def staged_rollout? = is_staged_rollout
 
   def set_deployment_number
-    self.deployment_number = step.deployments.maximum(:deployment_number).to_i + 1
+    self.deployment_number = step.all_deployments.maximum(:deployment_number).to_i + 1
   end
 
   def external?

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -196,7 +196,7 @@ class Release < ApplicationRecord
   end
 
   def end_time
-    completed_at || stopped_at || Time.current
+    completed_at || stopped_at
   end
 
   def fetch_commit_log

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -195,6 +195,10 @@ class Release < ApplicationRecord
     may_stop?
   end
 
+  def end_time
+    completed_at || stopped_at || Time.current
+  end
+
   def fetch_commit_log
     if upcoming?
       ongoing_head = train.ongoing_release.first_commit

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -153,14 +153,14 @@ class ReleasePlatformRun < ApplicationRecord
     return true if step.first? && step_runs_for(step).empty?
     return false if step.first?
 
-    (next_step == step) && previous_step_run_for(step)&.success?
+    (next_step == step) && previous_step_run_for(step).success?
   end
 
   def upcoming_startable_step?(step)
     return false if train.inactive?
     return false unless on_track?
 
-    (next_step == step) && previous_step_run_for(step)&.success? && upcoming_release_step?(step)
+    (next_step == step) && previous_step_run_for(step).success? && upcoming_release_step?(step)
   end
 
   def upcoming_release_step?(step)

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -153,14 +153,14 @@ class ReleasePlatformRun < ApplicationRecord
     return true if step.first? && step_runs_for(step).empty?
     return false if step.first?
 
-    (next_step == step) && previous_step_run_for(step).success?
+    (next_step == step) && previous_step_run_for(step)&.success?
   end
 
   def upcoming_startable_step?(step)
     return false if train.inactive?
     return false unless on_track?
 
-    (next_step == step) && previous_step_run_for(step).success? && upcoming_release_step?(step)
+    (next_step == step) && previous_step_run_for(step)&.success? && upcoming_release_step?(step)
   end
 
   def upcoming_release_step?(step)

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -24,9 +24,9 @@ class Step < ApplicationRecord
 
   belongs_to :release_platform, inverse_of: :steps
   has_many :step_runs, inverse_of: :step, dependent: :destroy
-  has_many :deployments, -> { sequential }, inverse_of: :step, dependent: :destroy
+  has_many :deployments, -> { kept.sequential }, inverse_of: :step, dependent: :destroy
+  has_many :all_deployments, -> { sequential }, class_name: "Deployment", inverse_of: :step, dependent: :destroy
   has_many :deployment_runs, through: :deployments
-
   validates :ci_cd_channel, presence: true, uniqueness: {scope: :release_platform_id, message: "you have already used this in another step of this train!"}
   validates :release_suffix, format: {with: /\A[a-zA-Z\-_]+\z/, message: "only allows letters and underscore"}, if: -> { release_suffix.present? }
   validates :deployments, presence: true, on: :create
@@ -54,6 +54,11 @@ class Step < ApplicationRecord
   delegate :app, :train, to: :release_platform
   delegate :android?, to: :app
   delegate :ci_cd_provider, :notify!, to: :train
+
+  def active_deployments_for(release)
+    return deployments unless release
+    all_deployments.where("created_at < ?", release.scheduled_at).where("discarded_at IS NULL OR discarded_at >= ?", release.end_time)
+  end
 
   def set_step_number
     self.step_number = release_platform.steps.review.maximum(:step_number).to_i + 1

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -57,7 +57,11 @@ class Step < ApplicationRecord
 
   def active_deployments_for(release)
     return deployments unless release
-    all_deployments.where("created_at < ?", release.scheduled_at).where("discarded_at IS NULL OR discarded_at >= ?", release.end_time)
+    return deployments.where("created_at < ?", release.scheduled_at) if release.end_time.blank?
+
+    all_deployments
+      .where("created_at < ?", release.scheduled_at)
+      .where("discarded_at IS NULL OR discarded_at >= ?", release.end_time)
   end
 
   def set_step_number

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -251,7 +251,7 @@ class StepRun < ApplicationRecord
   end
 
   def first_deployment
-    step.deployments.find_by(deployment_number: 1)
+    step.deployments.order(deployment_number: :asc).first
   end
 
   def finished_deployments?

--- a/app/views/shared/_deployments.html.erb
+++ b/app/views/shared/_deployments.html.erb
@@ -1,12 +1,12 @@
 <ol>
-  <% step.deployments.each do |deployment| %>
+  <% step.active_deployments_for(platform_run&.release).each do |deployment| %>
     <li class="last:mb-0 mb-1">
       <div>
         <%= render partial: "shared/deployment", locals: { deployment: deployment } %>
 
         <% if show_deployment_status %>
           <%= render partial: "shared/live_release/deployment_status",
-                     locals: { step_run: step_run, deployment: deployment, release: release } %>
+                     locals: { step_run: step_run, deployment: deployment, platform_run: platform_run } %>
         <% else %>
           <% if deployment.staged_rollout? %>
             <div class="my-4 pt-4 ml-6 border-t border-dashed w-1/2">

--- a/app/views/shared/_per_step_metadata.html.erb
+++ b/app/views/shared/_per_step_metadata.html.erb
@@ -12,7 +12,7 @@
         <%= render partial: "trains/edit_step_button", locals: { editable: editable, step: step } %>
       <% end %>
 
-      <% if release.present? %>
+      <% if platform_run.present? %>
         <%= render partial: "shared/live_release/step_run_status", locals: { step_run: step_run, step: step } %>
       <% end %>
     </div>
@@ -40,7 +40,7 @@
       <div class="flex flex-row items-center w-full">
         <div class="inline-flex mr-1"></div>
         <%= render partial: "shared/deployments",
-                   locals: { step: step, step_run: step_run, release: release, show_deployment_status: release.present? } %>
+                   locals: { step: step, step_run: step_run, platform_run:, show_deployment_status: platform_run.present? } %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_step_tree_viz.html.erb
+++ b/app/views/shared/_step_tree_viz.html.erb
@@ -1,7 +1,7 @@
 <ol class="mt-2">
   <!-- review steps -->
   <% release_platform.steps.review.includes(deployments: [:integration]).order(:step_number).each do |step| %>
-    <li><%= render partial: "shared/per_step_metadata", locals: { editable: editable, step: step, step_run: nil, release: nil } %></li>
+    <li><%= render partial: "shared/per_step_metadata", locals: { editable: editable, step: step, step_run: nil, platform_run: nil } %></li>
     <%= render partial: "shared/step_tree_connector", locals: { color: step_color(step.kind) } %>
   <% end %>
 
@@ -12,7 +12,7 @@
   <% release_step = release_platform.steps.release.first %>
   <% if release_step %>
     <%= render partial: "shared/step_tree_connector", locals: { color: step_color("review") } %>
-    <li><%= render partial: "shared/per_step_metadata", locals: { editable: editable, step: release_step, step_run: nil, release: nil } %></li>
+    <li><%= render partial: "shared/per_step_metadata", locals: { editable: editable, step: release_step, step_run: nil, platform_run: nil } %></li>
   <% end %>
 
   <!-- add release button -->

--- a/app/views/shared/live_release/_deployment_status.html.erb
+++ b/app/views/shared/live_release/_deployment_status.html.erb
@@ -2,7 +2,7 @@
   <% if step_run.manually_startable_deployment?(deployment) %>
     <%= authz_button_to :blue,
                         "Start this deployment",
-                        start_release_step_run_deployment_path(release, step_run, deployment),
+                        start_release_step_run_deployment_path(platform_run, step_run, deployment),
                         { class: 'mt-2 btn-xs' } %>
   <% end %>
 

--- a/app/views/shared/live_release/_stability.html.erb
+++ b/app/views/shared/live_release/_stability.html.erb
@@ -63,7 +63,7 @@
 
           <div>
             <%= render partial: "shared/per_step_metadata",
-                       locals: { editable: false, release: release, step: step, step_run: step_run } %>
+                       locals: { editable: false, platform_run: release, step: step, step_run: step_run } %>
           </div>
         </li>
 

--- a/db/migrate/20231011072223_add_deleted_at_to_deployments.rb
+++ b/db/migrate/20231011072223_add_deleted_at_to_deployments.rb
@@ -1,0 +1,8 @@
+class AddDeletedAtToDeployments < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      add_column :deployments, :discarded_at, :datetime
+      add_index :deployments, :discarded_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_11_063020) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_11_072223) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -161,8 +161,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_11_063020) do
     t.datetime "updated_at", null: false
     t.decimal "staged_rollout_config", default: [], array: true
     t.boolean "is_staged_rollout", default: false
+    t.datetime "discarded_at"
     t.index ["build_artifact_channel", "integration_id", "step_id"], name: "idx_deployments_on_build_artifact_chan_and_integration_and_step", unique: true
     t.index ["deployment_number", "step_id"], name: "index_deployments_on_deployment_number_and_step_id", unique: true
+    t.index ["discarded_at"], name: "index_deployments_on_discarded_at"
     t.index ["integration_id"], name: "index_deployments_on_integration_id"
     t.index ["step_id"], name: "index_deployments_on_step_id"
   end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -129,6 +129,7 @@ describe Step do
 
   describe "#active_deployments_for" do
     let(:release_platform) { create(:release_platform) }
+    let(:train) { release_platform.train }
 
     it "returns all non-discarded deployments when no release is passed in" do
       step = create(:step, :with_deployment, release_platform: release_platform)
@@ -139,27 +140,50 @@ describe Step do
       expect(step.active_deployments_for(nil)).to contain_exactly(step.deployments.first, next_deployment)
     end
 
-    it "returns deployments active at the duration of the release" do
-      train = release_platform.train
+    it "returns deployments that were available in the past releases" do
       two_days_ago = 2.days.ago
       two_hours_ago = 2.hours.ago
       four_hours_ago = 2.hours.ago
+      step = travel_to(two_days_ago) { create(:step, :with_deployment, release_platform: release_platform) }
+      d1 = create(:deployment, step:, created_at: two_days_ago)
+      d2 = create(:deployment, step:, created_at: two_days_ago)
+      old_release = create(:release, train:, scheduled_at: four_hours_ago, completed_at: two_hours_ago)
+
+      d2.discard!
+
+      step.reload
+      expect(step.active_deployments_for(old_release)).to contain_exactly(step.deployments.first, d1, d2)
+    end
+
+    it "returns deployments active at the duration of the release" do
+      two_days_ago = 2.days.ago
+      step = travel_to(two_days_ago) { create(:step, :with_deployment, release_platform: release_platform) }
+      d1 = create(:deployment, step:, created_at: two_days_ago)
+      d2 = create(:deployment, step:, created_at: two_days_ago)
+
+      travel_to(1.minute.ago) { d2.discard! }
+      current_release = create(:release, train:, scheduled_at: Time.current)
+
+      step.reload
+      expect(step.active_deployments_for(current_release)).to contain_exactly(step.deployments.first, d1)
+    end
+
+    it "returns deployments that will be available for a new future release" do
+      two_days_ago = 2.days.ago
       two_hours_later = 2.hours.from_now
       four_hours_later = 4.hours.from_now
       step = travel_to(two_days_ago) { create(:step, :with_deployment, release_platform: release_platform) }
       d1 = create(:deployment, step:, created_at: two_days_ago)
       d2 = create(:deployment, step:, created_at: two_days_ago)
-
-      d2.discard!
-      old_release = create(:release, train:, scheduled_at: four_hours_ago, completed_at: two_hours_ago)
-      current_release = create(:release, train:, scheduled_at: Time.current)
-      travel_to(1.minute.from_now) { d1.discard! }
-      d3 = create(:deployment, step:)
       future_release = create(:release, train:, scheduled_at: two_hours_later, completed_at: four_hours_later)
 
-      step.reload
-      expect(step.active_deployments_for(old_release)).to contain_exactly(step.deployments.first, d1, d2)
-      expect(step.active_deployments_for(current_release)).to contain_exactly(step.deployments.first, d1)
+      travel_to(1.minute.ago) do
+        d1.discard!
+        d2.discard!
+      end
+
+      d3 = create(:deployment, step:)
+
       expect(step.active_deployments_for(future_release)).to contain_exactly(step.deployments.first, d3)
     end
   end


### PR DESCRIPTION
So that we can edit people's deployments without losing history for historical releases, at least from the backend for the time being.

Eventually in the future, we should have model snapshots.