### PR TITLE
Add config to manage release tags and allow tag suffix for a train

### DIFF
--- a/app/controllers/trains_controller.rb
+++ b/app/controllers/trains_controller.rb
@@ -116,7 +116,9 @@ class TrainsController < SignedInApplicationController
       :compact_build_notes,
       :tag_all_store_releases,
       :tag_platform_releases,
-      :notifications_enabled
+      :notifications_enabled,
+      :tag_releases,
+      :tag_suffix
     )
   end
 
@@ -150,7 +152,9 @@ class TrainsController < SignedInApplicationController
       :compact_build_notes,
       :tag_all_store_releases,
       :tag_platform_releases,
-      :notifications_enabled
+      :notifications_enabled,
+      :tag_releases,
+      :tag_suffix
     )
   end
 

--- a/app/javascript/controllers/domain/release_suffix_help_controller.js
+++ b/app/javascript/controllers/domain/release_suffix_help_controller.js
@@ -3,7 +3,8 @@ import {Controller} from "@hotwired/stimulus";
 export default class extends Controller {
   static values = {
     version: String,
-    versionSuffixCurrent: String
+    versionSuffixCurrent: String,
+    prefix: String
   }
 
   static targets = [
@@ -21,9 +22,9 @@ export default class extends Controller {
 
   __set(suffix) {
     if (suffix !== "") {
-      this.helpTextTarget.innerHTML = this.versionValue + "-" + suffix;
+      this.helpTextTarget.innerHTML = this.prefixValue + this.versionValue + "-" + suffix;
     } else {
-      this.helpTextTarget.innerHTML = this.versionValue;
+      this.helpTextTarget.innerHTML = this.prefixValue + this.versionValue;
     }
   }
 }

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -228,6 +228,7 @@ class Release < ApplicationRecord
   # recursively attempt to create a release until a unique one gets created
   # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
   def create_release!(input_tag_name = base_tag_name)
+    return unless train.tag_releases?
     return if tag_name.present?
     train.create_release!(release_branch, input_tag_name)
     update!(tag_name: input_tag_name)
@@ -332,7 +333,9 @@ class Release < ApplicationRecord
   private
 
   def base_tag_name
-    "v#{release_version}"
+    tag = "v#{release_version}"
+    tag += "-" + train.tag_suffix if train.tag_suffix.present?
+    tag
   end
 
   def create_platform_runs

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -21,6 +21,8 @@
 #  status                   :string           not null
 #  tag_all_store_releases   :boolean          default(FALSE)
 #  tag_platform_releases    :boolean          default(FALSE)
+#  tag_releases             :boolean          default(TRUE)
+#  tag_suffix               :string
 #  version_current          :string
 #  version_seeded_with      :string
 #  working_branch           :string

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -173,6 +173,7 @@
       <%= render partial: "backmerge_config_form", locals: { form: } %>
       <%= render partial: "manual_release_form", locals: { form: } %>
       <%= render partial: "compact_build_notes_form", locals: { form: } %>
+      <%= render partial: "release_tag_form", locals: { form: } %>
       <% if @app.cross_platform? %>
         <%= render partial: "store_tags_form", locals: { form: } %>
       <% end %>

--- a/app/views/trains/_release_tag_form.html.erb
+++ b/app/views/trains/_release_tag_form.html.erb
@@ -1,0 +1,48 @@
+<article data-controller="reveal">
+  <div class="text-xl text-slate-600 font-medium mt-2 mb-1">Tag Your Releases</div>
+  <div class="text-sm mt-1 mb-6">
+    By default, a tag is created at the end of the release with the final version of the release.<br/>
+    You can turn of creation of tag. Or, you can add an optional suffix to your tags.
+  </div>
+  <section data-controller="toggle-switch"
+           data-toggle-switch-on-label-value="Release Tag enabled"
+           data-toggle-switch-off-label-value="Release Tag disabled">
+    <div class="flex items-center">
+      <div class="form-switch">
+        <%= form.check_box :tag_releases,
+                           { id: "tag_releases-switch",
+                             class: "sr-only",
+                             data: { action: "toggle-switch#change reveal#toggle",
+                                     toggle_switch_target: "checkbox" } },
+                           "true", "false" %>
+        <label class="bg-slate-400" for="tag_releases-switch">
+          <span class="bg-white shadow-sm" aria-hidden="true"></span>
+          <span class="sr-only">Switch label</span>
+        </label>
+      </div>
+
+      <div class="text-sm text-slate-600 ml-2" data-toggle-switch-target="output"></div>
+    </div>
+
+    <section class="mt-6" data-reveal
+             <%= "hidden" unless @train.tag_releases? %> data-controller="help-text">
+      <div data-controller="domain--release-suffix-help"
+           data-domain--release-suffix-help-version-value="<%= @train.version_current || @train.version_seeded_with %>"
+           data-domain--release-suffix-help-version-suffix-current-value="<%= @train.tag_suffix %>"
+           data-domain--release-suffix-help-prefix-value="v">
+        <%= form.label :tag_suffix, class: "block text-sm font-medium mb-1" %>
+        <%= form.text_field :tag_suffix,
+                            class: "form-input w-full",
+                            placeholder: "Eg: nightly",
+                            autocomplete: "off",
+                            data: { domain__release_suffix_help_target: "input",
+                                    action: "domain--release-suffix-help#set" } %>
+        <div class="text-sm mt-1">
+          This is appended to the <strong>tag name</strong> of the release, as follows:&nbsp;
+          <span class="font-mono" data-domain--release-suffix-help-target="helpText"></span>
+        </div>
+      </div>
+    </section>
+  </section>
+  <div class="border-t border-dashed border-slate-200 pb-8 mt-8"></div>
+</article>

--- a/db/migrate/20231020054546_add_config_to_tag_release_to_train.rb
+++ b/db/migrate/20231020054546_add_config_to_tag_release_to_train.rb
@@ -1,0 +1,10 @@
+class AddConfigToTagReleaseToTrain < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :trains, bulk: true do |t|
+        t.column :tag_releases, :boolean, default: true
+        t.column :tag_suffix, :string
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_13_071746) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_20_054546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -522,6 +522,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_13_071746) do
     t.boolean "tag_platform_releases", default: false
     t.boolean "tag_all_store_releases", default: false
     t.boolean "compact_build_notes", default: false
+    t.boolean "tag_releases", default: true
+    t.string "tag_suffix"
     t.index ["app_id"], name: "index_trains_on_app_id"
   end
 

--- a/spec/factories/trains.rb
+++ b/spec/factories/trains.rb
@@ -12,6 +12,8 @@ FactoryBot.define do
     manual_release { false }
     tag_platform_releases { false }
     tag_all_store_releases { false }
+    tag_releases { true }
+    tag_suffix { nil }
 
     trait :draft do
       status { "draft" }


### PR DESCRIPTION
## Because

People may not want to create GitHub/GitLab releases for their nightly trains. Or they may want to add suffixes to those releases to differentiate them from their production version tags/releases.
