### PR TITLE
More reldex components and minor fixes

### DIFF
--- a/app/components/v2/reldex/form_component.rb
+++ b/app/components/v2/reldex/form_component.rb
@@ -17,7 +17,9 @@ class V2::Reldex::FormComponent < V2::Reldex::BaseComponent
     rollout_duration: {allowed_range: 0..30, step: 1},
     duration: {allowed_range: 0..30, step: 1},
     stability_duration: {allowed_range: 0..20, step: 1},
-    stability_changes: {allowed_range: 0..50, step: 1}
+    stability_changes: {allowed_range: 0..50, step: 1},
+    rollout_changes: {allowed_range: 0..20, step: 1},
+    days_since_last_release: {allowed_range: 0..30, step: 1}
   }
 
   def base_form_config

--- a/app/javascript/controllers/charts_controller.js
+++ b/app/javascript/controllers/charts_controller.js
@@ -131,6 +131,12 @@ export default class extends Controller {
       },
       yaxis: {
         show: false,
+      },
+      markers: {
+        size: 3,
+        hover: {
+          sizeOffset: 2
+        }
       }
     }
   }
@@ -187,7 +193,7 @@ export default class extends Controller {
         curve: 'smooth'
       },
       xaxis: {
-        tickPlacement: 'between',
+        tickPlacement: 'on',
         labels: {
           show: this.showXAxisValue,
           style: {
@@ -208,7 +214,13 @@ export default class extends Controller {
       yaxis: {
         show: this.showYAxisValue,
       },
-      annotations: this.annotationsValue
+      annotations: this.annotationsValue,
+      markers: {
+        size: 3,
+        hover: {
+          sizeOffset: 2
+        }
+      }
     }
   }
 

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -67,15 +67,22 @@ class Commit < ApplicationRecord
     return none if head_step_run.nil?
     return none if base_step_run.nil? && head_step_run.nil?
 
-    base_condition = where(release_id: (base_step_run || head_step_run).release.id)
+    between_commits(base_step_run&.commit, head_step_run.commit)
+  end
+
+  def self.between_commits(base_commit, head_commit)
+    return none if head_commit.nil?
+    return none if base_commit.nil? && head_commit.nil?
+
+    base_condition = where(release_id: (base_commit || head_commit).release.id)
       .order(created_at: :desc)
 
-    if base_step_run
+    if base_commit
       base_condition
-        .where("created_at > ? AND created_at <= ?", base_step_run.commit.created_at, head_step_run.commit.created_at)
+        .where("created_at > ? AND created_at <= ?", base_commit.created_at, head_commit.created_at)
     else
       base_condition
-        .where("created_at <= ?", head_step_run.commit.created_at)
+        .where("created_at <= ?", head_commit.created_at)
     end
   end
 

--- a/app/models/release_index_component.rb
+++ b/app/models/release_index_component.rb
@@ -23,7 +23,9 @@ class ReleaseIndexComponent < ApplicationRecord
     rollout_duration: {default_weight: 0.15, default_tolerance: 7..10, tolerance_unit: :day},
     duration: {default_weight: 0.05, default_tolerance: 14..17, tolerance_unit: :day},
     stability_duration: {default_weight: 0.15, default_tolerance: 7..10, tolerance_unit: :day},
-    stability_changes: {default_weight: 0.15, default_tolerance: 10..20, tolerance_unit: :number}
+    stability_changes: {default_weight: 0.15, default_tolerance: 10..20, tolerance_unit: :number},
+    rollout_changes: {default_weight: 0, default_tolerance: 1..5, tolerance_unit: :number},
+    days_since_last_release: {default_weight: 0, default_tolerance: 10..15, tolerance_unit: :day}
   }
 
   DEFAULT_COMPONENTS.each do |component, details|
@@ -70,10 +72,12 @@ class ReleaseIndexComponent < ApplicationRecord
     end
 
     def range_value
-      if @input_value <= tolerable_range.begin; then 1
-      elsif tolerable_range.cover?(@input_value); then 0.5
-      else
+      if @input_value <= tolerable_range.begin
+        1
+      elsif @input_value >= tolerable_range.end
         0
+      else
+        0.5
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,8 @@ en:
           duration: "Release Duration"
           stability_duration: "Stability Duration"
           stability_changes: "Stability Changes"
+          rollout_changes: "Rollout Changes"
+          days_since_last_release: "Days since last release"
         description:
           hotfixes: "These are the fixes that are done after the release has reached all the users."
           rollout_fixes: "These are the fixes that are done while the staged rollout of the release is in progress."
@@ -155,6 +157,8 @@ en:
           duration: "The number of days from release start (code freeze) to 100% rollout of the release."
           stability_duration: "The number of days it takes to stabilize the build before submitting it to the stores for review."
           stability_changes: "The number of commits it took to stabilize the build for release."
+          rollout_changes: "The number of commits that went into the patch fixes for the release."
+          days_since_last_release: "The number of days since the last release."
     attributes:
       integration:
         categories:

--- a/db/data/20240512081228_add_more_reldex_components.rb
+++ b/db/data/20240512081228_add_more_reldex_components.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddMoreReldexComponents < ActiveRecord::Migration[7.0]
+  def up
+    new_components = [:days_since_last_release, :rollout_changes]
+    ReleaseIndex.all.each do |reldex|
+      ReleaseIndexComponent::DEFAULT_COMPONENTS.slice(*new_components).each do |component, details|
+        next if reldex.components.find_by(name: component.to_s)
+
+        reldex.components.create!(
+          name: component.to_s,
+          weight: details[:default_weight],
+          tolerable_unit: details[:tolerance_unit],
+          tolerable_range: details[:default_tolerance]
+        )
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240422123909)
+DataMigrate::Data.define(version: 20240512081228)

