### PR TITLE
Ignore first commit from stability commits and team analysis

### DIFF
--- a/app/components/final_summary_component.rb
+++ b/app/components/final_summary_component.rb
@@ -97,7 +97,7 @@ class FinalSummaryComponent < ViewComponent::Base
   end
 
   def team_stability_chart
-    {data: team_stability_commits,
+    {data: team_stability_commits.reject { |_, value| value.zero? },
      colors: team_colors,
      type: "polar-area",
      value_format: "number",
@@ -110,7 +110,7 @@ class FinalSummaryComponent < ViewComponent::Base
   end
 
   def team_release_chart
-    {data: team_release_commits,
+    {data: team_release_commits.reject { |_, value| value.zero? },
      colors: team_colors,
      type: "polar-area",
      value_format: "number",

--- a/app/libs/charts/devops_report.rb
+++ b/app/libs/charts/devops_report.rb
@@ -131,7 +131,7 @@ class Charts::DevopsReport
     finished_releases(last)
       .group_by(&:release_version)
       .sort_by { |v, _| v.to_semverish }.to_h
-      .transform_values { |releases| releases[0].all_commits.count_by_team(organization) }
+      .transform_values { |releases| releases[0].stability_commits.count_by_team(organization) }
       .compact_blank
   end
 

--- a/app/libs/queries/release_summary.rb
+++ b/app/libs/queries/release_summary.rb
@@ -182,7 +182,7 @@ class Queries::ReleaseSummary
       steps_summary: StepsSummary.from_release(release),
       store_versions: StoreVersions.from_release(release),
       pull_requests: release.pull_requests.automatic,
-      team_stability_commits: release.all_commits.count_by_team(release.organization),
+      team_stability_commits: release.stability_commits.count_by_team(release.organization),
       team_release_commits: release.release_changelog&.commits_by_team
     }
   end

--- a/app/models/accounts/team.rb
+++ b/app/models/accounts/team.rb
@@ -12,7 +12,7 @@
 class Accounts::Team < ApplicationRecord
   has_paper_trail
 
-  belongs_to :organization, inverse_of: :memberships, optional: false
+  belongs_to :organization, inverse_of: :teams, optional: false
   has_many :memberships, dependent: :nullify
 
   validates :color, uniqueness: {scope: :organization_id}

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -192,6 +192,10 @@ class Release < ApplicationRecord
     all_commits.where(backmerge_failure: true)
   end
 
+  def stability_commits
+    all_commits.where.not(id: first_commit.id)
+  end
+
   def compare_url
     vcs_provider.compare_url(train.working_branch, release_branch)
   end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -193,7 +193,7 @@ class Release < ApplicationRecord
   end
 
   def stability_commits
-    all_commits.where.not(id: first_commit.id)
+    all_commits.where.not(id: first_commit&.id)
   end
 
   def compare_url

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -121,7 +121,7 @@
       <%= render partial: "shared/live_release/separator" %>
 
       <div class="grid grid-cols-2 gap-6 mt-8">
-        <%= render partial: "shared/live_release/teams", locals: { release: @release, commits: @commits, pull_requests: @mid_release_prs } %>
+        <%= render partial: "shared/live_release/teams", locals: { release: @release, commits: @release.stability_commits, pull_requests: @mid_release_prs } %>
       </div>
     <% end %>
 

--- a/spec/factories/deployment_runs.rb
+++ b/spec/factories/deployment_runs.rb
@@ -74,7 +74,8 @@ def create_deployment_run_tree(platform, *traits, deployment_traits: [], step_tr
   create_deployment_tree(platform, *deployment_traits, step_traits:, train_traits:) => { app:, train:, release_platform:, step:, deployment: }
   release = create(:release, *release_traits, train:)
   release_platform_run = create(:release_platform_run, release_platform:, release:)
-  step_run = create(:step_run, *step_run_traits, step:, release_platform_run:)
+  commit = create(:commit, release:)
+  step_run = create(:step_run, *step_run_traits, step:, release_platform_run:, commit:)
   deployment_run = create(:deployment_run, *traits, deployment:, step_run:)
   {app:, train:, release_platform:, step:, deployment:, release:, release_platform_run:, step_run:, deployment_run:}
 end

--- a/spec/libs/deployments/google_play_store/release_spec.rb
+++ b/spec/libs/deployments/google_play_store/release_spec.rb
@@ -205,7 +205,7 @@ describe Deployments::GooglePlayStore::Release do
             deployment_run.build_number,
             deployment_run.release_version,
             Deployment::FULL_ROLLOUT_VALUE,
-            [{language: "en-US", text: "Nothing new"}])
+            anything)
       end
 
       it "creates release with full rollout for production channel" do
@@ -255,7 +255,7 @@ describe Deployments::GooglePlayStore::Release do
             deployment_run.build_number,
             deployment_run.release_version,
             Deployment::FULL_ROLLOUT_VALUE,
-            [{language: "en-US", text: "Nothing new"}])
+            anything)
       end
 
       it "sends release notes when deployment is configured so" do
