### PR TITLE
Fixes for Parallel Working Branch strategy

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -124,9 +124,9 @@ class ReleasesController < SignedInApplicationController
   end
 
   def set_pull_requests
-    @pre_release_prs = @release.pull_requests.pre_release
-    @post_release_prs = @release.pull_requests.post_release
-    @ongoing_open_release_prs = @release.pull_requests.ongoing.open
+    @pre_release_prs = @release.pre_release_prs
+    @post_release_prs = @release.post_release_prs
+    @ongoing_open_release_prs = @release.backmerge_prs.open
   end
 
   def set_commits

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -217,6 +217,8 @@ module Installations
     end
 
     def create_pr!(repo, to, from, title, body, transforms)
+      raise Installations::Errors::PullRequestWithoutCommits unless diff?(repo, to, from)
+
       execute do
         @client
           .create_pull_request(repo, to, from, title, body)

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -258,6 +258,15 @@ module Installations
       end
     end
 
+    def diff?(repo, from_branch, to_branch)
+      execute do
+        @client
+          .compare(repo, from_branch, to_branch)
+          .dig(:files)
+          .present?
+      end
+    end
+
     def head(repo, working_branch_name, sha_only: true, commit_transforms: nil)
       raise ArgumentError, "transforms must be supplied when querying head object" if !sha_only && !commit_transforms
 

--- a/app/libs/triggers/post_release/parallel_branches.rb
+++ b/app/libs/triggers/post_release/parallel_branches.rb
@@ -20,8 +20,6 @@ class Triggers::PostRelease
     delegate :logger, to: Rails
 
     def create_and_merge_pr
-      return GitHub::Result.new { true } unless release.post_release_pr_required?
-
       Triggers::PullRequest.create_and_merge!(
         release: release,
         new_pull_request: release.pull_requests.post_release.open.build,

--- a/app/libs/triggers/post_release/parallel_branches.rb
+++ b/app/libs/triggers/post_release/parallel_branches.rb
@@ -26,7 +26,8 @@ class Triggers::PostRelease
         to_branch_ref: working_branch,
         from_branch_ref: release_branch,
         title: pr_title,
-        description: pr_description
+        description: pr_description,
+        existing_pr: release.pull_requests.post_release.first
       ).then do |value|
         stamp_pr_success
         GitHub::Result.new { value }

--- a/app/libs/triggers/post_release/parallel_branches.rb
+++ b/app/libs/triggers/post_release/parallel_branches.rb
@@ -20,6 +20,8 @@ class Triggers::PostRelease
     delegate :logger, to: Rails
 
     def create_and_merge_pr
