### PR TITLE
[experimental] App Variants

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,7 +63,7 @@ RSpec/MultipleExpectations:
   Max: 4
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 10
+  Max: 12
 
 RSpec/MessageChain:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,3 +34,4 @@ Rails/I18nLocaleTexts:
     - 'app/controllers/integrations/slack_controller.rb'
     - 'app/controllers/integrations/google_firebase_controller.rb'
     - 'app/controllers/notification_settings_controller.rb'
+    - 'app/controllers/app_variants_controller.rb'

--- a/app/assets/images/dna.svg
+++ b/app/assets/images/dna.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M17 3v1c-.01 3.352 -1.68 6.023 -5.008 8.014c-3.328 1.99 3.336 -2 .008 -.014c-3.328 1.99 -5 4.662 -5.008 8.014v1" />
+  <path d="M17 21.014v-1c-.01 -3.352 -1.68 -6.023 -5.008 -8.014c-3.328 -1.99 3.336 2 .008 .014c-3.328 -1.991 -5 -4.662 -5.008 -8.014v-1" />
+  <path d="M7 4h10" />
+  <path d="M7 20h10" />
+  <path d="M8 8h8" />
+  <path d="M8 16h8" />
+</svg>

--- a/app/controllers/app_variants_controller.rb
+++ b/app/controllers/app_variants_controller.rb
@@ -1,0 +1,33 @@
+class AppVariantsController < SignedInApplicationController
+  using RefinedString
+  before_action :require_write_access!, only: %i[create update]
+  around_action :set_time_zone
+
+  def create
+    @config = @app.config
+    @app_variant = @config.variants.new(parsed_app_variant_params)
+
+    if @app_variant.save
+      redirect_to edit_app_app_config_path, notice: "App Variant was successfully created."
+    else
+      redirect_back fallback_location: edit_app_app_config_path, flash: {error: @app_variant.errors.full_messages.to_sentence}
+    end
+  end
+
+  def update
+  end
+
+  private
+
+  def app_variant_params
+    params.require(:app_variant)
+      .permit(:name, :bundle_identifier, :firebase_android_config, :firebase_ios_config)
+  end
+
+  def parsed_app_variant_params
+    app_variant_params
+      .merge(firebase_ios_config: app_variant_params[:firebase_ios_config]&.safe_json_parse)
+      .merge(firebase_android_config: app_variant_params[:firebase_android_config]&.safe_json_parse)
+      .compact
+  end
+end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -95,7 +95,8 @@ class StepsController < SignedInApplicationController
       :release_suffix,
       :kind,
       :auto_deploy,
-      :build_artifact_name_pattern
+      :build_artifact_name_pattern,
+      :app_variant_id
     )
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,6 +94,8 @@ module ApplicationHelper
   end
 
   def status_badge(status, custom = [], fixed = nil, pulse: false)
+    return if status.blank?
+
     styles =
       case custom
       when Array

--- a/app/libs/deployments/google_firebase/release.rb
+++ b/app/libs/deployments/google_firebase/release.rb
@@ -38,11 +38,12 @@ module Deployments
         :release_metadata,
         :google_firebase_integration?,
         :release_platform,
+        :step_run,
         to: :run
       delegate :platform, to: :release_platform
 
       def kickoff!
-        if (similar_run = run.step_run.similar_deployment_runs_for(run).find(&:has_uploaded?))
+        if (similar_run = step_run.similar_deployment_runs_for(run).find(&:has_uploaded?))
           run.create_external_release(similar_run.external_release.attributes.except("id", "created_at", "updated_at"))
           return run.upload!
         end
@@ -56,7 +57,7 @@ module Deployments
           return if run.uploaded?
 
           run.build_artifact.with_open do |file|
-            result = provider.upload(file, run.build_artifact.file.filename.to_s, platform:)
+            result = provider.upload(file, run.build_artifact.file.filename.to_s, platform:, variant: step_run.app_variant)
             if result.ok?
               run.start_upload!(op_name: result.value!)
             else
@@ -89,7 +90,7 @@ module Deployments
       end
 
       def update_build_notes!(release)
