### PR TITLE
Handle release failure from Google Play Store when a previous build was review rejected

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,9 @@ RSpec/AnyInstance:
 RSpec/MultipleExpectations:
   Max: 4
 
+RSpec/NestedGroups:
+  Max: 4
+
 RSpec/MultipleMemoizedHelpers:
   Max: 12
 

--- a/app/controllers/step_runs_controller.rb
+++ b/app/controllers/step_runs_controller.rb
@@ -48,9 +48,9 @@ class StepRunsController < SignedInApplicationController
   end
 
   def ensure_syncable
-    unless @step_run.deployment_failed_with_sync_option?
+    unless @step_run.failed_with_action_required?
       redirect_back fallback_location: root_path,
-        flash: {error: "Cannot perform this operation. This step cannot be started."}
+        flash: {error: "Cannot perform this operation. This step does not require a manual submission."}
     end
   end
 

--- a/app/controllers/step_runs_controller.rb
+++ b/app/controllers/step_runs_controller.rb
@@ -24,10 +24,10 @@ class StepRunsController < SignedInApplicationController
   def sync_store_status
     @step_run.sync_store_status!
 
-    if @step_run.deployment_started?
-      redirect_back fallback_location: root_path, notice: "Status updated from store, all good. Go ahead with rest of the release."
+    if @step_run.deployment_restarted?
+      redirect_back fallback_location: root_path, notice: "Status resolved on the console UI, the release train will move forward."
     else
-      redirect_back fallback_location: root_path, notice: "You have not resolved anything, do it again. Ensure to submit the changes for review."
+      redirect_back fallback_location: root_path, flash: {error: "Status remains unresolved on the console UI. Please make sure to submit the changes for review in a public track."}
     end
   rescue
     error = "Failed to sync the store status! Contact support if the issue persists."

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -28,7 +28,7 @@ module ReleasesHelper
         ["In progress", :ongoing]
       when :build_ready
         ["Looking for build to deploy", :ongoing]
-      when :deployment_started
+      when :deployment_started, :deployment_restarted
         ["Deployments in progress", :ongoing]
       when :build_found_in_store
         ["Build found in store", :routine]

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -47,7 +47,7 @@ module ReleasesHelper
       when :deployment_failed
         ["Deployment failed", :failure]
       when :deployment_failed_with_sync_option
-        ["Needs manual intervention", :failure]
+        ["Needs manual submission", :failure]
       when :cancelling
         ["Cancelling", :inert]
       when :cancelled
@@ -89,7 +89,7 @@ module ReleasesHelper
       when :failed
         ["Failed", :failure]
       when :failed_with_sync_option
-        ["Needs manual intervention", :failure]
+        ["Needs manual submission", :failure]
       else
         ["Unknown", :neutral]
       end

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -46,7 +46,7 @@ module ReleasesHelper
         ["Build unavailable", :failure]
       when :deployment_failed
         ["Deployment failed", :failure]
-      when :deployment_failed_with_sync_option
+      when :failed_with_action_required
         ["Needs manual submission", :failure]
       when :cancelling
         ["Cancelling", :inert]
@@ -88,7 +88,7 @@ module ReleasesHelper
         ["Released", :success]
       when :failed
         ["Failed", :failure]
-      when :failed_with_sync_option
+      when :failed_with_action_required
         ["Needs manual submission", :failure]
       else
         ["Unknown", :neutral]

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -46,6 +46,8 @@ module ReleasesHelper
         ["Build unavailable", :failure]
       when :deployment_failed
         ["Deployment failed", :failure]
+      when :deployment_failed_with_sync_option
+        ["Needs manual intervention", :failure]
       when :cancelling
         ["Cancelling", :inert]
       when :cancelled
@@ -86,6 +88,8 @@ module ReleasesHelper
         ["Released", :success]
       when :failed
         ["Failed", :failure]
+      when :failed_with_sync_option
+        ["Needs manual intervention", :failure]
       else
         ["Unknown", :neutral]
       end

--- a/app/libs/installations/google/play_developer/api.rb
+++ b/app/libs/installations/google/play_developer/api.rb
@@ -62,7 +62,7 @@ module Installations
       end
     end
 
-    def create_release(track_name, version_code, release_version, rollout_percentage, release_notes)
+    def create_release(track_name, version_code, release_version, rollout_percentage, release_notes, skip_review: nil)
       @track_name = track_name
       @version_code = version_code
       @release_version = release_version
@@ -72,11 +72,11 @@ module Installations
       execute do
         edit = client.insert_edit(package_name)
         edit_track(edit, active_release)
-        client.commit_edit(package_name, edit.id)
+        client.commit_edit(package_name, edit.id, changes_not_sent_for_review: skip_review)
       end
     end
 
-    def create_draft_release(track_name, version_code, release_version, release_notes)
+    def create_draft_release(track_name, version_code, release_version, release_notes, skip_review: nil)
       @track_name = track_name
       @version_code = version_code
       @release_version = release_version