@@ -322,7 +322,7 @@ describe Deployments::GooglePlayStore::Release do
               deployment_run.build_number,
               deployment_run.release_version,
               Deployment::FULL_ROLLOUT_VALUE,
-              [{language: "en-US", text: "Nothing new"}])
+              anything)
         end
 
         it "marks a run as released when no staged rollout" do

--- a/spec/libs/queries/release_summary_spec.rb
+++ b/spec/libs/queries/release_summary_spec.rb
@@ -25,21 +25,39 @@ describe Queries::ReleaseSummary, type: :model do
         expect(actual[:overall].attributes["version"]).to eq(release.release_version)
         expect(actual[:pull_requests]).to eq([])
         expect(actual[:steps_summary].all[0].attributes).to eq({"builds_created_count" => 1,
-                                                                "duration" => 0.seconds,
-                                                                "ended_at" => Time.current,
-                                                                "name" => step.name,
-                                                                "phase" => "release",
-                                                                "platform" => "Android",
-                                                                "platform_raw" => "android",
-                                                                "started_at" => Time.current})
-        expect(actual[:store_versions].all[0].attributes).to eq({"build_number" => step_run.build_number,
-                                                                 "built_at" => Time.current,
+                                                                 "duration" => 0.seconds,
+                                                                 "ended_at" => Time.current,
+                                                                 "name" => step.name,
+                                                                 "phase" => "release",
                                                                  "platform" => "Android",
-                                                                 "staged_rollouts" => [],
-                                                                 "submitted_at" => Time.current,
-                                                                 "release_started_at" => Time.current,
-                                                                 "version" => step_run.build_version})
+                                                                 "platform_raw" => "android",
+                                                                 "started_at" => Time.current})
+        expect(actual[:store_versions].all[0].attributes).to eq({"build_number" => step_run.build_number,
+                                                                  "built_at" => Time.current,
+                                                                  "platform" => "Android",
+                                                                  "staged_rollouts" => [],
+                                                                  "submitted_at" => Time.current,
+                                                                  "release_started_at" => Time.current,
+                                                                  "version" => step_run.build_version})
       end
+    end
+
+    it "returns team stability summary when teams exist for the organization" do
+      org = create(:organization)
+      team = org.teams.create!(name: "Team 1")
+      create_deployment_run_tree(:android,
+        :released,
+        deployment_traits: [:with_production_channel],
+        release_traits: [:with_no_platform_runs],
+        step_traits: [:release],
+        step_run_traits: [:success]) => { app:, step:, release:, step_run:, deployment_run: }
+      app.update!(organization: org)
+      stability_commits = create_list(:commit, 3, release:)
+      deployment_run.event_stamp_now!(reason: :release_started, kind: :notice, data: deployment_run.send(:stamp_data))
+      described_class.warm(release.id)
+      actual = described_class.all(release.id)
+      expect(actual[:overall].attributes["version"]).to eq(release.release_version)
+      expect(actual[:team_stability_commits]).to eq({"Unknown" => stability_commits.size, team.name => 0})
     end
   end
 end

--- a/spec/libs/webhook_processors/push_spec.rb
+++ b/spec/libs/webhook_processors/push_spec.rb
@@ -137,14 +137,10 @@ describe WebhookProcessors::Push do
     context "when build queue" do
       let(:queue_size) { 3 }
       let(:factory_tree) {
-        create_deployment_run_tree(:android, :uploaded,
-          step_traits: [:release],
-          step_run_traits: [:deployment_restarted],
-          train_traits: [:with_build_queue],
-          release_traits: [:with_no_platform_runs, :on_track])
+        create_deployment_tree(:android, step_traits: [:release], train_traits: [:with_build_queue])
       }
       let(:train) { factory_tree[:train] }
-      let(:release) { factory_tree[:release] }
+      let(:release) { create(:release, :on_track, train:) }
 
       before do
         train.update!(build_queue_size: queue_size)

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -428,4 +428,21 @@ describe Release do
       end
     end
   end
+
+  describe "#stability_commits" do
+    let(:factory_tree) { create_deployment_run_tree(:android, release_traits: [:on_track]) }
+    let(:release) { factory_tree[:release] }
+
+    it "returns the subsequent commits made on the release branch after release starts" do
+      stability_commits = create_list(:commit, 4, release:)
+      expect(release.stability_commits).to exist
+      expect(release.stability_commits).to eq(stability_commits)
+      expect(release.all_commits.size).to eq(stability_commits.size + 1)
+    end
+
+    it "returns nothing if no fixes are made" do
+      expect(release.all_commits).to exist
+      expect(release.stability_commits).to be_none
+    end
+  end
 end


### PR DESCRIPTION
Unrelated changes:
- Fix team <-> organization relationship
- Fix the deployment tree factory method to create a commit associated with the release