-        provider.update_release_notes(release, run.step_run.build_notes)
+        provider.update_release_notes(release, step_run.build_notes)
       end
 
       def start_release!

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -30,7 +30,7 @@ class App < ApplicationRecord
 
   belongs_to :organization, class_name: "Accounts::Organization", optional: false
   has_one :config, class_name: "AppConfig", dependent: :destroy
-  has_many :variants, class_name: "AppVariant", through: :config
+  has_many :variants, through: :config
   has_many :external_apps, inverse_of: :app, dependent: :destroy
   has_many :integrations, inverse_of: :app, dependent: :destroy
   has_many :trains, -> { sequential }, dependent: :destroy, inverse_of: :app
@@ -75,6 +75,11 @@ class App < ApplicationRecord
       ios: "iOS",
       cross_platform: "Cross Platform"
     }.invert
+  end
+
+  def variant_options
+    opts = {"Default (#{bundle_identifier})" => nil}
+    opts.merge variants.map.to_h { |v| [v.display_text, v.id] }
   end
 
   def active_runs

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -30,6 +30,7 @@ class App < ApplicationRecord
 
   belongs_to :organization, class_name: "Accounts::Organization", optional: false
   has_one :config, class_name: "AppConfig", dependent: :destroy
+  has_many :variants, class_name: "AppVariant", through: :config
   has_many :external_apps, inverse_of: :app, dependent: :destroy
   has_many :integrations, inverse_of: :app, dependent: :destroy
   has_many :trains, -> { sequential }, dependent: :destroy, inverse_of: :app

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -16,6 +16,7 @@
 class AppConfig < ApplicationRecord
   has_paper_trail
   include Notifiable
+  include PlatformAwareness
 
   MINIMUM_REQUIRED_CONFIG = %i[code_repository]
   PLATFORM_AWARE_CONFIG_SCHEMA = Rails.root.join("config/schema/platform_aware_integration_config.json")
@@ -65,6 +66,11 @@ class AppConfig < ApplicationRecord
 
   def further_monitoring_setup?
     app.integrations.monitoring_provider&.further_setup?
+  end
+
+  def firebase_app(platform, variant: nil)
+    return variant.pick_firebase_app_id(platform) if variant&.in?(variants)
+    pick_firebase_app_id(platform)
   end
 
   private

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -21,6 +21,7 @@ class AppConfig < ApplicationRecord
   PLATFORM_AWARE_CONFIG_SCHEMA = Rails.root.join("config/schema/platform_aware_integration_config.json")
 
   belongs_to :app
+  has_many :variants, class_name: "AppVariant", dependent: :destroy
 
   validates :firebase_ios_config,
     allow_blank: true,

--- a/app/models/app_variant.rb
+++ b/app/models/app_variant.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: app_variants
+#
+#  id                      :uuid             not null, primary key
+#  bundle_identifier       :string           not null, indexed => [app_config_id]
+#  firebase_android_config :jsonb
+#  firebase_ios_config     :jsonb
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  app_config_id           :uuid             not null, indexed, indexed => [bundle_identifier]
+#
+class AppVariant < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :app_config
+
+  validates :bundle_identifier, presence: true, uniqueness: { scope: :app_config_id }
+  validate :duplicate_bundle_identifier, on: :create
+
+  delegate :app, to: :app_config
+
+  private
+
+  def duplicate_bundle_identifier
+    errors.add(:bundle_identifier, :same_as_parent) if app.bundle_identifier == bundle_identifier
+  end
+end

--- a/app/models/app_variant.rb
+++ b/app/models/app_variant.rb
@@ -6,19 +6,26 @@
 #  bundle_identifier       :string           not null, indexed => [app_config_id]
 #  firebase_android_config :jsonb
 #  firebase_ios_config     :jsonb
+#  name                    :string           not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  app_config_id           :uuid             not null, indexed, indexed => [bundle_identifier]
 #
 class AppVariant < ApplicationRecord
   has_paper_trail
+  include PlatformAwareness
 
   belongs_to :app_config
+  has_many :steps, dependent: :nullify
 
-  validates :bundle_identifier, presence: true, uniqueness: { scope: :app_config_id }
+  validates :bundle_identifier, presence: true, uniqueness: {scope: :app_config_id}
   validate :duplicate_bundle_identifier, on: :create
 
   delegate :app, to: :app_config