@@ -85,11 +85,11 @@ module Installations
       execute do
         edit = client.insert_edit(package_name)
         edit_track(edit, draft_release)
-        client.commit_edit(package_name, edit.id)
+        client.commit_edit(package_name, edit.id, changes_not_sent_for_review: skip_review)
       end
     end
 
-    def halt_release(track_name, version_code, release_version, rollout_percentage)
+    def halt_release(track_name, version_code, release_version, rollout_percentage, skip_review: nil)
       @track_name = track_name
       @version_code = version_code
       @release_version = release_version
@@ -98,7 +98,7 @@ module Installations
       execute do
         edit = client.insert_edit(package_name)
         edit_track(edit, halted_release)
-        client.commit_edit(package_name, edit.id)
+        client.commit_edit(package_name, edit.id, changes_not_sent_for_review: skip_review)
       end
     end
 

--- a/app/libs/installations/google/play_developer/api.rb
+++ b/app/libs/installations/google/play_developer/api.rb
@@ -23,11 +23,11 @@ module Installations
       set_client
     end
 
-    def upload(apk_path)
+    def upload(apk_path, skip_review)
       execute do
         edit = client.insert_edit(package_name)
         client.upload_edit_bundle(package_name, edit.id, upload_source: apk_path, content_type: CONTENT_TYPE)
-        client.commit_edit(package_name, edit.id)
+        client.commit_edit(package_name, edit.id, changes_not_sent_for_review: skip_review)
       end
     end
 
@@ -49,6 +49,16 @@ module Installations
           &.tracks
           &.map { |t| t.to_h }
           &.then { |tracks| Installations::Response::Keys.transform(tracks, transforms) }
+      end
+    end
+
+    def get_track(track_name, transforms)
+      execute do
+        edit = client.insert_edit(package_name)
+        client.get_edit_track(package_name, edit.id, track_name)
+          &.to_h
+          &.then { |track| Installations::Response::Keys.transform([track], transforms) }
+          &.first
       end
     end
 

--- a/app/libs/installations/google/play_developer/api.rb
+++ b/app/libs/installations/google/play_developer/api.rb
@@ -23,7 +23,7 @@ module Installations
       set_client
     end
 
-    def upload(apk_path, skip_review)
+    def upload(apk_path, skip_review: nil)
       execute do
         edit = client.insert_edit(package_name)
         client.upload_edit_bundle(package_name, edit.id, upload_source: apk_path, content_type: CONTENT_TYPE)

--- a/app/libs/installations/google/play_developer/error.rb
+++ b/app/libs/installations/google/play_developer/error.rb
@@ -97,7 +97,7 @@ module Installations
         status: "PERMISSION_DENIED",
         code: 403,
         message_matcher: /has already been used/i,
-        decorated_reason: :build_exists
+        decorated_reason: :build_exists_in_build_channel
       }
     ]
 

--- a/app/libs/notifiers/slack/renderers/step_failed.rb
+++ b/app/libs/notifiers/slack/renderers/step_failed.rb
@@ -2,6 +2,10 @@ module Notifiers
   module Slack
     class Renderers::StepFailed < Renderers::Base
       TEMPLATE_FILE = "step_failed.json.erb".freeze
+
+      def manual_submission_required_text
+        "- Due to a previous rejection, new changes cannot be submitted to the store from Tramline. Please submit the current build (#{@build_number}) for review manually from the Google Play Console by creating a release in a public track (eg. Closed testing, Open testing). Once that is done, you can sync the store status with Tramline and move forward with the release train."
+      end
     end
   end
 end

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -71,6 +71,7 @@ class DeploymentRun < ApplicationRecord
     release_started
     released
     review_failed
+    skipped
   ]
 
   STATES = {
@@ -154,7 +155,7 @@ class DeploymentRun < ApplicationRecord
       after { step_run.fail_deployment_with_sync_option! }
     end
 
-    event(:skip) do
+    event :skip, after_commit: -> { event_stamp!(reason: :skipped, kind: :notice, data: stamp_data) } do
       transitions from: :failed_with_sync_option, to: :released
       after { step_run.finish_deployment!(deployment) }
     end

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -86,7 +86,7 @@ class DeploymentRun < ApplicationRecord
     rollout_started: "rollout_started",
     released: "released",
     review_failed: "review_failed",
-    failed_with_sync_option: "failed_with_sync_option",
+    failed_with_action_required: "failed_with_action_required",
     failed: "failed"
   }
 
@@ -151,12 +151,12 @@ class DeploymentRun < ApplicationRecord
     end
 
     event :fail_with_sync_option, before: :set_reason do
-      transitions from: [:started, :prepared_release, :uploading, :uploaded, :submitted_for_review, :ready_to_release, :rollout_started, :failed_prepare_release, :failed_with_sync_option], to: :failed_with_sync_option
+      transitions from: [:started, :prepared_release, :uploading, :uploaded, :submitted_for_review, :ready_to_release, :rollout_started, :failed_prepare_release, :failed_with_action_required], to: :failed_with_action_required
       after { step_run.fail_deployment_with_sync_option! }
     end
 
     event :skip, after_commit: -> { event_stamp!(reason: :skipped, kind: :notice, data: stamp_data) } do
