### PR TITLE
Fix picking only merge commits from changelog if feature enabled

### DIFF
--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -60,7 +60,8 @@ class GithubIntegration < ApplicationRecord
     author_name: [:commit, :author, :name],
     author_timestamp: [:commit, :author, :date],
     author_login: [:author, :login],
-    author_url: [:author, :html_url]
+    author_url: [:author, :html_url],
+    parents: [:parents]
   }
 
   PR_TRANSFORMATIONS = {

--- a/app/models/release_changelog.rb
+++ b/app/models/release_changelog.rb
@@ -22,6 +22,12 @@ class ReleaseChangelog < ApplicationRecord
     commits.pluck("message")
   end
 
+  def merge_commit_messages
+    commits
+      .filter { |c| c["parents"].size > 1 }
+      .pluck("message")
+  end
+
   def unique_authors
     commits.pluck("author_name").uniq
   end

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -296,32 +296,18 @@ class StepRun < ApplicationRecord
 
   def relevant_changes
     if release.first_commit == commit && release.release_changelog.present?
+      return release.release_changelog.merge_commit_messages if organization.merge_only_build_notes?
       return release.release_changelog.commit_messages
     end
     release_platform_run.commit_messages_before(self)
   end
 
   def build_notes
-    return merge_only_build_notes if organization.merge_only_build_notes?
-
     build_notes_raw
       .map { |str| str&.strip }
       .flat_map { |line| train.compact_build_notes? ? line.split("\n").first : line.split("\n") }
       .map { |line| line.gsub(/\p{Emoji_Presentation}\s*/, "") }
       .reject { |line| line =~ /\AMerge|\ACo-authored-by|\A---------/ }
-      .compact_blank
-      .uniq
-      .map { |str| "• #{str}" }
-      .join("\n").presence || "Nothing new"
-  end
-
-  def merge_only_build_notes
-    build_notes_raw
-      .map { |str| str&.strip }
-      .filter { |line| line.start_with?("Merge") }
-      .flat_map { |line| line.split("\n") }
-      .map { |line| line.gsub(/\p{Emoji_Presentation}\s*/, "") }
-      .reject { |line| line.start_with?("Merge") }
       .compact_blank
       .uniq
       .map { |str| "• #{str}" }


### PR DESCRIPTION
Changes the logic for picking merge commits to rely on parents of the commit rather than message body.

This needs to be used on conjugation with `compact_build_notes` flag on the train to get the first commit of all merge commits.