+
+  def display_text
+    "#{name} (#{bundle_identifier})"
+  end
 
   private
 

--- a/app/models/concerns/platform_awareness.rb
+++ b/app/models/concerns/platform_awareness.rb
@@ -8,4 +8,15 @@ module PlatformAwareness
       {ios: ios, android: android}
     end
   end
+
+  def pick_firebase_app_id(platform)
+    case platform
+    when "android"
+      firebase_android_config["app_id"]
+    when "ios"
+      firebase_ios_config["app_id"]
+    else
+      raise ArgumentError, "platform must be valid"
+    end
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -15,6 +15,7 @@
 #  step_number                 :integer          default(0), not null, indexed => [release_platform_id]
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
+#  app_variant_id              :uuid
 #  release_platform_id         :uuid             not null, indexed => [ci_cd_channel], indexed, indexed => [step_number]
 #
 class Step < ApplicationRecord
@@ -24,6 +25,7 @@ class Step < ApplicationRecord
   self.implicit_order_column = :step_number
 
   belongs_to :release_platform, inverse_of: :steps
+  belongs_to :app_variant, inverse_of: :steps, optional: true
   has_many :step_runs, inverse_of: :step, dependent: :destroy
   has_many :deployments, -> { kept.sequential }, inverse_of: :step, dependent: :destroy
   has_many :all_deployments, -> { sequential }, class_name: "Deployment", inverse_of: :step, dependent: :destroy

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -171,7 +171,7 @@ class StepRun < ApplicationRecord
   delegate :organization, to: :app
   delegate :commit_hash, to: :commit
   delegate :download_url, to: :build_artifact
-  delegate :workflow_id, :workflow_name, :step_number, :build_artifact_name_pattern, :has_uploadables?, :has_findables?, :name, to: :step
+  delegate :workflow_id, :workflow_name, :step_number, :build_artifact_name_pattern, :has_uploadables?, :has_findables?, :name, :app_variant, to: :step
   scope :not_failed, -> { where.not(status: [:ci_workflow_failed, :ci_workflow_halted, :build_not_found_in_store, :build_unavailable, :deployment_failed]) }
 
   def active?

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -25,7 +25,7 @@
 #  tag_suffix               :string
 #  version_current          :string
 #  version_seeded_with      :string
-#  versioning_strategy      :string           default(NULL)
+#  versioning_strategy      :string           default("semver")
 #  working_branch           :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null

--- a/app/views/app_configs/_app_variant_form.html.erb
+++ b/app/views/app_configs/_app_variant_form.html.erb
@@ -21,8 +21,8 @@
       App variants are akin to <strong>product flavors</strong> or <strong>build variants</strong>, but with an explicit
       requirement of having a different
       bundle identifier.
-      For example, a staging app variant <code><%= app.bundle_identifier + ".staging" %></code> that you want to deploy
-      to a different Firebase project.
+      For example, you can setup a staging variant <code><%= app.bundle_identifier + ".staging" %></code> that gets
+      deployed to a different Firebase app than the primary <code><%= app.bundle_identifier %></code> app.
     </div>
 
     <div class="grid grid-cols-2 gap-x-5">
@@ -42,7 +42,6 @@
 
     <%= render partial: "firebase_form", locals: { form:, config:, app:, firebase_ios_apps:, firebase_android_apps: } %>
   </div>
-
 
   <!-- Modal footer -->
   <div class="flex items-center p-4 space-x-2 border-t border-gray-200 rounded-b">