-      transitions from: :failed_with_sync_option, to: :released
+      transitions from: :failed_with_action_required, to: :released
       after { step_run.finish_deployment!(deployment) }
     end
 

--- a/app/models/google_play_store_integration.rb
+++ b/app/models/google_play_store_integration.rb
@@ -47,6 +47,11 @@ class GooglePlayStoreIntegration < ApplicationRecord
 
   def rollout_release(channel, build_number, version, rollout_percentage, release_notes)
     GitHub::Result.new do
+      # error_body = {"error" => {"status" => "INVALID_ARGUMENT",
+      #                           "code" => 400,
+      #                           "message" => "Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI"}}
+      # error = Google::Apis::ClientError.new("Error", body: error_body.to_json)
+      # raise Installations::Google::PlayDeveloper::Error.new(error)
       installation.create_release(channel, build_number, version, rollout_percentage, release_notes)
     end
   end
@@ -64,14 +69,16 @@ class GooglePlayStoreIntegration < ApplicationRecord
   end
 
   ALLOWED_ERRORS = [:build_exists_in_build_channel]
-  RETRYABLE_ERRORS = [:timeout, :duplicate_call, :unauthorized]
+  RETRYABLE_ERRORS = [:timeout, :duplicate_call, :unauthorized, :app_review_rejected]
 
   def upload(file)
     attempt = 1
+    skip_review = nil
     GitHub::Result.new do
-      installation.upload(file)
+      installation.upload(file, skip_review)
     rescue Installations::Google::PlayDeveloper::Error => ex
       attempt += 1
+      skip_review = true if ex.reason == :app_review_rejected
       retry if RETRYABLE_ERRORS.include?(ex.reason) && attempt <= 3
       raise ex unless ALLOWED_ERRORS.include?(ex.reason)
       elog(ex)
@@ -112,6 +119,15 @@ class GooglePlayStoreIntegration < ApplicationRecord
 
   def draft_check?
     channel_data.find { |c| c[:name].in?(%w[alpha beta production]) && c[:releases].present? }.blank?
+  end
+
+  def build_added_to_public_track?(build_number)
+    channel_data&.any? { |c| c[:name].in?(%w[alpha beta production]) && build_number.in?(c[:releases].pluck(:build_number)) }
+  end
+
+  def build_present_in_channel?(channel, build_number)
+    track_data = installation.get_track(channel, CHANNEL_DATA_TRANSFORMATIONS)
+    build_number.in?(track_data[:releases].pluck(:build_number))
   end
 
   def to_s

--- a/app/models/google_play_store_integration.rb
+++ b/app/models/google_play_store_integration.rb
@@ -36,6 +36,9 @@ class GooglePlayStoreIntegration < ApplicationRecord
   DEVELOPER_URL_TEMPLATE =
     Addressable::Template.new("https://play.google.com/console/u/0/developers/{project_id}")
   PUBLIC_ICON = "https://storage.googleapis.com/tramline-public-assets/play-console.png".freeze
+  MAX_RETRY_ATTEMPTS = 3
+  ALLOWED_ERRORS = [:build_exists_in_build_channel]
+  RETRYABLE_ERRORS = [:timeout, :duplicate_call, :unauthorized, :app_review_rejected]
 
   def access_key
     StringIO.new(json_key)
@@ -46,37 +49,28 @@ class GooglePlayStoreIntegration < ApplicationRecord
   end
 
   def rollout_release(channel, build_number, version, rollout_percentage, release_notes)
-    GitHub::Result.new do
-      installation.create_release(channel, build_number, version, rollout_percentage, release_notes)
+    execute_with_retry do |skip_review|
+      installation.create_release(channel, build_number, version, rollout_percentage, release_notes, skip_review:)
     end
   end
 
   def create_draft_release(channel, build_number, version, release_notes)
-    GitHub::Result.new do
-      installation.create_draft_release(channel, build_number, version, release_notes)
+    execute_with_retry do |skip_review|
+      installation.create_draft_release(channel, build_number, version, release_notes, skip_review:)
     end
   end
 
   def halt_release(channel, build_number, version, rollout_percentage)
-    GitHub::Result.new do
-      installation.halt_release(channel, build_number, version, rollout_percentage)
+    execute_with_retry do |skip_review|
+      installation.halt_release(channel, build_number, version, rollout_percentage, skip_review:)
     end
   end
 
-  ALLOWED_ERRORS = [:build_exists_in_build_channel]
-  RETRYABLE_ERRORS = [:timeout, :duplicate_call, :unauthorized, :app_review_rejected]
-
   def upload(file)
-    attempt = 1
-    skip_review = nil
-    GitHub::Result.new do
+    execute_with_retry do |skip_review|
       installation.upload(file, skip_review:)
     rescue Installations::Google::PlayDeveloper::Error => ex