--- a/spec/models/release_index_spec.rb
+++ b/spec/models/release_index_spec.rb
@@ -38,21 +38,21 @@ describe ReleaseIndex do
       reldex = create(:release_index, tolerable_range: 0.5..0.8)
 
       score = reldex.score(**metrics)
-      expect(score.value).to eq 0.650
+      expect(score.value).to eq 0.5
     end
 
     it "computes the reldex grade" do
       reldex = create(:release_index, tolerable_range: 0.5..0.8)
 
       score = reldex.score(**metrics)
-      expect(score.grade).to eq :acceptable
+      expect(score.grade).to eq :mediocre
     end
 
     it "computes the individual component scores" do
       reldex = create(:release_index, tolerable_range: 0.5..0.8)
 
       score = reldex.score(**metrics)
-      expect(score.components.map(&:value)).to match_array([0.15, 0.2, 0.0, 0.0, 0.15, 0.15])
+      expect(score.components.map(&:value)).to match_array([0.0, 0.2, 0.0, 0.0, 0.15, 0.15])
     end
 
     it "contains the release index itself" do

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -496,11 +496,11 @@ describe Release do
         stability_changes: {input: 11, range_value: 0.5, value: 0.075}
       ), 0.825],
       [PERFECT_SCORE_COMPONENTS.merge(
-        hotfixes: {input: 1, range_value: 0.5, value: 0.15},
+        hotfixes: {input: 1, range_value: 0, value: 0},
         duration: {input: 15, range_value: 0.5, value: 0.025},
         rollout_duration: {input: 9, range_value: 0.5, value: 0.075},
         stability_changes: {input: 11, range_value: 0.5, value: 0.075}
-      ), 0.675],
+      ), 0.525],
       [PERFECT_SCORE_COMPONENTS.merge(
         hotfixes: {input: 1, range_value: 0, value: 0},
         rollout_fixes: {input: 2, range_value: 0, value: 0},

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -502,12 +502,12 @@ describe Release do
         stability_changes: {input: 11, range_value: 0.5, value: 0.075}
       ), 0.675],
       [PERFECT_SCORE_COMPONENTS.merge(
-        hotfixes: {input: 1, range_value: 0.5, value: 0.15},
+        hotfixes: {input: 1, range_value: 0, value: 0},
         rollout_fixes: {input: 2, range_value: 0, value: 0},
         duration: {input: 15, range_value: 0.5, value: 0.025},
         rollout_duration: {input: 9, range_value: 0.5, value: 0.075},
         stability_changes: {input: 11, range_value: 0.5, value: 0.075}
-      ), 0.475]
+      ), 0.325]
     ].each do |components, final_score|
       it "returns the index score for a finished release" do
         create_deployment_tree(:android, :with_staged_rollout, step_traits: [:release]) => { step:, deployment:, train: }


### PR DESCRIPTION
Two more components:
- `rollout_changes`: The number of commits that went into the patch fixes for the release
- `days_since_last_release`: The number of days since the last release

Fixes:
- Fix component value calculation boundary checks
- Make charts better readable with markers and better tick placement for line charts

<img width="1312" alt="Screenshot 2024-05-12 at 4 53 12 PM" src="https://github.com/tramlinehq/tramline/assets/1309111/73ec9933-e04a-46b8-b90a-1b137c7a1032">