--- a/app/views/app_configs/_app_variant_form.html.erb
+++ b/app/views/app_configs/_app_variant_form.html.erb
@@ -1,0 +1,51 @@
+<%= form_with(model: [app, config, app_variant],
+              url: app_app_config_app_variants_path(app, config),
+              builder: ButtonHelper::AuthzForms) do |form| %>
+  <!-- Modal header -->
+  <div class="flex flex-col items-start rounded-t p-4">
+    <div class="flex justify-between w-full items-center border-b py-4">
+      <h3 class="text-xl font-semibold text-gray-900 inline-flex items-center">
+        <%= inline_svg("dna.svg", classname: "w-6 h-6 fill-current mr-1") %>
+        New App Variant
+      </h3>
+      <button type="button" class="text-slate-400 hover:cursor-pointer hover:text-slate-500" data-action="modal#close">
+        <%= inline_svg("close_icon.svg", classname: "w-4 h-4 fill-current") %>
+        <span class="sr-only">Close modal</span>
+      </button>
+    </div>
+  </div>
+
+  <!-- Modal body -->
+  <div class="p-4 space-y-6">
+    <div>
+      App variants are akin to <strong>product flavors</strong> or <strong>build variants</strong>, but with an explicit
+      requirement of having a different
+      bundle identifier.
+      For example, a staging app variant <code><%= app.bundle_identifier + ".staging" %></code> that you want to deploy
+      to a different Firebase project.
+    </div>
+
+    <div class="grid grid-cols-2 gap-x-5">
+      <div>
+        <%= form.label :name, class: "block text-sm font-medium mb-1" %>
+        <%= form.text_field :name, class: "form-input w-full", placeholder: "Enter app name...", required: true %>
+      </div>
+
+      <div>
+        <%= form.label :bundle_identifier, class: "block text-sm font-medium mb-1" %>
+        <%= form.text_field :bundle_identifier, class: "form-input w-full", placeholder: "eg., com.just.use.rails", required: true %>
+        <div class="text-sm mt-1">If you're going to deploy to the App Store or Play Store, this <strong>must</strong>
+          match the identifier in the store listing.
+        </div>
+      </div>
+    </div>
+
+    <%= render partial: "firebase_form", locals: { form:, config:, app:, firebase_ios_apps:, firebase_android_apps: } %>
+  </div>
+
+
+  <!-- Modal footer -->
+  <div class="flex items-center p-4 space-x-2 border-t border-gray-200 rounded-b">
+    <%= form.authz_submit :blue, "Save" %>
+  </div>
+<% end %>

--- a/app/views/app_configs/_firebase_form.html.erb
+++ b/app/views/app_configs/_firebase_form.html.erb
@@ -1,0 +1,38 @@
+<% if app.firebase_connected? %>
+  <section class="border-t border-dashed pb-8">
+    <div class="my-8">
+      <h2 class="font-bold text-xl">
+        <%= image_tag "integrations/logo_firebase.png", title: "Firebase", width: 40, class: "pb-2" %>
+        Firebase App Distribution
+      </h2>
+    </div>
+
+    <div class="grid gap-5 md:grid-cols-2">
+      <% if firebase_android_apps.present? %>
+        <div class="mb-4">
+          <%= form.label :firebase_android_config, "Android App", class: "block text-sm font-medium mb-1" %>
+          <%= form.select :firebase_android_config,
+                          options_for_select(
+                            display_channels(firebase_android_apps) { |app| "#{app[:display_name]} #{app[:app_id]}" },
+                            config.firebase_android_config.to_json
+                          ),
+                          { class: "form-select" },
+                          data: { controller: "input-select" } %>
+        </div>
+      <% end %>
+
+      <% if firebase_ios_apps.present? %>
+        <div>
+          <%= form.label :firebase_ios_config, "iOS App", class: "block text-sm font-medium mb-1" %>
+          <%= form.select :firebase_ios_config,
+                          options_for_select(
+                            display_channels(firebase_ios_apps) { |app| "#{app[:display_name]} #{app[:app_id]}" },
+                            config.firebase_ios_config.to_json
+                          ),
+                          { class: "form-select" },
+                          data: { controller: "input-select" } %>
+        </div>
+      <% end %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/app_configs/edit.html.erb
+++ b/app/views/app_configs/edit.html.erb
@@ -95,7 +95,7 @@
   <% end %>
 
   <section class="border-t border-dashed my-8 pt-8">
-    <%= render TableComponent.new(columns: %w[name bundle_identifier actions]) do |table| %>
+    <%= render TableComponent.new(columns: %w[name bundle_identifier]) do |table| %>
       <% table.with_heading do %>
         <div class="flex justify-between items-end mb-2">
           <h2 class="text-2xl text-slate-800 font-bold flex flex-row items-center">

--- a/app/views/app_configs/edit.html.erb
+++ b/app/views/app_configs/edit.html.erb
@@ -60,44 +60,8 @@
       </section>
     <% end %>
 