-      attempt += 1
-      skip_review = true if ex.reason == :app_review_rejected
-      retry if RETRYABLE_ERRORS.include?(ex.reason) && attempt <= 3
       raise ex unless ALLOWED_ERRORS.include?(ex.reason)
-      elog(ex)
     end
   end
 
@@ -191,6 +185,19 @@ class GooglePlayStoreIntegration < ApplicationRecord
   end
 
   private
+
+  def execute_with_retry
+    attempt = 1
+    skip_review = nil
+    GitHub::Result.new do
+      yield(skip_review)
+    rescue Installations::Google::PlayDeveloper::Error => ex
+      attempt += 1
+      skip_review = true if ex.reason == :app_review_rejected
+      retry if RETRYABLE_ERRORS.include?(ex.reason) && attempt <= MAX_RETRY_ATTEMPTS
+      raise ex
+    end
+  end
 
   def project_id
     JSON.parse(json_key)["project_id"]&.split("-")&.third

--- a/app/models/google_play_store_integration.rb
+++ b/app/models/google_play_store_integration.rb
@@ -47,11 +47,6 @@ class GooglePlayStoreIntegration < ApplicationRecord
 
   def rollout_release(channel, build_number, version, rollout_percentage, release_notes)
     GitHub::Result.new do
-      # error_body = {"error" => {"status" => "INVALID_ARGUMENT",
-      #                           "code" => 400,
-      #                           "message" => "Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI"}}
-      # error = Google::Apis::ClientError.new("Error", body: error_body.to_json)
-      # raise Installations::Google::PlayDeveloper::Error.new(error)
       installation.create_release(channel, build_number, version, rollout_percentage, release_notes)
     end
   end

--- a/app/models/google_play_store_integration.rb
+++ b/app/models/google_play_store_integration.rb
@@ -75,7 +75,7 @@ class GooglePlayStoreIntegration < ApplicationRecord
     attempt = 1
     skip_review = nil
     GitHub::Result.new do
-      installation.upload(file, skip_review)
+      installation.upload(file, skip_review:)
     rescue Installations::Google::PlayDeveloper::Error => ex
       attempt += 1
       skip_review = true if ex.reason == :app_review_rejected
@@ -121,12 +121,13 @@ class GooglePlayStoreIntegration < ApplicationRecord
     channel_data.find { |c| c[:name].in?(%w[alpha beta production]) && c[:releases].present? }.blank?
   end
 
-  def build_added_to_public_track?(build_number)
+  def build_present_in_public_track?(build_number)
     channel_data&.any? { |c| c[:name].in?(%w[alpha beta production]) && build_number.in?(c[:releases].pluck(:build_number)) }
   end
 
   def build_present_in_channel?(channel, build_number)
     track_data = installation.get_track(channel, CHANNEL_DATA_TRANSFORMATIONS)
+    return unless track_data
     build_number.in?(track_data[:releases].pluck(:build_number))
   end
 

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -176,7 +176,7 @@ class StepRun < ApplicationRecord
 
   delegate :release_platform, :release, :platform, to: :release_platform_run
   delegate :release_branch, :release_version, to: :release
-  delegate :train, to: :release_platform
+  delegate :train, :store_provider, to: :release_platform
   delegate :app, :ci_cd_provider, :unzip_artifact?, :notify!, to: :train
   delegate :organization, to: :app
   delegate :commit_hash, to: :commit
@@ -189,7 +189,7 @@ class StepRun < ApplicationRecord
   end
 
   def find_build
-    release_platform.store_provider.find_build(build_number)
+    store_provider.find_build(build_number)
   end
 
   def get_workflow_run
@@ -364,7 +364,8 @@ class StepRun < ApplicationRecord
   end
 
   def sync_store_status!
-    restart_deploy! if release_platform.store_provider.build_added_to_public_track?(build_number)
+    return unless deployment_failed_with_sync_option?
+    restart_deploy! if store_provider.build_present_in_public_track?(build_number)
   end
 
   private

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -242,11 +242,15 @@ class StepRun < ApplicationRecord
   end
 
   def in_progress?
-    on_track? || ci_workflow_triggered? || ci_workflow_started? || build_ready? || deployment_started?
+    on_track? || ci_workflow_triggered? || ci_workflow_started? || build_ready? || deployment_started? || deployment_restarted?
+  end
+
+  def blocked?
+    ci_workflow_failed? || ci_workflow_halted? || deployment_failed_with_sync_option?
   end
 
   def failed?
-    build_unavailable? || ci_workflow_unavailable? || ci_workflow_failed? || ci_workflow_halted? || deployment_failed?
+    build_unavailable? || ci_workflow_unavailable? || deployment_failed?
   end
 
   def done?

--- a/app/views/notifiers/slack/step_failed.json.erb
+++ b/app/views/notifiers/slack/step_failed.json.erb
@@ -7,5 +7,17 @@
         "text": "The *<%= @step_type %>* step *<%= @step_name %>* failed because – <%= @step_fail_reason %> :rotating_light:"
       }
     }
