### PR TITLE
Enable auto merge for back-merge PRs

### DIFF
--- a/app/libs/triggers/patch_pull_request.rb
+++ b/app/libs/triggers/patch_pull_request.rb
@@ -20,6 +20,7 @@ class Triggers::PatchPullRequest
     end.then do |value|
       pr = commit.build_pull_request(release:, phase: :ongoing).update_or_insert!(**value)
       logger.debug "Patch Pull Request: Created a patch PR successfully", pr
+      repo_integration.enable_auto_merge!(pr.number)
       stamp_pr_success(pr)
       GitHub::Result.new { value }
     end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -48,6 +48,10 @@ class AppConfig < ApplicationRecord
     code_repository["namespace"]
   end
 
+  def code_repo_name_only
+    code_repository["name"]
+  end
+
   def bitrise_project
     bitrise_project_id&.fetch("id", nil)
   end

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -16,7 +16,7 @@ class GithubIntegration < ApplicationRecord
   include Rails.application.routes.url_helpers
   using RefinedHash
 
-  delegate :code_repository_name, :code_repo_namespace, to: :app_config
+  delegate :code_repository_name, :code_repo_namespace, :code_repo_name_only, to: :app_config
   delegate :app, to: :integration
   delegate :organization, to: :app
 
@@ -253,6 +253,10 @@ class GithubIntegration < ApplicationRecord
 
   def create_patch_pr!(to_branch, patch_branch, commit_hash, pr_title_prefix)
     installation.cherry_pick_pr(code_repository_name, to_branch, commit_hash, patch_branch, pr_title_prefix, PR_TRANSFORMATIONS).merge_if_present(source: :github)
+  end
+
+  def enable_auto_merge!(pr_number)
+    installation.enable_auto_merge(code_repo_namespace, code_repo_name_only, pr_number)
   end
 
   def find_pr(to_branch_ref, from_branch_ref)

--- a/app/models/gitlab_integration.rb
+++ b/app/models/gitlab_integration.rb
@@ -228,6 +228,10 @@ class GitlabIntegration < ApplicationRecord
     {}.merge_if_present(source: :gitlab)
   end
 
+  def enable_auto_merge!(pr_number)
+    # FIXME
+  end
+
   def public_icon_img
     "https://storage.googleapis.com/tramline-public-assets/gitlab_small.png".freeze
   end


### PR DESCRIPTION
To automate the merge process of the back-merge PRs once checks and approvals have passed.