-    <% if @app.firebase_connected? %>
-      <section class="border-t border-dashed pb-8">
-        <div class="my-8">
-          <h2 class="font-bold text-xl">
-            <%= image_tag "integrations/logo_firebase.png", title: "Firebase", width: 40, class: "pb-2" %>
-            Firebase App Distribution
-          </h2>
-        </div>
+    <%= render partial: "firebase_form", locals: { form:, app: @app, config: @config, firebase_ios_apps: @firebase_ios_apps, firebase_android_apps: @firebase_android_apps } %>
 
-        <div class="grid gap-5 md:grid-cols-2">
-          <% if @firebase_android_apps.present? %>
-            <div class="mb-4">
-              <%= form.label :firebase_android_config, "Android App", class: "block text-sm font-medium mb-1" %>
-              <%= form.select :firebase_android_config,
-                              options_for_select(
-                                display_channels(@firebase_android_apps) { |app| "#{app[:display_name]} #{app[:app_id]}" },
-                                @config.firebase_android_config.to_json
-                              ),
-                              { class: "form-select" },
-                              data: { controller: "input-select" } %>
-            </div>
-          <% end %>
-
-          <% if @firebase_ios_apps.present? %>
-            <div>
-              <%= form.label :firebase_ios_config, "iOS App", class: "block text-sm font-medium mb-1" %>
-              <%= form.select :firebase_ios_config,
-                              options_for_select(
-                                display_channels(@firebase_ios_apps) { |app| "#{app[:display_name]} #{app[:app_id]}" },
-                                @config.firebase_ios_config.to_json
-                              ),
-                              { class: "form-select" },
-                              data: { controller: "input-select" } %>
-            </div>
-          <% end %>
-        </div>
-      </section>
-    <% end %>
 
     <% if @app.bugsnag_connected? %>
       <section class="border-t border-dashed pb-8">
@@ -129,4 +93,49 @@
       <%= form.authz_submit :blue, "Update" %>
     </div>
   <% end %>
+
+  <section class="border-t border-dashed my-8 pt-8">
+    <%= render TableComponent.new(columns: %w[name bundle_identifier actions]) do |table| %>
+      <% table.with_heading do %>
+        <div class="flex justify-between items-end mb-2">
+          <h2 class="text-2xl text-slate-800 font-bold flex flex-row items-center">
+            <%= inline_svg("dna.svg", classname: "w-7 h-7 fill-current mr-1") %>
+            App Variants
+          </h2>
+          <div data-controller="modal" class="px-2">
+            <%= authz_link_to :green, "#", { data: { action: "modal#open" } } do %>
+              <%= inline_svg("create_plus.svg", classname: "w-4 fill-current opacity-50 shrink-0") %>
+              <span class="hidden xs:block ml-2">Create an app variant</span>
+            <% end %>
+
+            <dialog data-modal-target="modal"
+                    class="p-0 backdrop:bg-gray-400 backdrop:bg-opacity-50 open:animate-fade-in w-2/3">
+              <div class="relative bg-white rounded-lg shadow">
+                <%= render partial: "app_variant_form", locals: { app: @app, config: @config, app_variant: @config.variants.build,
+                                                                  firebase_ios_apps: @firebase_ios_apps, firebase_android_apps: @firebase_android_apps } %>
+              </div>
+            </dialog>
+          </div>
+        </div>
+      <% end %>
+
+      <% @config.variants.each do |variant| %>
+        <% table.with_row do |row| %>
+          <% row.with_cell do %>
+            <%= variant.name %>
+          <% end %>
+
+          <% row.with_cell do %>
+            <%= variant.bundle_identifier %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% unless @config.variants.exists? %>
+      <div class="text-gray-500 text-sm">
+        No app variants have been configured yet.
+      </div>
+    <% end %>
+  </section>
 <% end %>

--- a/app/views/shared/_per_step_metadata.html.erb
+++ b/app/views/shared/_per_step_metadata.html.erb
@@ -1,6 +1,6 @@
 <div>
   <div class="px-4 py-2 bg-<%= step_color step.kind %>-50 rounded-md border-2 border-<%= step_color step.kind %>-300">
