### PR TITLE
Config to send build, release and no notes to non-prod distributions

### DIFF
--- a/app/assets/images/bolt.svg
+++ b/app/assets/images/bolt.svg
@@ -1,1 +1,1 @@
-<svg fill="none" height="100%" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24" width="100%" xmlns="http://www.w3.org/2000/svg"><path d="m0 0h24v24h-24z" fill="none" stroke="none"/><path d="m13 3v7h6l-8 11v-7h-6z"/></svg>
+<svg fill="none" height="100%" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24" width="100%" xmlns="http://www.w3.org/2000/svg"><path d="m0 0h24v24h-24z" fill="none" stroke="none"/><path d="m13 3v7h6l-8 11v-7h-6z"/></svg>

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -131,7 +131,7 @@ class StepsController < SignedInApplicationController
         :build_artifact_channel,
         :deployment_number,
         :is_staged_rollout,
-        :send_notes,
+        :notes,
         :staged_rollout_config
       ])
   end
@@ -147,7 +147,7 @@ class StepsController < SignedInApplicationController
         attributes.merge(
           staged_rollout_config: attributes[:staged_rollout_config]&.safe_csv_parse,
           build_artifact_channel: attributes[:build_artifact_channel]&.safe_json_parse
-        ).merge(deployment_notes_config(attributes[:send_notes]))
+        )
       ]
     end
   end
@@ -157,11 +157,5 @@ class StepsController < SignedInApplicationController
       .build_channel_integrations
       .map { |bc| [bc.providable.display, bc.id] }
       .push(Integration::EXTERNAL_BUILD_INTEGRATION[:build_integration])
-  end
-
-  def deployment_notes_config(send_notes)
-    return {send_build_notes: true} if send_notes == "send_build_notes"
-    return {send_release_notes: true} if send_notes == "send_release_notes"
-    {}
   end
 end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -131,7 +131,7 @@ class StepsController < SignedInApplicationController
         :build_artifact_channel,
         :deployment_number,
         :is_staged_rollout,
-        :send_build_notes,
+        :send_notes,
         :staged_rollout_config
       ])
   end
@@ -147,7 +147,7 @@ class StepsController < SignedInApplicationController
         attributes.merge(
           staged_rollout_config: attributes[:staged_rollout_config]&.safe_csv_parse,
           build_artifact_channel: attributes[:build_artifact_channel]&.safe_json_parse
-        )
+        ).merge(deployment_notes_config(attributes[:send_notes]))
       ]
     end
   end
@@ -157,5 +157,11 @@ class StepsController < SignedInApplicationController
       .build_channel_integrations
       .map { |bc| [bc.providable.display, bc.id] }
       .push(Integration::EXTERNAL_BUILD_INTEGRATION[:build_integration])
+  end
+
+  def deployment_notes_config(send_notes)
+    return {send_build_notes: true} if send_notes == "send_build_notes"
+    return {send_release_notes: true} if send_notes == "send_release_notes"
+    {}
   end
 end

--- a/app/jobs/deployments/app_store_connect/update_build_notes_job.rb
+++ b/app/jobs/deployments/app_store_connect/update_build_notes_job.rb
@@ -3,7 +3,7 @@ class Deployments::AppStoreConnect::UpdateBuildNotesJob < ApplicationJob
 
   def perform(deployment_run_id)
     run = DeploymentRun.find(deployment_run_id)
-    return unless run.send_build_notes?
+    return unless run.send_notes?
     return unless run.test_flight_release?
 
     Deployments::AppStoreConnect::Release.update_build_notes!(run)

--- a/app/jobs/deployments/google_firebase/update_build_notes_job.rb
+++ b/app/jobs/deployments/google_firebase/update_build_notes_job.rb
@@ -3,7 +3,7 @@ class Deployments::GoogleFirebase::UpdateBuildNotesJob < ApplicationJob
 
   def perform(deployment_run_id, release)
     run = DeploymentRun.find(deployment_run_id)
-    return unless run.send_build_notes?
+    return unless run.send_notes?
     return unless run.google_firebase_integration?
 
     Deployments::GoogleFirebase::Release.update_build_notes!(run, release)

--- a/app/libs/deployments/app_store_connect/release.rb
+++ b/app/libs/deployments/app_store_connect/release.rb
@@ -75,6 +75,7 @@ module Deployments
         :staged_rollout_config,
         :release_metadata,
         :internal_channel?,
+        :deployment_notes,
         to: :run
 
       def kickoff!
@@ -100,8 +101,7 @@ module Deployments
       end
 
       def update_build_notes!
-        build_notes = run.step_run.build_notes.truncate(ReleaseMetadata::NOTES_MAX_LENGTH)
-        provider.update_release_notes(build_number, build_notes)
+        provider.update_release_notes(build_number, deployment_notes)
       end
 
       def prepare_for_release!(force: false)