+    <% if @manual_submission_required %>
+    ,{
+      "type": "context",
+      "elements": [
+        {
+          "type": "plain_text",
+          "text": "<%= manual_submission_required_text %>",
+          "emoji": false
+        }
+      ]
+    }
+    <% end %>
   ]
 }

--- a/app/views/shared/live_release/_stability.html.erb
+++ b/app/views/shared/live_release/_stability.html.erb
@@ -60,13 +60,16 @@
             <% end %>
 
             <% if step_run&.deployment_failed_with_sync_option? && release.on_track? %>
-              <%= authz_button_to :blue,
-                                  "Sync store status",
-                                  sync_store_status_release_step_run_path(release, step_run),
-                                  method: :patch,
-                                  data: { turbo_method: :patch,
-                                          turbo_confirm: "Please ensure that you have manually submitted the build for review by creating a release in at least one public (alpha, beta, production) channel. Continue?" },
-                                  class: "btn-xs mb-2" %>
+              <div class="flex flex-col gap-y-2">
+                <%= render "shared/note_box", type: :error, message: "Due to a previous rejection, new changes cannot be submitted to the store from Tramline. Please submit the current build (#{step_run.build_number}) for review manually from the Google Play Console by creating a release in a public track (eg. Closed testing, Open testing). Once that is done, you can sync the store status with Tramline and move forward with the release train." %>
+                <%= authz_button_to :blue,
+                                    "Sync store status",
+                                    sync_store_status_release_step_run_path(release, step_run),
+                                    method: :patch,
+                                    data: { turbo_method: :patch,
+                                            turbo_confirm: "Please ensure that you have manually submitted the build for review by creating a release in at least one public (alpha, beta, production) channel. Continue?" },
+                                    class: "btn-xs mb-2" %>
+              </div>
             <% end %>
           </div>
 

--- a/app/views/shared/live_release/_stability.html.erb
+++ b/app/views/shared/live_release/_stability.html.erb
@@ -59,7 +59,7 @@
                                   class: "btn-xs mb-2" %>
             <% end %>
 
-            <% if step_run&.deployment_failed_with_sync_option? && release.on_track? %>
+            <% if step_run&.failed_with_action_required? && release.on_track? %>
               <div class="flex flex-col gap-y-2">
                 <%= render "shared/note_box", type: :error, message: "Due to a previous rejection, new changes cannot be submitted to the store from Tramline. Please submit the current build (#{step_run.build_number}) for review manually from the Google Play Console by creating a release in a public track (eg. Closed testing, Open testing). Once that is done, you can sync the store status with Tramline and move forward with the release train." %>
                 <%= authz_button_to :blue,

--- a/app/views/shared/live_release/_stability.html.erb
+++ b/app/views/shared/live_release/_stability.html.erb
@@ -58,6 +58,16 @@
                                           turbo_confirm: "This will re-run the CI workflow. Are you sure?" },
                                   class: "btn-xs mb-2" %>
             <% end %>
+
+            <% if step_run&.deployment_failed_with_sync_option? && release.on_track? %>
+              <%= authz_button_to :blue,
+                                  "Sync store status",
+                                  sync_store_status_release_step_run_path(release, step_run),
+                                  method: :patch,
+                                  data: { turbo_method: :patch,
+                                          turbo_confirm: "Please ensure that you have manually submitted the build for review by creating a release in at least one public (alpha, beta, production) channel. Continue?" },
+                                  class: "btn-xs mb-2" %>
+            <% end %>
           </div>
 
           <div>

--- a/app/views/shared/live_release/_step_run_status.html.erb
+++ b/app/views/shared/live_release/_step_run_status.html.erb
@@ -4,7 +4,7 @@
   <% if step_run&.in_progress? %>
     <span class="w-4 h-4 mt-2 mr-1 bg-indigo-100 rounded-full animate-ping ring-2"></span>
   <% elsif step_run&.blocked? %>
-    <span class="w-6 h-6 bg-amber-100 rounded-full ring-2 ring-rose-500"></span>
+    <span class="w-6 h-6 bg-amber-100 rounded-full ring-2 ring-amber-500"></span>
   <% elsif step_run&.done? %>
     <span class="w-6 h-6 bg-green-100 rounded-full ring-2 ring-green-500 text-white"></span>
   <% elsif step_run&.failed? %>

--- a/app/views/shared/live_release/_step_run_status.html.erb
+++ b/app/views/shared/live_release/_step_run_status.html.erb
@@ -3,6 +3,8 @@
 <div class="flex items-center">
   <% if step_run&.in_progress? %>
     <span class="w-4 h-4 mt-2 mr-1 bg-indigo-100 rounded-full animate-ping ring-2"></span>
+  <% elsif step_run&.blocked? %>
+    <span class="w-6 h-6 bg-amber-100 rounded-full ring-2 ring-rose-500"></span>
   <% elsif step_run&.done? %>
     <span class="w-6 h-6 bg-green-100 rounded-full ring-2 ring-green-500 text-white"></span>
   <% elsif step_run&.failed? %>