-    <div class="flex justify-between">
+    <div class="flex justify-between mb-1">
       <div class="flex flex-row items-center w-full">
         <h3 class="text-lg font-bold text-slate-800"><%= step.name %></h3>
         <%= status_badge "##{step.step_number}", %w[text-xs ml-2], :neutral %>
@@ -17,10 +17,18 @@
       <% end %>
     </div>
 
-    <div class="flex flex-col gap-y-5 mb-6">
-      <div class="flex flex-row items-center w-full">
-        <div class="text-slate-500 text-sm"><%= safe_simple_format(step.description) %></div>
-      </div>
+    <div class="flex flex-col gap-y-5 mb-5">
+      <% if step.app_variant.present? %>
+        <div class="flex flex-row items-center text-slate-600 text-xs">
+          App Variant – <%= step.app_variant.display_text %>
+        </div>
+      <% end %>
+
+      <% if step.description.present? %>
+        <div class="flex flex-row items-center w-full">
+          <div class="text-slate-500 text-sm"><%= safe_simple_format(step.description) %></div>
+        </div>
+      <% end %>
 
       <% if step_run&.build_version %>
         <div class="flex flex-col w-full">

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -69,7 +69,8 @@
             artifact
             (aab/apk/ipa) among the files generated.</p>
           <p class="mt-1">When left blank, Tramline will choose the largest file generated as the build artifact.</p>
-          <p class="mt-1">To understand the build artifact selection
+          <p class="mt-1">
+            To understand the build artifact selection
             better, <%= link_to_external "read the docs", "https://docs.tramline.app/integrations/ci-cd/#build-artifact-selection", class: "underline" %>
             .</p>
         </div>

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -65,12 +65,22 @@
         <%= form.label "Build Artifact Name (Optional)", class: "block text-sm font-medium mb-1" %>
         <%= form.text_field :build_artifact_name_pattern, class: "form-input w-full" %>
         <div class="text-sm">
-          <p class="mt-1">If your CI workflow generates multiple artifacts, provide a name to choose the correct build artifact
+          <p class="mt-1">If your CI workflow generates multiple artifacts, provide a name to choose the correct build
+            artifact
             (aab/apk/ipa) among the files generated.</p>
           <p class="mt-1">When left blank, Tramline will choose the largest file generated as the build artifact.</p>
-          <p class="mt-1">To understand the build artifact selection better, <%= link_to_external "read the docs", "https://docs.tramline.app/integrations/ci-cd/#build-artifact-selection", class: "underline" %>.</p>
+          <p class="mt-1">To understand the build artifact selection
+            better, <%= link_to_external "read the docs", "https://docs.tramline.app/integrations/ci-cd/#build-artifact-selection", class: "underline" %>
+            .</p>
         </div>
       </div>
+
+      <% if @app.variants.exists? %>
+        <div class="mt-4">
+          <%= form.label "Pick an app variant", class: "block text-sm font-medium mb-1" %>
+          <%= form.select :app_variant_id, options_for_select(@app.variant_options, @step.app_variant&.id), { class: "form-select" }, data: { controller: "input-select" } %>
+        </div>
+      <% end %>
     </div>
   </div>
   <div class="mt-4 px-5 py-3 bg-indigo-50 border border-indigo-100 rounded-sm text-left">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,7 +130,7 @@ en:
         app_variant:
           attributes:
             bundle_identifier:
-              same_as_parent: "cannot be the same as the parent app"
+              same_as_parent: "Cannot be the same as the parent app"
         accounts/user:
           attributes:
             email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,10 @@ en:
         release_suffix: "Release suffix"
     errors:
       models:
+        app_variant:
+          attributes:
+            bundle_identifier:
+              same_as_parent: "cannot be the same as the parent app"
         accounts/user:
           attributes:
             email:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,9 @@ Rails.application.routes.draw do
   end
 
   resources :apps do
-    resource :app_config, only: %i[edit update], path: :config
+    resource :app_config, only: %i[edit update], path: :config do
+      resources :app_variants, only: %i[create update]
+    end
 
     member do
       get :all_builds

--- a/db/migrate/20231203081907_add_app_variants.rb
+++ b/db/migrate/20231203081907_add_app_variants.rb
@@ -1,8 +1,9 @@
 class AddAppVariants < ActiveRecord::Migration[7.0]
   def change
     create_table :app_variants, id: :uuid do |t|
