### PR TITLE
Stop automatic ongoing releases on failure 

### DIFF
--- a/app/controllers/trains_controller.rb
+++ b/app/controllers/trains_controller.rb
@@ -121,6 +121,7 @@ class TrainsController < SignedInApplicationController
       :build_queue_wait_time_unit,
       :build_queue_wait_time_value,
       :release_schedule_enabled,
+      :stop_automatic_releases_on_failure,
       :continuous_backmerge_enabled,
       :manual_release,
       :compact_build_notes,
@@ -157,6 +158,7 @@ class TrainsController < SignedInApplicationController
       :repeat_duration_value,
       :repeat_duration_unit,
       :release_schedule_enabled,
+      :stop_automatic_releases_on_failure,
       :continuous_backmerge_enabled,
       :manual_release,
       :compact_build_notes,
@@ -216,7 +218,7 @@ class TrainsController < SignedInApplicationController
   end
 
   def release_schedule_config_params
-    [:release_schedule_enabled, :kickoff_at, :repeat_duration_value, :repeat_duration_unit]
+    [:release_schedule_enabled, :kickoff_at, :repeat_duration_value, :repeat_duration_unit, :stop_automatic_releases_on_failure]
   end
 
   def release_schedule_config(config_params)
@@ -224,7 +226,8 @@ class TrainsController < SignedInApplicationController
 
     {
       repeat_duration: parsed_duration(config_params[:repeat_duration_value], config_params[:repeat_duration_unit]),
-      kickoff_at: config_params[:kickoff_at]&.time_in_utc
+      kickoff_at: config_params[:kickoff_at]&.time_in_utc,
+      stop_automatic_releases_on_failure: config_params[:stop_automatic_releases_on_failure]
     }
   end
 

--- a/app/jobs/release_kickoff_job.rb
+++ b/app/jobs/release_kickoff_job.rb
@@ -8,7 +8,7 @@ class ReleaseKickoffJob < ApplicationJob
     return if scheduled_release.blank?
     return unless scheduled_release.train.active?
 
-    stop_failed_release!(scheduled_release.train)
+    scheduled_release.train.stop_failed_ongoing_release!
     response = Triggers::Release.call(scheduled_release.train, automatic: true)
 
     if response.success?
@@ -18,13 +18,5 @@ class ReleaseKickoffJob < ApplicationJob
       failure_reason = response.body
       scheduled_release.update!(failure_reason:)
     end
-  end
-
-  def stop_failed_release!(train)
-    return unless train.ongoing_release.present?
-    return unless train.ongoing_release.failure_anywhere?
-    return unless train.stop_automatic_release_on_failure?
-
-    train.ongoing_release.stop!
   end
 end

--- a/app/jobs/release_kickoff_job.rb
+++ b/app/jobs/release_kickoff_job.rb
@@ -8,6 +8,7 @@ class ReleaseKickoffJob < ApplicationJob
     return if scheduled_release.blank?
     return unless scheduled_release.train.active?
 
+    stop_failed_release!(scheduled_release.train)
     response = Triggers::Release.call(scheduled_release.train, automatic: true)
 
     if response.success?
@@ -17,5 +18,13 @@ class ReleaseKickoffJob < ApplicationJob
       failure_reason = response.body
       scheduled_release.update!(failure_reason:)
     end
+  end
+
+  def stop_failed_release!(train)
+    return unless train.ongoing_release.present?
+    return unless train.ongoing_release.failure_anywhere?
+    return unless train.stop_automatic_release_on_failure?
+
+    train.ongoing_release.stop!
   end
 end

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -98,6 +98,7 @@ class DeploymentRun < ApplicationRecord
 
   READY_STATES = [STATES[:rollout_started], STATES[:ready_to_release], STATES[:released]]
   STORE_SUBMISSION_STATES = READY_STATES + [STATES[:submitted_for_review], STATES[:review_failed]]