--- a/config/locales/passport/en.yml
+++ b/config/locales/passport/en.yml
@@ -33,6 +33,8 @@ en:
       build_unavailable_html: 'Build <span class="emphasize">%{version}</span> is not available'
       build_not_found_in_store_html: 'Build <span class="emphasize">%{version}</span> was not found in the store'
       build_found_in_store_html: 'Build <span class="emphasize">%{version}</span> located in the store'
+      deployment_restarted_html: 'Build <span class="emphasize">%{version}</span> review status was manually resolved from the store console, release resumed'
+      deployment_failed_with_sync_option_html: 'Build <span class="emphasize">%{version}</span> review status in the store needs to be manually resolved, release blocked'
       finished_html: 'Finished step <span class="emphasize">%{name}</span> for <span class="emphasize">%{sha}</span>'
     commit:
       created_html: 'New commit <span class="emphasize">%{sha}</span> has landed'
@@ -46,6 +48,7 @@ en:
       review_approved_html: 'Review for release for <span class="emphasize">%{version}</span> approved by the store'
       release_started_html: 'Started the release of <span class="emphasize">%{version}</span> to <span class="emphasize">%{provider}</span> in <span class="emphasize">%{chan}</span>'
       released_html: 'Finished releasing <span class="emphasize">%{version}</span> to <span class="emphasize">%{provider}</span> in <span class="emphasize">%{chan}</span>'
+      skipped_html: 'Skipped releasing <span class="emphasize">%{version}</span> to <span class="emphasize">%{provider}</span> in <span class="emphasize">%{chan}</span> as it was manually overridden'
     staged_rollout:
       started_html: 'Staged release started with <span class="emphasize">%{rollout_percentage}%</span>'
       paused_html: 'Staged release paused at <span class="emphasize">%{rollout_percentage}%</span>'

--- a/config/locales/passport/en.yml
+++ b/config/locales/passport/en.yml
@@ -34,7 +34,7 @@ en:
       build_not_found_in_store_html: 'Build <span class="emphasize">%{version}</span> was not found in the store'
       build_found_in_store_html: 'Build <span class="emphasize">%{version}</span> located in the store'
       deployment_restarted_html: 'Build <span class="emphasize">%{version}</span> review status was manually resolved from the store console, release resumed'
-      deployment_failed_with_sync_option_html: 'Build <span class="emphasize">%{version}</span> review status in the store needs to be manually resolved, release blocked'
+      failed_with_action_required_html: 'Build <span class="emphasize">%{version}</span> review status in the store needs to be manually resolved, release blocked'
       finished_html: 'Finished step <span class="emphasize">%{name}</span> for <span class="emphasize">%{sha}</span>'
     commit:
       created_html: 'New commit <span class="emphasize">%{sha}</span> has landed'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
           member do
             post :start
             patch :retry_ci_workflow
+            patch :sync_store_status
           end
 
           resources :deployments, only: [] do

--- a/spec/factories/deployments.rb
+++ b/spec/factories/deployments.rb
@@ -13,6 +13,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_release_step do
+      before(:create) do |deployment, _|
+        train = create(:train, app: deployment.integration.app)
+        release_platform = create(:release_platform, train: train)
+        build(:step, :release, release_platform: release_platform)
+          .tap { |step| step.deployments << deployment }
+          .save
+      end
+    end
+
     trait :with_production_channel do
       build_artifact_channel { {is_production: true} }
     end

--- a/spec/factories/step_runs.rb
+++ b/spec/factories/step_runs.rb
@@ -28,6 +28,10 @@ FactoryBot.define do
       status { "deployment_started" }
     end
 
+    trait :deployment_restarted do
+      status { "deployment_restarted" }
+    end
+
     trait :success do
       status { "success" }
     end

--- a/spec/libs/deployments/google_play_store/release_spec.rb
+++ b/spec/libs/deployments/google_play_store/release_spec.rb
@@ -139,4 +139,154 @@ describe Deployments::GooglePlayStore::Release do
       expect(providable_dbl).to have_received(:halt_release)
     end
   end