-      t.belongs_to :app_config, null: false, index: { unique: true }, foreign_key: true, type: :uuid
+      t.belongs_to :app_config, null: false, index: true, foreign_key: true, type: :uuid
 
+      t.string :name, null: false
       t.string :bundle_identifier, null: false
       t.jsonb :firebase_ios_config, null: true
       t.jsonb :firebase_android_config, null: true

--- a/db/migrate/20231203081907_add_app_variants.rb
+++ b/db/migrate/20231203081907_add_app_variants.rb
@@ -1,0 +1,15 @@
+class AddAppVariants < ActiveRecord::Migration[7.0]
+  def change
+    create_table :app_variants, id: :uuid do |t|
+      t.belongs_to :app_config, null: false, index: { unique: true }, foreign_key: true, type: :uuid
+
+      t.string :bundle_identifier, null: false
+      t.jsonb :firebase_ios_config, null: true
+      t.jsonb :firebase_android_config, null: true
+
+      t.timestamps
+    end
+
+    add_index :app_variants, [:bundle_identifier, :app_config_id], unique: true
+  end
+end

--- a/db/migrate/20231203103432_add_app_variant_to_step.rb
+++ b/db/migrate/20231203103432_add_app_variant_to_step.rb
@@ -1,0 +1,5 @@
+class AddAppVariantToStep < ActiveRecord::Migration[7.0]
+  def change
+    add_column :steps, :app_variant_id, :uuid, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_03_081907) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_03_103432) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -67,12 +67,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_03_081907) do
 
   create_table "app_variants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "app_config_id", null: false
+    t.string "name", null: false
     t.string "bundle_identifier", null: false
     t.jsonb "firebase_ios_config"
     t.jsonb "firebase_android_config"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["app_config_id"], name: "index_app_variants_on_app_config_id", unique: true
+    t.index ["app_config_id"], name: "index_app_variants_on_app_config_id"
     t.index ["bundle_identifier", "app_config_id"], name: "index_app_variants_on_bundle_identifier_and_app_config_id", unique: true
   end
 
@@ -561,6 +562,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_03_081907) do
     t.string "kind"
     t.boolean "auto_deploy", default: true
     t.string "build_artifact_name_pattern"
+    t.uuid "app_variant_id"
     t.index ["ci_cd_channel", "release_platform_id"], name: "index_steps_on_ci_cd_channel_and_release_platform_id", unique: true
     t.index ["release_platform_id"], name: "index_steps_on_release_platform_id"
     t.index ["step_number", "release_platform_id"], name: "index_steps_on_step_number_and_release_platform_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_01_191245) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_03_081907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -63,6 +63,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_01_191245) do
     t.string "issuer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "app_variants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "app_config_id", null: false
+    t.string "bundle_identifier", null: false
+    t.jsonb "firebase_ios_config"
+    t.jsonb "firebase_android_config"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["app_config_id"], name: "index_app_variants_on_app_config_id", unique: true
+    t.index ["bundle_identifier", "app_config_id"], name: "index_app_variants_on_bundle_identifier_and_app_config_id", unique: true
   end
 
   create_table "apps", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -633,6 +644,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_01_191245) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "app_configs", "apps"
+  add_foreign_key "app_variants", "app_configs"
   add_foreign_key "apps", "organizations"
   add_foreign_key "build_artifacts", "step_runs"
   add_foreign_key "build_queues", "releases"

--- a/spec/factories/app_configs.rb
+++ b/spec/factories/app_configs.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :app_config do
     code_repository { {id: 123, full_name: "tramline/repo", namespace: "tramline"} }
     notification_channel { {id: 123, name: "build_notifications"} }
-    association :app, factory: [:app, :android]
+    association :app, factory: [:app, :android, :without_config]
   end
 end

--- a/spec/factories/app_variants.rb
+++ b/spec/factories/app_variants.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :app_variant do
+    association :app_config
+    bundle_identifier { "com.example.com" }
+  end
+end

--- a/spec/factories/app_variants.rb
+++ b/spec/factories/app_variants.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :app_variant do
     association :app_config
+    name { Faker::Lorem.word }
     bundle_identifier { "com.example.com" }
   end
 end