--- a/app/libs/deployments/google_firebase/release.rb
+++ b/app/libs/deployments/google_firebase/release.rb
@@ -38,6 +38,7 @@ module Deployments
         :google_firebase_integration?,
         :release_platform,
         :step_run,
+        :deployment_notes,
         to: :run
       delegate :platform, to: :release_platform
 
@@ -89,7 +90,7 @@ module Deployments
       end
 
       def update_build_notes!(release)
-        provider.update_release_notes(release, step_run.build_notes)
+        provider.update_release_notes(release, deployment_notes)
       end
 
       def start_release!

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -50,6 +50,8 @@ class DeploymentRun < ApplicationRecord
     :app_store?,
     :test_flight?,
     :store?,
+    :send_notes?,
+    :send_release_notes?,
     :send_build_notes?,
     :staged_rollout?,
     :staged_rollout_config,
@@ -191,6 +193,11 @@ class DeploymentRun < ApplicationRecord
 
   def self.reached_production
     ready.includes(:step_run, :deployment).select(&:production_channel?)
+  end
+
+  def deployment_notes
+    return step_run.build_notes.truncate(ReleaseMetadata::NOTES_MAX_LENGTH) if send_build_notes?
+    release_metadata.release_notes if send_release_notes?
   end
 
   def healthy?

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -51,8 +51,8 @@ class DeploymentRun < ApplicationRecord
     :test_flight?,
     :store?,
     :send_notes?,
-    :send_release_notes?,
-    :send_build_notes?,
+    :release_notes?,
+    :build_notes?,
     :staged_rollout?,
     :staged_rollout_config,
     :google_firebase_integration?,
@@ -196,8 +196,8 @@ class DeploymentRun < ApplicationRecord
   end
 
   def deployment_notes
-    return step_run.build_notes.truncate(ReleaseMetadata::NOTES_MAX_LENGTH) if send_build_notes?
-    release_metadata.release_notes if send_release_notes?
+    return step_run.build_notes.truncate(ReleaseMetadata::NOTES_MAX_LENGTH) if build_notes?
+    release_metadata.release_notes if release_notes?
   end
 
   def healthy?

--- a/app/views/shared/_deployment.html.erb
+++ b/app/views/shared/_deployment.html.erb
@@ -4,14 +4,14 @@
            locals: { name: show_deployment(deployment),
                      provider_name: deployment.integration_type.to_s } %>
 
-<% if deployment.send_build_notes %>
+<% if deployment.build_notes? %>
   <div class="inline-flex text-slate-500 text-xs ml-1" title="Auto-generated Notes">
     <%= inline_svg("clipboard_copy.svg", classname: "w-4 inline-flex") %>
     <span>+</span>
     <%= inline_svg("bolt.svg", classname: "w-4 inline-flex") %>
   </div>
 <% end %>
-<% if deployment.send_release_notes? %>
+<% if deployment.release_notes? %>
   <div class="inline-flex text-slate-500 ml-1" title="Public Release Notes">
     <%= inline_svg("clipboard_copy.svg", classname: "w-4 inline-flex") %>
   </div>

--- a/app/views/shared/_deployment.html.erb
+++ b/app/views/shared/_deployment.html.erb
@@ -4,6 +4,19 @@
            locals: { name: show_deployment(deployment),
                      provider_name: deployment.integration_type.to_s } %>
 
+<% if deployment.send_build_notes %>
+  <div class="inline-flex text-slate-500 text-xs ml-1" title="Auto-generated Notes">
+    <%= inline_svg("clipboard_copy.svg", classname: "w-4 inline-flex") %>
+    <span>+</span>
+    <%= inline_svg("bolt.svg", classname: "w-4 inline-flex") %>
+  </div>
+<% end %>
+<% if deployment.send_release_notes? %>
+  <div class="inline-flex text-slate-500 ml-1" title="Public Release Notes">
+    <%= inline_svg("clipboard_copy.svg", classname: "w-4 inline-flex") %>
+  </div>
+<% end %>
+
 <% if deployment.staged_rollout? %>
   <span class="ml-1"><%= status_badge("Staged rollout enabled", :neutral) %></span>
 <% end %>

--- a/app/views/steps/_deployment.html.erb
+++ b/app/views/steps/_deployment.html.erb
@@ -43,16 +43,16 @@
       <div data-dropdown-stream-target="hideElement">
         <div class="flex flex-row items-center gap-x-4">
           <div class="flex flex-row items-center gap-x-2">
-            <%= form.radio_button :send_notes, "send_build_notes" %>
-            <%= form.label :send_build_notes, "Send auto-generated build notes" %>
+            <%= form.radio_button :notes, "build_notes" %>
+            <%= form.label :build_notes, "Send auto-generated build notes" %>
           </div>
           <div class="flex flex-row items-center gap-x-2">
