### PR TITLE
Let the users decide which distributions should have builds notes sent

### DIFF
--- a/app/javascript/controllers/domain/staged_rollout_help_controller.js
+++ b/app/javascript/controllers/domain/staged_rollout_help_controller.js
@@ -1,6 +1,6 @@
 import {Controller} from "@hotwired/stimulus";
 
-const baseHelpText = "You will be able to rollout to users in the following stages: "
+const baseHelpText = "Rollout to users will be in the following stages: "
 
 export default class extends Controller {
   static targets = [

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -7,6 +7,7 @@
 #  deployment_number      :integer          default(0), not null, indexed => [step_id]
 #  discarded_at           :datetime         indexed
 #  is_staged_rollout      :boolean          default(FALSE)
+#  send_build_notes       :boolean          default(TRUE)
 #  staged_rollout_config  :decimal(, )      default([]), is an Array
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/app/views/steps/_deployment.html.erb
+++ b/app/views/steps/_deployment.html.erb
@@ -37,38 +37,46 @@
       </div>
     </div>
 
-    <% if step.release? %>
-      <div class="flex flex-row items-center gap-4 w-full">
-        <div class="w-6"></div>
-        <div class="flex-grow" data-dropdown-stream-target="showElement" hidden>
-          <div data-controller="reveal" class="inline-flex gap-x-4">
-            <div class="flex items-center">
-              <%= form.check_box :is_staged_rollout, class: "form-checkbox", data: { action: "reveal#toggle" } %>
-              <%= form.label :is_staged_rollout, t("staged_rollout.#{step.release_platform.platform}.checkbox"), class: "text-sm ml-2" %>
 
-              <% if step.release_platform.ios? %>
-                <span class="ml-2 text-xs text-slate-400">Phased release in App Store goes from 1%, 2%, 5%, 10%, 20%, 50% to 100% over 7 days</span>
-              <% else %>
-                <%= form.text_field :staged_rollout_config,
-                                    class: "ml-2 form-input",
-                                    hidden: true,
-                                    placeholder: "1, 2, 5, 10, 20, 50, 100",
-                                    data: { reveal: true,
-                                            domain__staged_rollout_help_target: "input",
-                                            action: "domain--staged-rollout-help#validateString" } %>
-              <% end %>
+    <div class="flex flex-row items-center gap-4 w-full">
+      <div class="w-6"></div>
+      <div class="flex-grow" data-dropdown-stream-target="showElement" hidden>
+        <div data-controller="reveal" class="inline-flex gap-x-4">
+          <div class="flex items-center gap-x-6">
+            <div>
+              <%= form.check_box :send_build_notes, class: "form-checkbox" %>
+              <%= form.label :send_build_notes, "Send auto-generated build notes", class: "text-sm" %>
             </div>
+
+            <% if step.release? %>
+              <div class="flex flex-row gap-x-3 items-center">
+                <div>
+                  <%= form.check_box :is_staged_rollout, class: "form-checkbox", data: { action: "reveal#toggle" } %>
+                  <%= form.label :is_staged_rollout, t("staged_rollout.#{step.release_platform.platform}.checkbox"), class: "text-sm" %>
+                </div>
+
+                <% if step.release_platform.ios? %>
+                <span class="text-xs text-slate-400">
+                  Phased release in App Store goes from 1%, 2%, 5%, 10%, 20%, 50% to 100% over 7 days
+                </span>
+                <% else %>
+                  <%= form.text_field :staged_rollout_config,
+                                      class: "form-input",
+                                      hidden: true,
+                                      placeholder: "1, 2, 5, 10, 20, 50, 100",
+                                      data: { reveal: true,
+                                              domain__staged_rollout_help_target: "input",
+                                              action: "domain--staged-rollout-help#validateString" } %>
+                <% end %>
+
+                <div class="text-sm text-slate-600 italic">
+                  <span data-domain--staged-rollout-help-target="helpErrorText helpSuccessText"></span>
+                </div>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>
-
-      <div class="flex flex-row items-center gap-4 w-full">
-        <div class="w-6"></div>
-
-        <div class="text-sm text-slate-600 italic">
-          <span data-domain--staged-rollout-help-target="helpErrorText helpSuccessText"></span>
-        </div>
-      </div>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,9 +1,9 @@
 en:
   staged_rollout:
     ios:
-      checkbox: "Enable Phased Release?"
+      checkbox: "Enable Phased Release"
     android:
-      checkbox: "Enable Staged Rollout?"
+      checkbox: "Enable Staged Rollout"
   activerecord:
     models:
       slack_integration: "Slack"

--- a/db/migrate/20240123232432_add_build_notes_check_in_deployments.rb
+++ b/db/migrate/20240123232432_add_build_notes_check_in_deployments.rb
@@ -1,0 +1,5 @@
+class AddBuildNotesCheckInDeployments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :deployments, :send_build_notes, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_10_092300) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_23_232432) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -181,6 +181,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_092300) do
     t.decimal "staged_rollout_config", default: [], array: true
     t.boolean "is_staged_rollout", default: false
     t.datetime "discarded_at"
+    t.boolean "send_build_notes", default: true
     t.index ["build_artifact_channel", "integration_id", "step_id"], name: "idx_deployments_on_build_artifact_chan_and_integration_and_step", unique: true
     t.index ["deployment_number", "step_id"], name: "index_deployments_on_deployment_number_and_step_id", unique: true
     t.index ["discarded_at"], name: "index_deployments_on_discarded_at"


### PR DESCRIPTION
So that we don't send unnecessary detailed notes to public channels.