+      return GitHub::Result.new { true } unless release.post_release_pr_required?
+
       Triggers::PullRequest.create_and_merge!(
         release: release,
         new_pull_request: release.pull_requests.post_release.open.build,

--- a/app/libs/triggers/release.rb
+++ b/app/libs/triggers/release.rb
@@ -54,6 +54,7 @@ class Triggers::Release
         raise ReleaseAlreadyInProgress.new("No more releases can be started until the ongoing release is finished!") if train.upcoming_release.present?
         raise UpcomingReleaseNotAllowed.new("Upcoming releases are not allowed for your train.") if train.ongoing_release.present? && !train.upcoming_release_startable?
         raise NothingToRelease.new("No diff since last release") if regular_release? && !train.diff_since_last_release?
+        raise NothingToRelease.new("No diff between working and release branch") if train.parallel_working_branch? && !train.diff_for_release?
         train.activate! unless train.active?
         create_release
         train.create_webhook!

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -272,6 +272,10 @@ class GithubIntegration < ApplicationRecord
     installation.commits_between(code_repository_name, from_branch, to_branch, COMMITS_TRANSFORMATIONS)
   end
 
+  def diff_between?(from_branch, to_branch)
+    installation.diff?(code_repository_name, from_branch, to_branch)
+  end
+
   def public_icon_img
     PUBLIC_ICON
   end

--- a/app/models/gitlab_integration.rb
+++ b/app/models/gitlab_integration.rb
@@ -219,6 +219,10 @@ class GitlabIntegration < ApplicationRecord
     with_api_retries { installation.commits_between(code_repository_name, from_branch, to_branch, COMMITS_BETWEEN_TRANSFORMATIONS) }
   end
 
+  def diff_between?(from_branch, to_branch)
+    with_api_retries { installation.diff?(code_repository_name, from_branch, to_branch) }
+  end
+
   def create_patch_pr!(to_branch, patch_branch, commit_hash, pr_title_prefix)
     # FIXME
     {}.merge_if_present(source: :gitlab)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -144,10 +144,6 @@ class Release < ApplicationRecord
 
   def self.for_branch(branch_name) = find_by(branch_name:)
 
-  def post_release_pr_required?
-    vcs_provider.diff_between?(train.working_branch, release_branch)
-  end
-
   def finish_after_partial_finish!
     with_lock do
       return unless partially_finished?

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -135,7 +135,7 @@ class Release < ApplicationRecord
   attr_accessor :has_major_bump, :force_finalize, :hotfix_platform, :custom_version
 
   delegate :versioning_strategy, to: :train
-  delegate :app, :pre_release_prs?, :vcs_provider, :release_platforms, :notify!, :continuous_backmerge?, to: :train
+  delegate :app, :vcs_provider, :release_platforms, :notify!, :continuous_backmerge?, to: :train
   delegate :platform, to: :app
 
   def self.pending_release?
@@ -159,6 +159,14 @@ class Release < ApplicationRecord
 
   def backmerge_prs
     pull_requests.ongoing
+  end
+
+  def post_release_prs
+    pull_requests.post_release
+  end
+
+  def pre_release_prs
+    pull_requests.pre_release
   end
 
   def duration

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -144,6 +144,10 @@ class Release < ApplicationRecord
 
   def self.for_branch(branch_name) = find_by(branch_name:)
 
+  def post_release_pr_required?
+    vcs_provider.diff_between?(train.working_branch, release_branch)
+  end
+
   def finish_after_partial_finish!
     with_lock do
       return unless partially_finished?

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -186,9 +186,9 @@ class Train < ApplicationRecord
   end
 
   def diff_since_last_release?
-    return vcs_provider.commit_log(ongoing_release.first_commit.commit_hash, working_branch).any? if ongoing_release
+    return vcs_provider.diff_between?(ongoing_release.first_commit.commit_hash, working_branch) if ongoing_release
     return true if last_finished_release.blank?
-    vcs_provider.commit_log(last_finished_release.tag_name || last_finished_release.last_commit.commit_hash, working_branch).any?
+    vcs_provider.diff_between?(last_finished_release.tag_name || last_finished_release.last_commit.commit_hash, working_branch)
   end
 
   def diff_for_release?

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -191,6 +191,11 @@ class Train < ApplicationRecord
     vcs_provider.commit_log(last_finished_release.tag_name || last_finished_release.last_commit.commit_hash, working_branch).any?
   end
 
+  def diff_for_release?
+    return false unless parallel_working_branch?
+    vcs_provider.diff_between?(release_branch, working_branch)
+  end
+
   def create_webhook!
     return false if Rails.env.test?
     result = vcs_provider.find_or_create_webhook!(id: vcs_webhook_id, train_id: id)
@@ -328,7 +333,7 @@ class Train < ApplicationRecord
     PullRequest.open.where(release_id: active_runs.ids, head_ref: branch_name)
   end
 
-  def pre_release_prs?
+  def parallel_working_branch?
     branching_strategy == "parallel_working"
   end
 

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -44,7 +44,7 @@
   <div>
     <%= render partial: "shared/live_release/kick_off", locals: { release: @release, release_train: @train } %>
 
-    <% if @release.pre_release_prs? %>
+    <% if @pre_release_prs.present? %>
       <%= render partial: "shared/live_release/separator", locals: { margin_only: true } %>
       <%= render partial: "shared/live_release/pre_release_prs", locals: { pre_release_prs: @pre_release_prs } %>
     <% end %>

--- a/spec/libs/triggers/release_spec.rb
+++ b/spec/libs/triggers/release_spec.rb
@@ -16,7 +16,7 @@ describe Triggers::Release do
       allow_any_instance_of(GooglePlayStoreIntegration).to receive(:draft_check?).and_return(false)
       allow(Installations::Github::Jwt).to receive(:new).and_return(github_jwt_double)
       allow(Installations::Github::Api).to receive(:new).and_return(github_api_double)
-      allow(github_api_double).to receive(:commits_between).and_return([1])
+      allow(github_api_double).to receive(:diff?).and_return(true)
     end
 
     it "creates a new release" do


### PR DESCRIPTION
Since we create a pre-release PR from the working branch to the release branch, depending on the merge strategy it can create an unnecessary merge cycle between the two branches even though the actual diff is empty.

Eg.
<img width="673" alt="Screenshot 2023-12-27 at 11 50 42 AM" src="https://github.com/tramlinehq/tramline/assets/1309111/01132b01-4312-4df3-99ff-56255fa386aa">

To fix this, we can check for the actual diff between the branches before creating the PRs.

Other changes:
- Fix retry of finalization to not create a PR if one exists already
- Check for diff between the working branch and  the release branch before starting the release, instead of failing later