+
+  describe ".start_release!" do
+    let(:providable_dbl) { instance_double(GooglePlayStoreIntegration) }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:provider).and_return(providable_dbl)
+    end
+
+    context "when staged rollout" do
+      let(:deployment_run) { create(:deployment_run, :uploaded, :with_google_play_store, :with_staged_rollout) }
+
+      it "creates draft release" do
+        allow(providable_dbl).to receive(:create_draft_release).and_return(GitHub::Result.new)
+        described_class.start_release!(deployment_run)
+        expect(providable_dbl).to have_received(:create_draft_release)
+          .with(deployment_run.deployment_channel,
+            deployment_run.build_number,
+            deployment_run.release_version,
+            [{language: "en-US",
+              text: "The latest version contains bug fixes and performance improvements."}])
+      end
+
+      it "marks the run as release started" do
+        allow(providable_dbl).to receive(:create_draft_release).and_return(GitHub::Result.new)
+        expect { described_class.start_release!(deployment_run) }.to change(deployment_run, :rollout_started?)
+      end
+    end
+
+    context "when no staged rollout" do
+      let(:deployment_run) { create(:deployment_run, :uploaded, :with_google_play_store) }
+
+      it "creates release with full rollout for non-production channel" do
+        allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
+        described_class.start_release!(deployment_run)
+        expect(providable_dbl).to have_received(:rollout_release)
+          .with(deployment_run.deployment_channel,
+            deployment_run.build_number,
+            deployment_run.release_version,
+            Deployment::FULL_ROLLOUT_VALUE,
+            [{language: "en-US", text: "Nothing new"}])
+      end
+
+      it "creates release with full rollout for production channel" do
+        deployment = create(:deployment, :with_release_step, :with_google_play_store, :with_production_channel)
+        deployment_run = create(:deployment_run, deployment:)
+        allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
+        described_class.start_release!(deployment_run)
+        expect(providable_dbl).to have_received(:rollout_release)
+          .with(deployment_run.deployment_channel,
+            deployment_run.build_number,
+            deployment_run.release_version,
+            Deployment::FULL_ROLLOUT_VALUE,
+            [{language: "en-US",
+              text: "The latest version contains bug fixes and performance improvements."}])
+      end
+
+      it "marks the run as released" do
+        allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
+        expect { described_class.start_release!(deployment_run) }.to change(deployment_run, :released?)
+      end
+    end
+
+    context "when step run is restarted and release is not present in the channel" do
+      context "when staged rollout" do
+        let(:step) { create(:step, :with_deployment, :release) }
+        let(:step_run) { create(:step_run, :deployment_restarted, step:) }
+        let(:deployment_run) { create(:deployment_run, :uploaded, :with_google_play_store, :with_staged_rollout, step_run:) }
+
+        it "creates the draft release" do
+          allow(providable_dbl).to receive(:build_present_in_channel?).and_return(false)
+          allow(providable_dbl).to receive(:create_draft_release).and_return(GitHub::Result.new)
+          described_class.start_release!(deployment_run)
+          expect(providable_dbl).to have_received(:create_draft_release)
+            .with(deployment_run.deployment_channel,
+              deployment_run.build_number,
+              deployment_run.release_version,
+              [{language: "en-US",
+                text: "The latest version contains bug fixes and performance improvements."}])
+        end
+
+        it "marks a run as release started" do
+          allow(providable_dbl).to receive(:build_present_in_channel?).and_return(false)
+          allow(providable_dbl).to receive(:create_draft_release).and_return(GitHub::Result.new)
+          expect { described_class.start_release!(deployment_run) }.to change(deployment_run, :rollout_started?)
+        end
+      end
+
+      context "when no staged rollout" do
+        let(:step_run) { create(:step_run, :deployment_restarted) }
+        let(:deployment_run) { create(:deployment_run, :uploaded, :with_google_play_store, step_run:) }
+
+        it "creates a full rollout release" do
+          allow(providable_dbl).to receive(:build_present_in_channel?).and_return(false)
+          allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
+          described_class.start_release!(deployment_run)
+          expect(providable_dbl).to have_received(:rollout_release)
+            .with(deployment_run.deployment_channel,
+              deployment_run.build_number,
+              deployment_run.release_version,
+              Deployment::FULL_ROLLOUT_VALUE,
+              [{language: "en-US", text: "Nothing new"}])
+        end
+
+        it "marks a run as released when no staged rollout" do
+          allow(providable_dbl).to receive(:build_present_in_channel?).and_return(false)
+          allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
+          expect { described_class.start_release!(deployment_run) }.to change(deployment_run, :released?)
+        end
+      end
+    end
+
+    context "when step run is restarted and release is present in the channel" do
+      context "when staged rollout" do
+        let(:step) { create(:step, :with_deployment, :release) }
+        let(:step_run) { create(:step_run, :deployment_restarted, step:) }
+        let(:deployment_run) { create(:deployment_run, :uploaded, :with_google_play_store, :with_staged_rollout, step_run:) }
+
+        it "does not create the draft release" do
+          allow(providable_dbl).to receive(:build_present_in_channel?).and_return(true)
+          allow(providable_dbl).to receive(:create_draft_release)
+          described_class.start_release!(deployment_run)
+          expect(providable_dbl).not_to have_received(:create_draft_release)
+        end
+
+        it "marks a run as release started" do
+          allow(providable_dbl).to receive(:build_present_in_channel?).and_return(true)
+          allow(providable_dbl).to receive(:create_draft_release)
+          expect { described_class.start_release!(deployment_run) }.to change(deployment_run, :rollout_started?)
+        end
+      end
+
+      context "when no staged rollout" do
+        let(:step_run) { create(:step_run, :deployment_restarted) }
+        let(:deployment_run) { create(:deployment_run, :uploaded, :with_google_play_store, step_run:) }
+
+        it "does not create a full rollout release" do
+          allow(providable_dbl).to receive(:build_present_in_channel?).and_return(true)
+          allow(providable_dbl).to receive(:rollout_release)
+          described_class.start_release!(deployment_run)
+          expect(providable_dbl).not_to have_received(:rollout_release)
+        end
+
+        it "marks a run as released when no staged rollout" do
+          allow(providable_dbl).to receive(:build_present_in_channel?).and_return(true)
+          allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
+          expect { described_class.start_release!(deployment_run) }.to change(deployment_run, :released?)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/google_play_store_integration_spec.rb
+++ b/spec/models/google_play_store_integration_spec.rb
@@ -19,7 +19,7 @@ describe GooglePlayStoreIntegration do
       allow(api_double).to receive(:upload)
 
       expect(google_integration.upload(file).ok?).to be true
