### PR TITLE
Persist team-related stats for release summary

### DIFF
--- a/app/components/v2/live_release/regression_testing_component.rb
+++ b/app/components/v2/live_release/regression_testing_component.rb
@@ -10,20 +10,19 @@ class V2::LiveRelease::RegressionTestingComponent < V2::BaseComponent
 
   def events
     [{
-       timestamp: time_format(1.day.ago, with_year: false),
-       description: "Build #239 was rejected by Derek O' Brien",
-       type: :error
-     },
-     {
-       timestamp: time_format(2.days.ago, with_year: false),
-       description: "Build #238 was approved by Akhil Vaidya",
-       type: :success
-     },
-     {
-       timestamp: time_format(3.days.ago, with_year: false),
-       description: "Build #237 was approved by Sagar Neeraj",
-       type: :success
-     },]
-
+      timestamp: time_format(1.day.ago, with_year: false),
+      description: "Build #239 was rejected by Derek O' Brien",
+      type: :error
+    },
+      {
+        timestamp: time_format(2.days.ago, with_year: false),
+        description: "Build #238 was approved by Akhil Vaidya",
+        type: :success
+      },
+      {
+        timestamp: time_format(3.days.ago, with_year: false),
+        description: "Build #237 was approved by Sagar Neeraj",
+        type: :success
+      }]
   end
 end

--- a/app/libs/charts/devops_report.rb
+++ b/app/libs/charts/devops_report.rb
@@ -157,7 +157,7 @@ class Charts::DevopsReport
     finished_releases(last)
       .group_by(&:release_version)
       .sort_by { |v, _| v.to_semverish }.to_h
-      .transform_values { |releases| releases[0].stability_commits.count_by_team(organization) }
+      .transform_values { |releases| release_summary(releases[0]).team_stability_commits }
       .compact_blank
   end
 
@@ -165,7 +165,7 @@ class Charts::DevopsReport
     finished_releases(last)
       .group_by(&:release_version)
       .sort_by { |v, _| v.to_semverish }.to_h
-      .transform_values { |releases| releases[0].release_changelog&.commits_by_team }
+      .transform_values { |releases| release_summary(releases[0]).team_release_commits }
       .compact_blank
   end
 
@@ -243,6 +243,10 @@ class Charts::DevopsReport
 
     return releases if hotfix
     releases.release
+  end
+
+  memoize def release_summary(release)
+    Queries::ReleaseSummary.new(release.id)
   end
 
   def cache_key


### PR DESCRIPTION
- Do not recompute team stats on recompute of summary
- Use persisted release summary team stats in train DevOps report

## Because

The users' team and VCS login details can change over time. The release and train stats around their team membership and commit contributions should not change with time.