-            <%= form.radio_button :send_notes, "send_release_notes" %>
-            <%= form.label :send_release_notes, "Send Release Notes" %>
+            <%= form.radio_button :notes, "release_notes" %>
+            <%= form.label :release_notes, "Send Release Notes" %>
           </div>
           <div class="flex flex-row items-center gap-x-2">
-            <%= form.radio_button :send_notes, "send_no_notes" %>
-            <%= form.label :send_no_notes, "Send No Notes" %>
+            <%= form.radio_button :notes, "no_notes" %>
+            <%= form.label :no_notes, "Send No Notes" %>
           </div>
         </div>
       </div>

--- a/app/views/steps/_deployment.html.erb
+++ b/app/views/steps/_deployment.html.erb
@@ -41,8 +41,20 @@
     <div class="flex flex-row items-center gap-4 w-full">
       <div class="w-6"></div>
       <div data-dropdown-stream-target="hideElement">
-        <%= form.check_box :send_build_notes, class: "form-checkbox" %>
-        <%= form.label :send_build_notes, "Send auto-generated build notes", class: "text-sm" %>
+        <div class="flex flex-row items-center gap-x-4">
+          <div class="flex flex-row items-center gap-x-2">
+            <%= form.radio_button :send_notes, "send_build_notes" %>
+            <%= form.label :send_build_notes, "Send auto-generated build notes" %>
+          </div>
+          <div class="flex flex-row items-center gap-x-2">
+            <%= form.radio_button :send_notes, "send_release_notes" %>
+            <%= form.label :send_release_notes, "Send Release Notes" %>
+          </div>
+          <div class="flex flex-row items-center gap-x-2">
+            <%= form.radio_button :send_notes, "send_no_notes" %>
+            <%= form.label :send_no_notes, "Send No Notes" %>
+          </div>
+        </div>
       </div>
       <div class="flex-grow" data-dropdown-stream-target="showElement" hidden>
         <div data-controller="reveal" class="inline-flex gap-x-4">

--- a/db/data/20240214075934_populate_send_release_notes_on_deployments.rb
+++ b/db/data/20240214075934_populate_send_release_notes_on_deployments.rb
@@ -4,8 +4,13 @@ class PopulateSendReleaseNotesOnDeployments < ActiveRecord::Migration[7.0]
   def up
     ActiveRecord::Base.transaction do
       Deployment.all.each do |deployment|
-        next unless deployment.production_channel?
-        deployment.update!(send_release_notes: true)
+        if deployment.send_build_notes?
+          deployment.update!(notes: "build_notes")
+        elsif deployment.production_channel?
+          deployment.update!(notes: "release_notes")
+        else
+          deployment.update!(notes: "no_notes")
+        end
       end
     end
   end

--- a/db/data/20240214075934_populate_send_release_notes_on_deployments.rb
+++ b/db/data/20240214075934_populate_send_release_notes_on_deployments.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-class PopulateSendBuildNotesOnDeployments < ActiveRecord::Migration[7.0]
+class PopulateSendReleaseNotesOnDeployments < ActiveRecord::Migration[7.0]
   def up
-    return
     ActiveRecord::Base.transaction do
       Deployment.all.each do |deployment|
-        next if deployment.production_channel?
-        deployment.update!(send_build_notes: true)
+        next unless deployment.production_channel?
+        deployment.update!(send_release_notes: true)
       end
     end
   end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240124124107)
+DataMigrate::Data.define(version: 20240214075934)

--- a/db/migrate/20240214075803_add_release_notes_check_in_deployments.rb
+++ b/db/migrate/20240214075803_add_release_notes_check_in_deployments.rb
@@ -1,0 +1,5 @@
+class AddReleaseNotesCheckInDeployments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :deployments, :send_release_notes, :boolean, default: false
+  end
+end

--- a/db/migrate/20240214075803_add_release_notes_check_in_deployments.rb
+++ b/db/migrate/20240214075803_add_release_notes_check_in_deployments.rb
@@ -1,5 +1,5 @@
 class AddReleaseNotesCheckInDeployments < ActiveRecord::Migration[7.0]
   def change
-    add_column :deployments, :send_release_notes, :boolean, default: false
+    add_column :deployments, :notes, :string, default: "no_notes", null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -182,7 +182,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_14_075803) do
     t.boolean "is_staged_rollout", default: false
     t.datetime "discarded_at"
     t.boolean "send_build_notes"
