### PR TITLE
Upcoming release without review step

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -218,6 +218,10 @@ class Release < ApplicationRecord
     false
   end
 
+  def production_release_happened?
+    release_platform_runs.all?(&:production_release_happened?)
+  end
+
   def finish_after_partial_finish!
     with_lock do
       return unless partially_finished?

--- a/app/models/step_run.rb
+++ b/app/models/step_run.rb
@@ -245,6 +245,10 @@ class StepRun < ApplicationRecord
     startable_deployment?(deployment) && (last_deployment_run&.released? || release_platform_run.patch_fix? || release.hotfix?)
   end
 
+  def deployment_start_blocked?(deployment)
+    release.upcoming? && deployment.production_channel?
+  end
+
   def last_deployment_run
     deployment_runs.last
   end

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -317,8 +317,8 @@ class Train < ApplicationRecord
   def upcoming_release_startable?
     manually_startable? &&
       release_platforms.any?(&:has_production_deployment?) &&
-      release_platforms.all?(&:has_review_steps?) &&
       ongoing_release.present? &&
+      (release_platforms.all?(&:has_review_steps?) || ongoing_release.production_release_happened?) &&
       upcoming_release.blank?
   end
 

--- a/app/views/shared/live_release/_deployment_status.html.erb
+++ b/app/views/shared/live_release/_deployment_status.html.erb
@@ -1,10 +1,24 @@
 <% if step_run.present? %>
-  <% if step_run.manually_startable_deployment?(deployment) %>
-    <%= authz_button_to :blue,
-                        "Start this deployment",
-                        start_release_step_run_deployment_path(platform_run, step_run, deployment),
-                        { class: 'mt-2 btn-xs' } %>
+  <% if step_run.deployment_start_blocked?(deployment) %>
+    <div class="flex flex-col mb-1">
+      <%= authz_button_to :disabled,
+                          "Start this deployment",
+                          start_release_step_run_deployment_path(platform_run, step_run, deployment),
+                          { class: 'mt-2 btn-xs' } %>
+      <div class="text-sm mt-2 font-normal text-gray-500 bg-gray-50 p-2 rounded-sm border border-gray-200">
+        You cannot start this release step until the <%= blocked_step_release_link(step_run.release) %> is
+        finished.
+      </div>
+    </div>
+  <% else %>
+    <% if step_run.manually_startable_deployment?(deployment) %>
+      <%= authz_button_to :blue,
+                          "Start this deployment",
+                          start_release_step_run_deployment_path(platform_run, step_run, deployment),
+                          { class: 'mt-2 btn-xs' } %>
+    <% end %>
   <% end %>
+
 
   <% deployment_run = step_run.last_run_for(deployment) %>
 


### PR DESCRIPTION
- Allows only when the ongoing production rollout has started
- Does not allow starting the production deployment of an upcoming release