### PR TITLE
Resume a halted controllable rollout

### DIFF
--- a/app/components/staged_rollout_component.rb
+++ b/app/components/staged_rollout_component.rb
@@ -9,7 +9,7 @@ class StagedRolloutComponent < ViewComponent::Base
   FULLY_RELEASE_CONFIRM = "You are about to release this build to all users in production.\n\nAre you sure?"
   PAUSE_RELEASE_CONFIRM = "You are about to pause the scheduled phased release in production.\n\nAre you sure?"
   RESUME_RELEASE_CONFIRM = "You are about to resume the scheduled phased release in production.\n\nAre you sure?"
-  RESUME_HALTED_CONFIRM = "You are about to resume the halted rollout of this build to production.\n\nAre you sure?"
+  RESUME_HALTED_CONFIRM = "You are about to resume the halted rollout of this build in production.\n\nAre you sure?"
 
   def initialize(staged_rollout)
     @staged_rollout = staged_rollout

--- a/app/components/staged_rollout_component.rb
+++ b/app/components/staged_rollout_component.rb
@@ -3,12 +3,13 @@ class StagedRolloutComponent < ViewComponent::Base
   include ButtonHelper
   include AssetsHelper
 
-  HALT_CONFIRM = "You are about to halt the rollout of this build to production, it can not be resumed.\n\nAre you sure?"
+  HALT_CONFIRM = "You are about to halt the rollout of this build to production.\n\nAre you sure?"
   START_RELEASE_CONFIRM = "You are about to release this build to the first stage in production.\n\nAre you sure?"
   RELEASE_CONFIRM = "You are about to release this build to the next stage in production.\n\nAre you sure?"
   FULLY_RELEASE_CONFIRM = "You are about to release this build to all users in production.\n\nAre you sure?"
   PAUSE_RELEASE_CONFIRM = "You are about to pause the scheduled phased release in production.\n\nAre you sure?"
   RESUME_RELEASE_CONFIRM = "You are about to resume the scheduled phased release in production.\n\nAre you sure?"
+  RESUME_HALTED_CONFIRM = "You are about to resume the halted rollout of this build to production.\n\nAre you sure?"
 
   def initialize(staged_rollout)
     @staged_rollout = staged_rollout
@@ -38,6 +39,7 @@ class StagedRolloutComponent < ViewComponent::Base
       actions << {form_url: increase_release_path, confirm: START_RELEASE_CONFIRM, type: :blue, name: "Start Rollout"} if created?
       actions << {form_url: increase_release_path, confirm: RELEASE_CONFIRM, type: :blue, name: "Increase Rollout"} if started?
       actions << {form_url: increase_release_path, confirm: RELEASE_CONFIRM, type: :blue, name: "Retry"} if failed?
+      actions << {form_url: resume_release_path, confirm: RESUME_HALTED_CONFIRM, type: :blue, name: "Resume Rollout"} if stopped?
     end
 
     if automatic_rollout?

--- a/app/controllers/staged_rollouts_controller.rb
+++ b/app/controllers/staged_rollouts_controller.rb
@@ -3,8 +3,8 @@ class StagedRolloutsController < SignedInApplicationController
   before_action :set_deployment_run
   before_action :set_staged_rollout
   before_action :ensure_controlled_rolloutable, only: [:increase, :halt]
-  before_action :ensure_rolloutable, only: [:fully_release]
-  before_action :ensure_auto_rolloutable, only: [:pause, :resume]
+  before_action :ensure_rolloutable, only: [:fully_release, :resume]
+  before_action :ensure_auto_rolloutable, only: [:pause]
 
   def increase
     @staged_rollout.move_to_next_stage!


### PR DESCRIPTION
## Because

that's allowed on the Play Store

<img width="608" alt="Screenshot 2024-02-08 at 2 10 25 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/c351e616-f3ce-4362-b59e-4bfed0f25f5d">