-    t.boolean "send_release_notes", default: false
+    t.string "notes", default: "no_notes", null: false
     t.index ["build_artifact_channel", "integration_id", "step_id"], name: "idx_deployments_on_build_artifact_chan_and_integration_and_step", unique: true
     t.index ["deployment_number", "step_id"], name: "index_deployments_on_deployment_number_and_step_id", unique: true
     t.index ["discarded_at"], name: "index_deployments_on_discarded_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_23_232432) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_14_075803) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -182,6 +182,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_23_232432) do
     t.boolean "is_staged_rollout", default: false
     t.datetime "discarded_at"
     t.boolean "send_build_notes"
+    t.boolean "send_release_notes", default: false
     t.index ["build_artifact_channel", "integration_id", "step_id"], name: "idx_deployments_on_build_artifact_chan_and_integration_and_step", unique: true
     t.index ["deployment_number", "step_id"], name: "index_deployments_on_deployment_number_and_step_id", unique: true
     t.index ["discarded_at"], name: "index_deployments_on_discarded_at"

--- a/spec/factories/deployments.rb
+++ b/spec/factories/deployments.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :deployment do
     sequence(:build_artifact_channel) { |n| {id: n} }
     send_build_notes { true }
+    notes { "build_notes" }
     association :integration
 
     trait :with_step do
@@ -26,8 +27,7 @@ FactoryBot.define do
 
     trait :with_production_channel do
       build_artifact_channel { {is_production: true} }
-      send_build_notes { false }
-      send_release_notes { true }
+      notes { "release_notes" }
     end
 
     trait :with_google_play_store do
@@ -56,8 +56,7 @@ FactoryBot.define do
       build_artifact_channel { {is_production: true} }
       is_staged_rollout { true }
       staged_rollout_config { [1, 100] }
-      send_build_notes { false }
-      send_release_notes { true }
+      notes { "release_notes" }
     end
   end
 end

--- a/spec/factories/deployments.rb
+++ b/spec/factories/deployments.rb
@@ -26,6 +26,8 @@ FactoryBot.define do
 
     trait :with_production_channel do
       build_artifact_channel { {is_production: true} }
+      send_build_notes { false }
+      send_release_notes { true }
     end
 
     trait :with_google_play_store do
@@ -54,6 +56,8 @@ FactoryBot.define do
       build_artifact_channel { {is_production: true} }
       is_staged_rollout { true }
       staged_rollout_config { [1, 100] }
+      send_build_notes { false }
+      send_release_notes { true }
     end
   end
 end

--- a/spec/libs/deployments/google_play_store/release_spec.rb
+++ b/spec/libs/deployments/google_play_store/release_spec.rb
@@ -219,7 +219,7 @@ describe Deployments::GooglePlayStore::Release do
       end
 
       it "does not send release notes when deployment is configured so" do
-        deployment = create(:deployment, :with_release_step, :with_google_play_store, send_build_notes: false)
+        deployment = create(:deployment, :with_release_step, :with_google_play_store, notes: "no_notes")
         deployment_run = create(:deployment_run, deployment:)
         allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
         described_class.start_release!(deployment_run)
@@ -229,6 +229,33 @@ describe Deployments::GooglePlayStore::Release do
             deployment_run.release_version,
             Deployment::FULL_ROLLOUT_VALUE,
             [])
+      end
+
+      it "sends build notes when deployment is configured so" do
+        deployment = create(:deployment, :with_release_step, :with_google_play_store, notes: "build_notes")
+        deployment_run = create(:deployment_run, deployment:)
+        allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
+        described_class.start_release!(deployment_run)
+        expect(providable_dbl).to have_received(:rollout_release)
+          .with(deployment_run.deployment_channel,
+            deployment_run.build_number,
+            deployment_run.release_version,
+            Deployment::FULL_ROLLOUT_VALUE,
+            [{language: "en-US", text: "Nothing new"}])
+      end
+
+      it "sends release notes when deployment is configured so" do
+        deployment = create(:deployment, :with_release_step, :with_google_play_store, notes: "release_notes")
+        deployment_run = create(:deployment_run, deployment:)
+        allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
+        described_class.start_release!(deployment_run)
+        expect(providable_dbl).to have_received(:rollout_release)
+          .with(deployment_run.deployment_channel,
+            deployment_run.build_number,
+            deployment_run.release_version,
+            Deployment::FULL_ROLLOUT_VALUE,
+            [{language: "en-US",
+              text: "The latest version contains bug fixes and performance improvements."}])
       end
     end
 


### PR DESCRIPTION
## Because

People want the flexibility to choose between auto-generated build notes, manually input release notes, and no notes when configuring a distribution in their release train.

Create UI:
![Screenshot 2024-02-14 at 4 20 55 PM](https://github.com/tramlinehq/tramline/assets/1309111/77402461-f6ea-46e8-bcd7-47cd8109719f)

Step tree viz:
![Screenshot 2024-02-14 at 4 18 54 PM](https://github.com/tramlinehq/tramline/assets/1309111/35c87f05-8736-407d-85f7-c538c432dabc)
