### PR TITLE
Add train configiguration to allow patch version bump only between releases

### DIFF
--- a/app/controllers/trains_controller.rb
+++ b/app/controllers/trains_controller.rb
@@ -129,7 +129,8 @@ class TrainsController < SignedInApplicationController
       :tag_platform_releases,
       :notifications_enabled,
       :tag_releases,
-      :tag_suffix
+      :tag_suffix,
+      :patch_version_bump_only
     )
   end
 
@@ -166,7 +167,8 @@ class TrainsController < SignedInApplicationController
       :tag_platform_releases,
       :notifications_enabled,
       :tag_releases,
-      :tag_suffix
+      :tag_suffix,
+      :patch_version_bump_only
     )
   end
 

--- a/app/models/concerns/versionable.rb
+++ b/app/models/concerns/versionable.rb
@@ -3,12 +3,12 @@ module Versionable
 
   def next_version(major_only: false, patch_only: false)
     raise ArgumentError, "both major and patch cannot be true" if major_only && patch_only
-    patch_only = true if patch_version_bump_only && !major_only
     version = version_current.to_semverish
     version_current.ver_bump(bump_term(version, major_only:, patch_only:), strategy: versioning_strategy)
   end
 
   def next_to_next_version(major_only: false, patch_only: false)
+    version = version_current.to_semverish
     next_version(major_only: major_only, patch_only: patch_only)
       .ver_bump(bump_term(version, major_only:, patch_only:), strategy: versioning_strategy)
   end
@@ -16,6 +16,7 @@ module Versionable
   private
 
   def bump_term(version, major_only: false, patch_only: false)
+    patch_only = true if patch_version_bump_only && !major_only
     if patch_only && version.proper?
       :patch
     else

--- a/app/models/concerns/versionable.rb
+++ b/app/models/concerns/versionable.rb
@@ -3,6 +3,7 @@ module Versionable
 
   def next_version(major_only: false, patch_only: false)
     raise ArgumentError, "both major and patch cannot be true" if major_only && patch_only
+    patch_only = true if patch_version_bump_only && !major_only
     version = version_current.to_semverish
     version_current.ver_bump(bump_term(version, major_only:, patch_only:), strategy: versioning_strategy)
   end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -170,7 +170,7 @@ class Release < ApplicationRecord
   attr_accessor :has_major_bump, :force_finalize, :hotfix_platform, :custom_version
   friendly_id :human_slug, use: :slugged
 
-  delegate :versioning_strategy, to: :train
+  delegate :versioning_strategy, :patch_version_bump_only, to: :train
   delegate :app, :vcs_provider, :release_platforms, :notify!, :continuous_backmerge?, to: :train
   delegate :platform, :organization, to: :app
 

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -14,6 +14,7 @@
 #  manual_release                     :boolean          default(FALSE)
 #  name                               :string           not null
 #  notification_channel               :jsonb
+#  patch_version_bump_only            :boolean          default(FALSE), not null
 #  release_backmerge_branch           :string
 #  release_branch                     :string
 #  repeat_duration                    :interval

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -245,6 +245,18 @@
       <% end %>
     <% end %>
 
+    <%= f.with_advanced_section(heading: "Patch Version Change Only") do |section| %>
+      <% section.with_description do %>
+        By default, minor version of the app is bumped up between each successful release of the train.
+        You can override this behavior to bump up the patch version only.
+      <% end %>
+
+      <%= render V2::Form::SwitchComponent.new(form: section.F,
+                                               field_name: :patch_version_bump_only,
+                                               on_label: "Only patch version will change between releases",
+                                               off_label: "Minor version will change between releases (default)") %>
+    <% end %>
+
     <% f.with_action do %>
       <%= f.F.authz_submit (train.persisted? ? "Update Train" : "Create Train"), (train.persisted? ? "v2/archive.svg" : "plus.svg"), disabled: @edit_not_allowed %>
     <% end %>

--- a/db/migrate/20240625180701_add_patch_version_bump_only_on_trains.rb
+++ b/db/migrate/20240625180701_add_patch_version_bump_only_on_trains.rb
@@ -1,0 +1,5 @@
+class AddPatchVersionBumpOnlyOnTrains < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trains, :patch_version_bump_only, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_22_112429) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_25_180701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -706,6 +706,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_22_112429) do
     t.string "tag_suffix"
     t.string "versioning_strategy", default: "semver"
     t.boolean "stop_automatic_releases_on_failure", default: false, null: false
+    t.boolean "patch_version_bump_only", default: false, null: false
     t.index ["app_id"], name: "index_trains_on_app_id"
   end
 

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -128,6 +128,32 @@ describe Release do
         end
       end
     end
+
+    context "when train has patch_version_bump_only" do
+      {
+        "1.2.3" => {major: "2.0.0", minor: "1.2.4"},
+        "1.2" => {major: "2.0", minor: "1.3"}
+      }.each do |ver, expect|
+        it "minor bump: sets the original_release_version to next version of the train with patch bump only for proper" do
+          train = create(:train, version_seeded_with: ver, patch_version_bump_only: true)
+          run = build(:release, original_release_version: nil, train:)
+
+          expect(run.original_release_version).to be_nil
+          run.save!
+          expect(run.original_release_version).to eq(expect[:minor])
+        end
+
+        it "major bump: sets the original_release_version to next version of the train with major bump" do
+          train = create(:train, version_seeded_with: ver, patch_version_bump_only: true)
+          run = build(:release, original_release_version: nil, train:)
+          run.has_major_bump = true
+
+          expect(run.original_release_version).to be_nil
+          run.save!
+          expect(run.original_release_version).to eq(expect[:major])
+        end
+      end
+    end
   end
 
   describe ".create" do


### PR DESCRIPTION
## Because

For daily/weekly scheduled releases, some users don't want minor versions increasing between each release.