### PR TITLE
Add platform-specific project & release stage config for Bugsnag

### DIFF
--- a/app/controllers/app_configs_controller.rb
+++ b/app/controllers/app_configs_controller.rb
@@ -128,14 +128,17 @@ class AppConfigsController < SignedInApplicationController
 
   def bugsnag_config(config_params)
     config = {}
+
     if config_params[:bugsnag_ios_release_stage].present?
       config[:bugsnag_ios_config] = {project_id: config_params[:bugsnag_ios_project_id].safe_json_parse,
                                      release_stage: config_params[:bugsnag_ios_release_stage]}
     end
+
     if config_params[:bugsnag_android_release_stage].present?
       config[:bugsnag_android_config] = {project_id: config_params[:bugsnag_android_project_id].safe_json_parse,
                                          release_stage: config_params[:bugsnag_android_release_stage]}
     end
+
     config
   end
 end

--- a/app/controllers/app_configs_controller.rb
+++ b/app/controllers/app_configs_controller.rb
@@ -131,12 +131,12 @@ class AppConfigsController < SignedInApplicationController
 
     if config_params[:bugsnag_ios_release_stage].present?
       config[:bugsnag_ios_config] = {project_id: config_params[:bugsnag_ios_project_id].safe_json_parse,
-                                     release_stage: config_params[:bugsnag_ios_release_stage]}
+                                      release_stage: config_params[:bugsnag_ios_release_stage]}
     end
 
     if config_params[:bugsnag_android_release_stage].present?
       config[:bugsnag_android_config] = {project_id: config_params[:bugsnag_android_project_id].safe_json_parse,
-                                         release_stage: config_params[:bugsnag_android_release_stage]}
+                                          release_stage: config_params[:bugsnag_android_release_stage]}
     end
 
     config

--- a/app/controllers/app_configs_controller.rb
+++ b/app/controllers/app_configs_controller.rb
@@ -72,9 +72,12 @@ class AppConfigsController < SignedInApplicationController
         :code_repository,
         :notification_channel,
         :bitrise_project_id,
-        :bugsnag_project_id,
         :firebase_android_config,
-        :firebase_ios_config
+        :firebase_ios_config,
+        :bugsnag_ios_release_stage,
+        :bugsnag_ios_project_id,
+        :bugsnag_android_release_stage,
+        :bugsnag_android_project_id
       )
   end
 
@@ -83,9 +86,10 @@ class AppConfigsController < SignedInApplicationController
       .merge(code_repository: app_config_params[:code_repository]&.safe_json_parse)
       .merge(notification_channel: app_config_params[:notification_channel]&.safe_json_parse)
       .merge(bitrise_project_id: app_config_params[:bitrise_project_id]&.safe_json_parse)
-      .merge(bugsnag_project_id: app_config_params[:bugsnag_project_id]&.safe_json_parse)
+      .merge(bugsnag_config(app_config_params.slice(*bugsnag_config_params)))
       .merge(firebase_ios_config: app_config_params[:firebase_ios_config]&.safe_json_parse)
       .merge(firebase_android_config: app_config_params[:firebase_android_config]&.safe_json_parse)
+      .except(*bugsnag_config_params)
       .compact
   end
 
@@ -116,5 +120,22 @@ class AppConfigsController < SignedInApplicationController
     else
       redirect_to app_path(@app), flash: {notice: "Invalid integration category."}
     end
+  end
+
+  def bugsnag_config_params
+    [:bugsnag_ios_project_id, :bugsnag_ios_release_stage, :bugsnag_android_project_id, :bugsnag_android_release_stage]
+  end
+
+  def bugsnag_config(config_params)
+    config = {}
+    if config_params[:bugsnag_ios_release_stage].present?
+      config[:bugsnag_ios_config] = {project_id: config_params[:bugsnag_ios_project_id].safe_json_parse,
+                                     release_stage: config_params[:bugsnag_ios_release_stage]}
+    end
+    if config_params[:bugsnag_android_release_stage].present?
+      config[:bugsnag_android_config] = {project_id: config_params[:bugsnag_android_project_id].safe_json_parse,
+                                         release_stage: config_params[:bugsnag_android_release_stage]}
+    end
+    config
   end
 end