-      expect(api_double).to have_received(:upload).with(file).once
+      expect(api_double).to have_received(:upload).with(file, skip_review: nil).once
     end
 
     it "returns successful result if there are allowed exceptions" do
@@ -28,7 +28,19 @@ describe GooglePlayStoreIntegration do
       allow(api_double).to receive(:upload).and_raise(Installations::Google::PlayDeveloper::Error.new(error))
 
       expect(google_integration.upload(file).ok?).to be true
-      expect(api_double).to have_received(:upload).with(file).once
+      expect(api_double).to have_received(:upload).with(file, skip_review: nil).once
+    end
+
+    it "retries if there are retryable exceptions" do
+      error_body = {"error" => {"status" => "INVALID_ARGUMENT",
+                                "code" => 400,
+                                "message" => "Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI"}}
+      error = Google::Apis::ClientError.new("Error", body: error_body.to_json)
+      allow(api_double).to receive(:upload).and_raise(Installations::Google::PlayDeveloper::Error.new(error))
+
+      expect(google_integration.upload(file).ok?).to be false
+      expect(api_double).to have_received(:upload).with(file, skip_review: nil).once
+      expect(api_double).to have_received(:upload).with(file, skip_review: true).twice
     end
 
     it "returns failed result if there are disallowed exceptions" do
@@ -37,14 +49,14 @@ describe GooglePlayStoreIntegration do
       allow(api_double).to receive(:upload).and_raise(Installations::Google::PlayDeveloper::Error.new(error))
 
       expect(google_integration.upload(file).ok?).to be false
-      expect(api_double).to have_received(:upload).with(file).once
+      expect(api_double).to have_received(:upload).with(file, skip_review: nil).once
     end
 
     it "returns failed result if there are unexpected exceptions" do
       allow(api_double).to receive(:upload).and_raise(StandardError.new)
 
       expect(google_integration.upload(file).ok?).to be false
-      expect(api_double).to have_received(:upload).with(file).once
+      expect(api_double).to have_received(:upload).with(file, skip_review: nil).once
     end
   end
 end

--- a/spec/models/release_platform_run_spec.rb
+++ b/spec/models/release_platform_run_spec.rb
@@ -153,7 +153,7 @@ describe ReleasePlatformRun do
       release_platform_run.update!(last_commit: commit)
       steps = create_list(:step, 4, :with_deployment, release_platform:)
       _step_run_1 = create(:step_run, commit:, step: steps.first, status: "success", release_platform_run:)
-      _step_run_2 = create(:step_run, commit:, step: steps.second, status: "ci_workflow_failed", release_platform_run:)
+      _step_run_2 = create(:step_run, commit:, step: steps.second, status: "deployment_failed", release_platform_run:)
       _step_run_3 = create(:step_run, commit:, step: steps.third, status: "on_track", release_platform_run:)
 
       expectation = {


### PR DESCRIPTION
Closes: https://github.com/tramlinehq/tramline/issues/569

Changes:
- Upload to Play Store with skip review flag when it fails due to previous rejection
- When the error happens during release creation, mark the deployment and step run as needing manual intervention
- Allow syncing store status for the step run from the release page (with a suggestion on how to fix the issue)
- If the build is present in a public track (and hence presumed to be submitted for review), skip the failed deployment run and move the release forward
- For further deployments to the store, if the step run was resumed after a manual intervention, check the build presence on the track before creating release

When step run is blocked due to the review submission error:
<img width="644" alt="Screenshot 2023-12-15 at 4 20 42 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/41ee84b1-482d-49e2-a4d5-6961f658f93b">

Notification for the same:
<img width="687" alt="Screenshot 2023-12-15 at 4 38 23 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/de90fb06-1c9f-4d7a-8e92-eedf42dbe55e">

If a user syncs the status before resolving it on the Console:
<img width="855" alt="Screenshot 2023-12-15 at 4 40 54 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/477f7aa7-d735-435c-8b90-d328fc80399a">

If a user syncs the status after resolving it on the Console:
<img width="569" alt="Screenshot 2023-12-15 at 4 41 56 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/64fa2572-1897-4df8-90f4-22205c96b13d">

Post resolution:
<img width="654" alt="Screenshot 2023-12-15 at 3 57 28 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/377b097a-65a3-40a2-a172-cd5f3e337ce5">

Events:
<img width="812" alt="Screenshot 2023-12-15 at 4 42 27 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/1f841f15-f2b4-489a-8605-f991b0a67d11">