+  FAILED_STATES = [STATES[:failed], STATES[:failed_prepare_release], STATES[:failed_with_action_required]]
 
   enum status: STATES
   enum failure_reason: {
@@ -186,6 +187,7 @@ class DeploymentRun < ApplicationRecord
   scope :for_ids, ->(ids) { includes(deployment: :integration).where(id: ids) }
   scope :matching_runs_for, ->(integration) { includes(:deployment).where(deployments: {integration: integration}) }
   scope :has_begun, -> { where.not(status: :created) }
+  scope :failed, -> { where(status: FAILED_STATES) }
   scope :not_failed, -> { where.not(status: [:failed, :failed_prepare_release]) }
   scope :ready, -> { where(status: READY_STATES) }
 

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -203,6 +203,10 @@ class DeploymentRun < ApplicationRecord
     where(status: STORE_SUBMISSION_STATES).includes([:staged_rollout, {step_run: [:commit], deployment: [:integration]}]).select(&:production_channel?)
   end
 
+  def failure?
+    status.in?(FAILED_STATES)
+  end
+
   def check_release_health
     return unless latest_health_data&.fresh?
     latest_health_data.check_release_health

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -483,7 +483,7 @@ class Release < ApplicationRecord
   end
 
   def failure_anywhere?
-    FAILED_STATES.include?(status) || step_runs.failed.exists? || deployment_runs.failed.exists?
+    status.to_sym.in?(FAILED_STATES) || release_platform_runs.any?(&:failure?)
   end
 
   private

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -36,6 +36,7 @@ class Release < ApplicationRecord
   self.ignored_columns += ["release_version"]
 
   TERMINAL_STATES = [:finished, :stopped, :stopped_after_partial_finish]
+  FAILED_STATES = [:post_release_failed]
   DEFAULT_INTERNAL_NOTES = {
     "ops" => [
       {"insert" => "Write your internal notes, tasks lists, description, pretty much anything really."},
@@ -479,6 +480,10 @@ class Release < ApplicationRecord
 
   def android_release_platform_run
     release_platform_runs.find(&:android?)
+  end
+
+  def failure_anywhere?
+    FAILED_STATES.include?(status) || step_runs.failed.exists? || deployment_runs.failed.exists?
   end
 
   private

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -103,6 +103,10 @@ class ReleasePlatformRun < ApplicationRecord
     latest_store_release&.unhealthy?
   end
 
+  def failure?
+    step_runs.last&.failure?
+  end
+
   def set_default_release_metadata
     base = {
       release_notes: ReleaseMetadata::DEFAULT_RELEASE_NOTES,

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -187,6 +187,7 @@ class StepRun < ApplicationRecord
   delegate :download_url, to: :build_artifact
   delegate :ci_cd_provider, :workflow_id, :workflow_name, :step_number, :build_artifact_name_pattern, :has_uploadables?, :has_findables?, :name, :app_variant, to: :step
   scope :not_failed, -> { where.not(status: FAILED_STATES) }
+  scope :failed, -> { where(status: FAILED_STATES) }
   scope :sequential, -> { order("step_runs.scheduled_at ASC") }
 
   def basic_build_version

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -190,6 +190,10 @@ class StepRun < ApplicationRecord
   scope :failed, -> { where(status: FAILED_STATES) }
   scope :sequential, -> { order("step_runs.scheduled_at ASC") }
 
+  def failure?
+    status.in?(FAILED_STATES) || last_deployment_run&.failure?
+  end
+
   def basic_build_version
     build_version.split("-").first
   end

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -416,9 +416,9 @@ class Train < ApplicationRecord
   end
 
   def stop_failed_ongoing_release!
+    return unless stop_automatic_release_on_failure?
     return if ongoing_release.blank?
     return unless ongoing_release.failure_anywhere?
-    return unless stop_automatic_release_on_failure?
 
     ongoing_release.stop!
   end

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -2,35 +2,36 @@
 #
 # Table name: trains
 #
-#  id                       :uuid             not null, primary key
-#  backmerge_strategy       :string           default("on_finalize"), not null
-#  branching_strategy       :string           not null
-#  build_queue_enabled      :boolean          default(FALSE)
-#  build_queue_size         :integer
-#  build_queue_wait_time    :interval
-#  compact_build_notes      :boolean          default(FALSE)
-#  description              :string
-#  kickoff_at               :datetime
-#  manual_release           :boolean          default(FALSE)
-#  name                     :string           not null
-#  notification_channel     :jsonb
-#  release_backmerge_branch :string
-#  release_branch           :string
-#  repeat_duration          :interval
-#  slug                     :string
-#  status                   :string           not null
-#  tag_all_store_releases   :boolean          default(FALSE)
-#  tag_platform_releases    :boolean          default(FALSE)
-#  tag_releases             :boolean          default(TRUE)
-#  tag_suffix               :string
-#  version_current          :string
-#  version_seeded_with      :string
-#  versioning_strategy      :string           default("semver")
-#  working_branch           :string
-#  created_at               :datetime         not null
-#  updated_at               :datetime         not null
-#  app_id                   :uuid             not null, indexed
-#  vcs_webhook_id           :string
+#  id                                 :uuid             not null, primary key
+#  backmerge_strategy                 :string           default("on_finalize"), not null
+#  branching_strategy                 :string           not null
+#  build_queue_enabled                :boolean          default(FALSE)
+#  build_queue_size                   :integer
+#  build_queue_wait_time              :interval
+#  compact_build_notes                :boolean          default(FALSE)
+#  description                        :string
+#  kickoff_at                         :datetime
+#  manual_release                     :boolean          default(FALSE)
+#  name                               :string           not null
+#  notification_channel               :jsonb
+#  release_backmerge_branch           :string
+#  release_branch                     :string
+#  repeat_duration                    :interval
+#  slug                               :string
+#  status                             :string           not null
+#  stop_automatic_releases_on_failure :boolean          default(FALSE), not null
+#  tag_all_store_releases             :boolean          default(FALSE)
+#  tag_platform_releases              :boolean          default(FALSE)
+#  tag_releases                       :boolean          default(TRUE)
+#  tag_suffix                         :string
+#  version_current                    :string
+#  version_seeded_with                :string
+#  versioning_strategy                :string           default("semver")
+#  working_branch                     :string
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
+#  app_id                             :uuid             not null, indexed
+#  vcs_webhook_id                     :string
 #
 class Train < ApplicationRecord
   has_paper_trail

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -415,6 +415,14 @@ class Train < ApplicationRecord
     release_platforms.any?(&:has_production_deployment?)
   end
 
+  def stop_failed_ongoing_release!
+    return unless ongoing_release.present?
+    return unless ongoing_release.failure_anywhere?
+    return unless stop_automatic_release_on_failure?
+
+    ongoing_release.stop!
+  end
+
   private
 
   def train_link

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -416,7 +416,7 @@ class Train < ApplicationRecord
   end
 
   def stop_failed_ongoing_release!
-    return unless ongoing_release.present?
+    return if ongoing_release.blank?
     return unless ongoing_release.failure_anywhere?
     return unless stop_automatic_release_on_failure?
 

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -416,7 +416,7 @@ class Train < ApplicationRecord
   end
 
   def stop_failed_ongoing_release!
-    return unless stop_automatic_release_on_failure?
+    return unless stop_automatic_releases_on_failure?
     return if ongoing_release.blank?
     return unless ongoing_release.failure_anywhere?
 

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -416,6 +416,7 @@ class Train < ApplicationRecord
   end
 
   def stop_failed_ongoing_release!
+    return unless automatic?
     return unless stop_automatic_releases_on_failure?
     return if ongoing_release.blank?
     return unless ongoing_release.failure_anywhere?

--- a/app/views/trains/_release_schedule_form.html.erb
+++ b/app/views/trains/_release_schedule_form.html.erb
@@ -37,6 +37,12 @@
             <span class="text-sm text-rose-700" data-domain--release-schedule-help-target="errOutput"></span>
             <span class="text-sm" data-domain--release-schedule-help-target="output"></span>
           </div>
+          <div class="col-span-3">
+            <%= render V2::Form::SwitchComponent.new(form:,
+                                                     field_name: :stop_automatic_releases_on_failure,
+                                                     on_label: "Automatically stop release on failure enabled",
+                                                     off_label: "Automatically stop release on failure disabled") %>
+          </div>
         </div>
       <% end %>
     <% end %>

--- a/db/migrate/20240510180828_add_stop_on_failure_on_scheduled_release.rb
+++ b/db/migrate/20240510180828_add_stop_on_failure_on_scheduled_release.rb
@@ -1,0 +1,5 @@
+class AddStopOnFailureOnScheduledRelease < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trains, :stop_automatic_releases_on_failure, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20240510180828_add_stop_on_failure_on_trains.rb
+++ b/db/migrate/20240510180828_add_stop_on_failure_on_trains.rb
@@ -1,4 +1,4 @@
-class AddStopOnFailureOnScheduledRelease < ActiveRecord::Migration[7.0]
+class AddStopOnFailureOnTrains < ActiveRecord::Migration[7.0]
   def change
     add_column :trains, :stop_automatic_releases_on_failure, :boolean, default: false, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_09_182925) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_10_180828) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -669,6 +669,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_09_182925) do
     t.boolean "tag_releases", default: true
     t.string "tag_suffix"
     t.string "versioning_strategy", default: "semver"
+    t.boolean "stop_automatic_releases_on_failure", default: false, null: false
     t.index ["app_id"], name: "index_trains_on_app_id"
   end
 

--- a/spec/factories/deployments.rb
+++ b/spec/factories/deployments.rb
@@ -69,3 +69,16 @@ def create_deployment_tree(platform = :android, *traits, train_traits: [], step_
   deployment = create(:deployment, *traits, integration: train.build_channel_integrations.first, step: step)
   {app:, train:, release_platform:, step:, deployment:}
 end
+
+def create_cross_platform_deployment_tree(*traits, train_traits: [], step_traits: [])
+  app = create(:app, :cross_platform)
+  train = create(:train, *train_traits, app:)
+  data = {app:, train:}
+  %i[android ios].each do |platform|
+    release_platform = create(:release_platform, train:, platform:)
+    step = create(:step, :with_deployment, *step_traits, release_platform: release_platform, integration: app.ci_cd_provider.integration)
+    deployment = create(:deployment, *traits, integration: train.build_channel_integrations.first, step: step)
+    data[platform] = {release_platform:, step:, deployment:}
+  end
+  data
+end

--- a/spec/factories/releases.rb
+++ b/spec/factories/releases.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
       status { "post_release_started" }
     end
 
+    trait :post_release_failed do
+      status { "post_release_failed" }
+    end
+
     trait :finished do
       status { "finished" }
       completed_at { Time.current }

--- a/spec/models/train_spec.rb
+++ b/spec/models/train_spec.rb
@@ -204,4 +204,42 @@ describe Train do
       expect(train.reload.hotfixable?).to be(true)
     end
   end
+
+  describe "#stop_failed_ongoing_release!" do
+    it "does nothing if teh train is not automatic" do
+      train = create(:train, :active, stop_automatic_releases_on_failure: true)
+      release = create(:release, :post_release_failed, train:)
+
+      train.stop_failed_ongoing_release!
+
+      expect(release.reload.stopped?).to be(false)
+    end
+
+    it "does nothing if the ongoing release is not in failed state" do
+      train = create(:train, :active, :with_schedule, stop_automatic_releases_on_failure: true)
+      release = create(:release, :on_track, train:)
+
+      train.stop_failed_ongoing_release!
+
+      expect(release.reload.stopped?).to be(false)
+    end
+
+    it "does nothing if the flag to stop release is not enabled" do
+      train = create(:train, :active, :with_schedule, stop_automatic_releases_on_failure: false)
+      release = create(:release, :post_release_failed, train:)
+
+      train.stop_failed_ongoing_release!
+
+      expect(release.reload.stopped?).to be(false)
+    end
+
+    it "stops the ongoing release which is in failed state" do
+      train = create(:train, :active, :with_schedule, stop_automatic_releases_on_failure: true)
+      release = create(:release, :post_release_failed, train:)
+
+      train.stop_failed_ongoing_release!
+
+      expect(release.reload.stopped?).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
So that nightly automatic scheduled trains don't require any manual intervention from users.