### PR TITLE
Handle resubmission of build for review from app store dashboard

### DIFF
--- a/app/libs/deployments/app_store_connect/release.rb
+++ b/app/libs/deployments/app_store_connect/release.rb
@@ -161,6 +161,9 @@ module Deployments
           run.complete!
         elsif release_info.failed?
           run.dispatch_fail!(reason: :developer_rejected)
+        elsif release_info.waiting_for_review? && run.review_failed?
+          # A failed review was re-submitted or responded to outside Tramline
+          run.submit_for_review!(resubmission: true)
         else
           run.fail_review! if release_info.review_failed? && !run.review_failed?
           raise ExternalReleaseNotInTerminalState, "Retrying in some time..."

--- a/app/libs/notifiers/slack/renderers/submit_for_review.rb
+++ b/app/libs/notifiers/slack/renderers/submit_for_review.rb
@@ -6,6 +6,11 @@ module Notifiers
       def sanitized_release_notes
         safe_string(":spiral_note_pad: *What's New*\n\n```#{@release_notes}```")
       end
+
+      def submitted_text
+        return "resubmitted" if @resubmission
+        "submitted"
+      end
     end
   end
 end

--- a/app/models/app_store_integration.rb
+++ b/app/models/app_store_integration.rb
@@ -270,6 +270,8 @@ class AppStoreIntegration < ApplicationRecord
     PROCESSING_EXCEPTION = "PROCESSING_EXCEPTION"
     BETA_APPROVED = "BETA_APPROVED"
     IN_BETA_TESTING = "IN_BETA_TESTING"
+    WAITING_FOR_BETA_REVIEW = "WAITING_FOR_BETA_REVIEW"
+    IN_BETA_REVIEW = "IN_BETA_REVIEW"
 
     def attributes
       build_info
@@ -288,6 +290,15 @@ class AppStoreIntegration < ApplicationRecord
       build_info[:status].in?(
         [
           BETA_REJECTED
+        ]
+      )
+    end
+
+    def waiting_for_review?
+      build_info[:status].in?(
+        [
+          WAITING_FOR_BETA_REVIEW,
+          IN_BETA_REVIEW
         ]
       )
     end
@@ -320,6 +331,8 @@ class AppStoreIntegration < ApplicationRecord
     INVALID_BINARY = "INVALID_BINARY"
     PHASED_RELEASE_COMPLETE = "COMPLETE"
     PHASED_RELEASE_INACTIVE = "INACTIVE"
+    IN_REVIEW = "IN_REVIEW"
+    WAITING_FOR_REVIEW = "WAITING_FOR_REVIEW"
 
     def attributes
       release_info.except(:phased_release_day, :phased_release_status)
@@ -365,6 +378,15 @@ class AppStoreIntegration < ApplicationRecord
           REJECTED,
           INVALID_BINARY,
           METADATA_REJECTED
+        ]
+      )
+    end
+
+    def waiting_for_review?
+      release_info[:status].in?(
+        [
+          IN_REVIEW,
+          WAITING_FOR_REVIEW
         ]
       )
     end

--- a/app/views/notifiers/slack/submit_for_review.json.erb
+++ b/app/views/notifiers/slack/submit_for_review.json.erb
@@ -4,7 +4,7 @@
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "*<%= @app_name %> (<%= @app_platform %>)* <%= @release_version %> (<%= @build_number %>) has been submitted for review to <%= @deployment_channel_type %> (<%= deployment_channel_display_name %>)! :tada:"
+        "text": "<%= @app_name %> (<%= @app_platform %>) <%= @release_version %> (<%= @build_number %>) has been *<%= submitted_text %>* for review to <%= @deployment_channel_type %> (<%= deployment_channel_display_name %>)! :tada:"
       }
     },
     {

--- a/config/locales/passport/en.yml
+++ b/config/locales/passport/en.yml
@@ -44,6 +44,7 @@ en:
       prepare_release_failed_html: 'Failed to prepare release for <span class="emphasize">%{version}</span> to submit for review in store'
       inflight_release_replaced_html: 'Replaced existing inflight release in store with <span class="emphasize">%{version}</span>'
       submitted_for_review_html: 'Submitted release for <span class="emphasize">%{version}</span> for review to the store'
+      resubmitted_for_review_html: 'Release <span class="emphasize">%{version}</span> was resubmitted for review to the store'
       review_failed_html: 'Review for release for <span class="emphasize">%{version}</span> was rejected by the store'
       review_approved_html: 'Review for release for <span class="emphasize">%{version}</span> approved by the store'
       release_started_html: 'Started the release of <span class="emphasize">%{version}</span> to <span class="emphasize">%{provider}</span> in <span class="emphasize">%{chan}</span>'


### PR DESCRIPTION
- change the state of the deployment run as submitted for review
- notify the users about the resubmission
- start polling for the new review afresh