--- a/app/javascript/controllers/nested_select_controller.js
+++ b/app/javascript/controllers/nested_select_controller.js
@@ -11,9 +11,7 @@ export default class extends Controller {
 
   updateNestedOptions() {
     const selectedValue = JSON.parse(this.primaryTarget.selectedOptions[0].value)
-
     this.populateNestedDropdowns(selectedValue.release_stages)
-
   }
 
   populateNestedDropdowns(options) {

--- a/app/javascript/controllers/nested_select_controller.js
+++ b/app/javascript/controllers/nested_select_controller.js
@@ -3,7 +3,10 @@ import {Controller} from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["primary", "nested"]
 
-  static values = { selectedOption: String }
+  static values = {
+    selectedNestedOption: String,
+    options: Array
+  }
 
   connect() {
     this.updateNestedOptions()
@@ -11,16 +14,18 @@ export default class extends Controller {
 
   updateNestedOptions() {
     const selectedValue = JSON.parse(this.primaryTarget.selectedOptions[0].value)
-    this.populateNestedDropdowns(selectedValue.release_stages)
+    console.log(selectedValue)
+    const releaseStages = this.optionsValue.find((option) => option.id === selectedValue.id).release_stages
+    this.populateNestedDropdowns(releaseStages)
   }
 
   populateNestedDropdowns(options) {
-    for(let target of this.nestedTargets) {
+    for (let target of this.nestedTargets) {
       target.innerHTML = options.map((option) => this.__createOption(option)).join("");
     }
   }
 
   __createOption(option) {
-      return `<option value=${JSON.stringify(option)} ${(this.selectedOptionValue !== "" && this.selectedOptionValue === option) ? "selected" : ""}>${option}</option>`
+    return `<option value=${JSON.stringify(option)} ${(this.selectedNestedOptionValue !== "" && this.selectedNestedOptionValue === option) ? "selected" : ""}>${option}</option>`
   }
 }

--- a/app/javascript/controllers/nested_select_controller.js
+++ b/app/javascript/controllers/nested_select_controller.js
@@ -1,0 +1,28 @@
+import {Controller} from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["primary", "nested"]
+
+  static values = { selectedOption: String }
+
+  connect() {
+    this.updateNestedOptions()
+  }
+
+  updateNestedOptions() {
+    const selectedValue = JSON.parse(this.primaryTarget.selectedOptions[0].value)
+
+    this.populateNestedDropdowns(selectedValue.release_stages)
+
+  }
+
+  populateNestedDropdowns(options) {
+    for(let target of this.nestedTargets) {
+      target.innerHTML = options.map((option) => this.__createOption(option)).join("");
+    }
+  }
+
+  __createOption(option) {
+      return `<option value=${JSON.stringify(option)} ${(this.selectedOptionValue !== "" && this.selectedOptionValue === option) ? "selected" : ""}>${option}</option>`
+  }
+}

--- a/app/models/bugsnag_integration.rb
+++ b/app/models/bugsnag_integration.rb
@@ -14,6 +14,7 @@ class BugsnagIntegration < ApplicationRecord
   include Displayable
   include Rails.application.routes.url_helpers
 
+  CACHE_EXPIRY = 1.month
   API = Installations::Bugsnag::Api
 
   ORGANIZATIONS_TRANSFORMATIONS = {
@@ -26,7 +27,8 @@ class BugsnagIntegration < ApplicationRecord
     name: :name,
     id: :id,
     slug: :slug,
-    url: :html_url
+    url: :html_url,
+    release_stages: :release_stages
   }
 
   RELEASE_TRANSFORMATIONS = {
@@ -45,8 +47,11 @@ class BugsnagIntegration < ApplicationRecord
   validates :access_token, presence: true
 
   encrypts :access_token, deterministic: true
-  delegate :bugsnag_project, to: :app_config
+  delegate :cache, to: Rails
+  delegate :app, to: :integration
+  delegate :bugsnag_project, :bugsnag_release_stage, to: :app_config
   alias_method :project, :bugsnag_project
+  alias_method :release_stage, :bugsnag_release_stage
 
   def installation
     API.new(access_token)
@@ -82,7 +87,9 @@ class BugsnagIntegration < ApplicationRecord
   end
 
   def list_projects
-    list_organizations.flat_map { |org| installation.list_projects(org[:id], PROJECTS_TRANSFORMATIONS) }
+    cache.fetch(list_projects_cache_key, expires_in: CACHE_EXPIRY) do
+      list_organizations.flat_map { |org| installation.list_projects(org[:id], PROJECTS_TRANSFORMATIONS) }
+    end
   end
 
   def list_organizations
@@ -94,30 +101,19 @@ class BugsnagIntegration < ApplicationRecord
   end
 
   def find_release(platform, version, build_number)
-    installation.find_release(project, release_stage_hack(platform), version, build_number, RELEASE_TRANSFORMATIONS)
+    installation.find_release(project(platform), release_stage(platform), version, build_number, RELEASE_TRANSFORMATIONS)
   end
 
   def dashboard_url(platform:, release_id:)
-    return if project_url.blank?
-    return "#{project_url}/release_groups/#{release_id}" if release_id.present?
-    "#{project_url}/overview?release_stage=#{release_stage_hack(platform)}"
+    return if project_url(platform).blank?
+    return "#{project_url(platform)}/release_groups/#{release_id}" if release_id.present?
+    "#{project_url(platform)}/overview?release_stage=#{release_stage(platform)}"
   end
 
   private
 
-  def project_url
-    app_config.bugsnag_project_id&.fetch("url", nil)
-  end
-
-  def release_stage_hack(platform)
-    case platform
-    when "android"
-      "prod"
-    when "ios"
-      "iOS-prod"
-    else
-      "prod"
-    end
+  def project_url(platform)
+    project(platform)&.fetch("url", nil)
   end
 
   def app_config
@@ -128,5 +124,9 @@ class BugsnagIntegration < ApplicationRecord
     if access_token.present?
       errors.add(:access_token, :no_orgs) if list_organizations.size < 1
     end
+  end
+
+  def list_projects_cache_key
+    "app/#{app.id}/bugsnag_integration/#{id}/list_projects"
   end
 end

--- a/app/models/concerns/platform_awareness.rb
+++ b/app/models/concerns/platform_awareness.rb
@@ -19,4 +19,26 @@ module PlatformAwareness
       raise ArgumentError, "platform must be valid"
     end
   end
+
+  def pick_bugsnag_release_stage(platform)
+    case platform
+    when "android"
+      bugsnag_android_config["release_stage"]
+    when "ios"
+      bugsnag_ios_config["release_stage"]
+    else
+      raise ArgumentError, "platform must be valid"
+    end
+  end
+
+  def pick_bugsnag_project_id(platform)
+    case platform
+    when "android"
+      bugsnag_android_config["project_id"]
+    when "ios"
+      bugsnag_ios_config["project_id"]
+    else
+      raise ArgumentError, "platform must be valid"
+    end
+  end
 end

--- a/app/views/app_configs/_bugsnag_project_form.html.erb
+++ b/app/views/app_configs/_bugsnag_project_form.html.erb
@@ -1,16 +1,19 @@
 <% form.with_section(heading: platform) do |section| %>
   <% section.with_description do %>
     For your connected Bugsnag organization.
-    <%= image_tag "integrations/logo_bugsnag.png", title: "Bugsnag", width: 22, class: "my-2" %>
+    <%= image_tag "integrations/logo_bugsnag.png", title: "Bugsnag", width: 22, class: "mt-2" %>
   <% end %>
 
-  <div data-controller="nested-select" class="grid gap-y-4" data-nested-select-selected-option-value="<%= stage %>">
+  <div class="grid gap-y-4"
+       data-controller="nested-select"
+       data-nested-select-selected-nested-option-value="<%= stage %>"
+       data-nested-select-options-value="<%= projects.to_json %>">
     <div>
       <%= section.F.labeled_select "bugsnag_#{platform}_project_id".downcase.to_sym,
                                    "Project",
                                    options_for_select(
-                                     display_channels(projects) { |project| "#{project[:name]} (#{project[:id]})" },
-                                     project
+                                     display_channels(projects.map {|p| p.except(:release_stages)}) { |project| "#{project[:name]} (#{project[:id]})" },
+                                     project.to_json
                                    ),
                                    {},
                                    { data: { nested_select_target: "primary", action: "nested-select#updateNestedOptions" } } %>

--- a/app/views/app_configs/_bugsnag_project_form.html.erb
+++ b/app/views/app_configs/_bugsnag_project_form.html.erb
@@ -1,0 +1,26 @@
+<% form.with_section(heading: platform) do |section| %>
+  <% section.with_description do %>
+    For your connected Bugsnag organization.
+    <%= image_tag "integrations/logo_bugsnag.png", title: "Bugsnag", width: 22, class: "my-2" %>
+  <% end %>
+
+  <div data-controller="nested-select" class="grid gap-y-4" data-nested-select-selected-option-value="<%= stage %>">
+    <div>
+      <%= section.F.labeled_select "bugsnag_#{platform}_project_id".downcase.to_sym,
+                                   "Project",
+                                   options_for_select(
+                                     display_channels(projects) { |project| "#{project[:name]} (#{project[:id]})" },
+                                     project
+                                   ),
+                                   {},
+                                   { data: { nested_select_target: "primary", action: "nested-select#updateNestedOptions" } } %>
+    </div>
+    <div>
+      <%= section.F.labeled_select "bugsnag_#{platform}_release_stage".downcase.to_sym,
+                                   "Release Stage",
+                                   {},
+                                   {},
+                                   { data: { nested_select_target: "nested", controller: "input-select" } } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/app_configs/monitoring.html+turbo_frame.erb
+++ b/app/views/app_configs/monitoring.html+turbo_frame.erb
@@ -1,22 +1,12 @@
 <%= render V2::EnhancedTurboFrameComponent.new("#{@integration_category}_config") do %>
-  <% if @app.bugsnag_connected? %>
+  <% if @app.bugsnag_connected? && @monitoring_projects.present? %>
     <%= render V2::FormComponent.new(model: [@app, @config], url: app_app_config_path(@app), method: :patch) do |f| %>
-      <% f.with_section(heading: "Select Project") do |section| %>
-        <% section.with_description do %>
-          For your connected Bugsnag organization.
-          <%= image_tag "integrations/logo_bugsnag.png", title: "Bugsnag", width: 22, class: "my-2" %>
-        <% end %>
+      <% if @app.ios? || @app.cross_platform? %>
+        <%= render partial: "bugsnag_project_form", locals: {form: f, platform: "iOS", projects: @monitoring_projects, project: @config.bugsnag_ios_project_id, stage: @config.bugsnag_ios_release_stage} %>
+      <% end %>
 
-        <% if @monitoring_projects.present? %>
-          <div>
-            <%= section.F.labeled_select :bugsnag_project_id,
-                                         "Project",
-                                         options_for_select(
-                                           display_channels(@monitoring_projects) { |project| "#{project[:name]} (#{project[:id]})" },
-                                           @config.bugsnag_project_id.to_json
-                                         ) %>
-          </div>
-        <% end %>
+      <% if @app.android? || @app.cross_platform? %>
+        <%= render partial: "bugsnag_project_form", locals: {form: f, platform: "Android", projects: @monitoring_projects, project: @config.bugsnag_android_project_id, stage: @config.bugsnag_android_release_stage} %>
       <% end %>
 
       <% f.with_action do %>

--- a/db/data/20240214075934_populate_send_release_notes_on_deployments.rb
+++ b/db/data/20240214075934_populate_send_release_notes_on_deployments.rb
@@ -2,6 +2,7 @@
 
 class PopulateSendReleaseNotesOnDeployments < ActiveRecord::Migration[7.0]
   def up
+    return
     ActiveRecord::Base.transaction do
       Deployment.all.each do |deployment|
         if deployment.send_build_notes?

--- a/db/data/20240305073559_populate_platform_specific_bugsnag_config.rb
+++ b/db/data/20240305073559_populate_platform_specific_bugsnag_config.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class PopulatePlatformSpecificBugsnagConfig < ActiveRecord::Migration[7.0]
+  def up
+    ActiveRecord::Base.transaction do
+      AppConfig.all.each do |app_config|
+        next if app_config.bugsnag_project_id.blank?
+
+        app = app_config.app
+        if app.ios? || app.cross_platform?
+          app_config.update!(bugsnag_ios_config: {
+            project_id: app_config.bugsnag_project_id,
+            release_stage: "iOS-prod"
+          })
+        end
+
+        if app.android? || app.cross_platform?
+          app_config.update!(bugsnag_android_config: {
+            project_id: app_config.bugsnag_project_id,
+            release_stage: "prod"
+          })
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240214075934)
+DataMigrate::Data.define(version: 20240305073559)

--- a/db/migrate/20240305072501_add_platform_specific_bugsnag_config.rb
+++ b/db/migrate/20240305072501_add_platform_specific_bugsnag_config.rb
@@ -1,0 +1,10 @@
+class AddPlatformSpecificBugsnagConfig < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_table :app_configs, bulk: true do |t|
+        t.column :bugsnag_ios_config, :jsonb, null: true
+        t.column :bugsnag_android_config, :jsonb, null: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_19_082821) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_05_072501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -54,6 +54,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_19_082821) do
     t.jsonb "firebase_ios_config"
     t.jsonb "firebase_android_config"
     t.jsonb "bugsnag_project_id"
+    t.jsonb "bugsnag_ios_config"
+    t.jsonb "bugsnag_android_config"
     t.index ["app_id"], name: "index_app_configs_on_app_id", unique: true
   end
 


### PR DESCRIPTION
## Because

App developers can customize the release stages in Bugsnag. We should allow them to configure each app platform's primary production release stage in Tramline.

The release stage is used to find the correct release version in Bugsnag when fetching release health metrics.