--- a/spec/factories/apps.rb
+++ b/spec/factories/apps.rb
@@ -34,8 +34,10 @@ FactoryBot.define do
       end
     end
 
-    after(:build) do |app, _|
-      app.config = build(:app_config, app: app)
+    trait :with_valid_config do
+      after(:build) do |app, _|
+        app.config = build(:app_config, app: app)
+      end
     end
   end
 end

--- a/spec/factories/apps.rb
+++ b/spec/factories/apps.rb
@@ -35,8 +35,14 @@ FactoryBot.define do
     end
 
     trait :with_valid_config do
-      after(:build) do |app, _|
+      after(:build) do |app|
         app.config = build(:app_config, app: app)
+      end
+    end
+
+    trait :without_config do
+      after(:build) do |app|
+        app.config = nil
       end
     end
   end

--- a/spec/libs/triggers/pull_request_spec.rb
+++ b/spec/libs/triggers/pull_request_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 describe Triggers::PullRequest do
-  let(:release) { create(:release) }
+  let(:app) { create(:app, :android, :with_valid_config) }
+  let(:train) { create(:train, app:) }
+  let(:release) { create(:release, train:) }
   let(:working_branch) { Faker::Lorem.word }
   let(:release_branch) { Faker::Lorem.word }
   let(:pr_title) { Faker::Lorem.word }
@@ -14,7 +16,7 @@ describe Triggers::PullRequest do
   }
   let(:merge_payload) { JSON.parse(File.read("spec/fixtures/github/merge_pull_request.json")).with_indifferent_access }
   let(:repo_integration) { instance_double(Installations::Github::Api) }
-  let(:repo_name) { release.train.app.config.code_repository_name }
+  let(:repo_name) { app.config.code_repository_name }
 
   before do
     allow(Installations::Github::Api).to receive(:new).and_return(repo_integration)

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -151,13 +151,18 @@ describe VersioningStrategies::Semverish do
 
     context "when calendar (year_and_next_week) version" do
       let(:year_and_next_week) { described_class.new("0.2347.0") }
+      let(:the_time) { Time.new(2023, 12, 1, 0, 0, 0, '+12:00') }
 
       it "bumps up major and keeps minor intact" do
-        expect(year_and_next_week.bump!(:major, strategy: :year_and_next_week).to_s).to eq("1.2349.0")
+        travel_to(the_time) do
+          expect(year_and_next_week.bump!(:major, strategy: :year_and_next_week).to_s).to eq("1.2349.0")
+        end
       end
 
       it "bumps up minor" do
-        expect(year_and_next_week.bump!(:minor, strategy: :year_and_next_week).to_s).to eq("0.2349.0")
+        travel_to(the_time) do
+          expect(year_and_next_week.bump!(:minor, strategy: :year_and_next_week).to_s).to eq("0.2349.0")
+        end
       end
 
       it "does not do anything if patch" do

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -151,7 +151,7 @@ describe VersioningStrategies::Semverish do
 
     context "when calendar (year_and_next_week) version" do
       let(:year_and_next_week) { described_class.new("0.2347.0") }
-      let(:the_time) { Time.new(2023, 12, 1, 0, 0, 0, '+12:00') }
+      let(:the_time) { Time.new(2023, 12, 1, 0, 0, 0, "+12:00") }
 
       it "bumps up major and keeps minor intact" do
         travel_to(the_time) do

--- a/spec/models/app_variant_spec.rb
+++ b/spec/models/app_variant_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe AppVariant do
+  it "has a valid factory" do
+    parent = "com.example"
+    variant = "com.example.com"
+    app = create(:app, :android, bundle_identifier: parent)
+    expect(create(:app_variant, app_config: app.config, bundle_identifier: variant)).to be_valid
+    expect(build(:app_variant, app_config: app.config, bundle_identifier: variant)).not_to be_valid
+  end
+end


### PR DESCRIPTION
Add a concept of App Variants (or build variants) to allow setting bundle identifiers that are extensions of the base identifiers set on the app. Useful for sending different packages to differents apps in FAD, stores etc.

<img width="1286" alt="Screenshot 2023-12-03 at 8 26 41 PM" src="https://github.com/tramlinehq/tramline/assets/50663/800ab664-f03d-4ddf-b0b7-bb4eca8688cc">
