### PR TITLE
Improved hotfixes with the new live release

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -3,7 +3,6 @@
 
 /* new styles */
 
-
 @layer base {
   @supports (font-variation-settings: normal) {
     @font-face {

--- a/app/components/v2/button_component.rb
+++ b/app/components/v2/button_component.rb
@@ -142,11 +142,8 @@ class V2::ButtonComponent < V2::BaseComponent
     options[:disabled] = true if disabled?
 
     options[:data] ||= {}
-    if @turbo
-      options[:data][:turbo] = @turbo
-    else
-      options[:data][:turbo_frame] = "_top"
-    end
+    options[:data][:turbo] = @turbo
+    options[:data][:turbo_frame] = "_top" unless @turbo
 
     if tooltip_allowed?
       options[:data][:popup_target] = "element"

--- a/app/components/v2/live_release/container_component.html.erb
+++ b/app/components/v2/live_release/container_component.html.erb
@@ -16,7 +16,7 @@
               <span class="self-end"><%= render V2::BadgeComponent.new(text: "Hotfix", kind: :featured) %></span>
             <% end %>
 
-            <div class="flex flex-row gap-2 justify-end items-baseline">
+            <div class="flex flex-row gap-2 justify-end items-baseline !bg-diagonal-stripes-soft-red">
               <% if cross_platform? %>
                 <div class="flex items-center gap-1">
                   <%= render V2::IconComponent.new("v2/android.svg", size: :lg) %>

--- a/app/components/v2/live_release/container_component.html.erb
+++ b/app/components/v2/live_release/container_component.html.erb
@@ -16,7 +16,7 @@
               <span class="self-end"><%= render V2::BadgeComponent.new(text: "Hotfix", kind: :featured) %></span>
             <% end %>
 
-            <div class="flex flex-row gap-2 justify-end items-baseline !bg-diagonal-stripes-soft-red">
+            <div class="flex flex-row gap-2 justify-end items-baseline <%= hotfix_background %>">
               <% if cross_platform? %>
                 <div class="flex items-center gap-1">
                   <%= render V2::IconComponent.new("v2/android.svg", size: :lg) %>

--- a/app/components/v2/live_release/container_component.rb
+++ b/app/components/v2/live_release/container_component.rb
@@ -75,4 +75,8 @@ class V2::LiveRelease::ContainerComponent < V2::BaseComponent
   def sidebar_title_tag(config)
     config[:unavailable] ? :div : :a
   end
+
+  def hotfix_background
+    "bg-diagonal-stripes-soft-red" if hotfix?
+  end
 end

--- a/app/components/v2/live_release/finalize_component.html.erb
+++ b/app/components/v2/live_release/finalize_component.html.erb
@@ -54,11 +54,11 @@
     <% if post_release_failed? %>
       <div class="flex flex-col items-start item-gap-default mt-4">
         <% if open_backmerge_prs? %>
-          <%= render V2::AlertComponent.new(type: :error, title: "We couldn't finish this release, please manually merge/close the backmerge PRs and retry.") %>
+          <%= render V2::AlertComponent.new(type: :error, title: "We couldn't finish this release, please manually merge/close the backmerge PRs and retry.", full_screen: false) %>
           <h3 class="heading-5">Backmerge Pull Requests</h3>
           <%= render(V2::PullRequestComponent.with_collection(open_backmerge_prs, simple: true)) %>
         <% elsif open_post_release_prs? %>
-          <%= render V2::AlertComponent.new(type: :error, title: "We couldn't automatically finish the release, please manually merge/close the PR and retry.") %>
+          <%= render V2::AlertComponent.new(type: :error, title: "We couldn't automatically finish the release, please manually merge/close the PR and retry.", full_screen: false) %>
           <h3 class="heading-5">Post-release Pull Request</h3>
           <%= render(V2::PullRequestComponent.with_collection(open_post_release_prs, simple: true)) %>
         <% end %>

--- a/app/components/v2/live_release/internal_builds_component.html.erb
+++ b/app/components/v2/live_release/internal_builds_component.html.erb
@@ -15,25 +15,34 @@
         <% end %>
       <% end %>
 
-      <% component.runs do |release_platform_run| %>
-        <% latest_release = latest_internal_release(release_platform_run) %>
+      <% component.runs do |run| %>
+        <% latest_release = latest_internal_release(run) %>
         <% if latest_release.present? %>
           <%= render V2::LiveRelease::PreProdRelease::CurrentReleaseComponent.new(latest_release) %>
-        <% elsif configured?(release_platform_run) %>
-          <%= render V2::EmptyStateComponent.new(
-            title: "Not ready yet",
-            text: "Please wait for changes to be applied before starting.",
-            banner_image: icon,
-            type: :subdued) %>
+        <% elsif configured?(run) %>
+          <% if run.hotfix? %>
+            <%= render V2::AlertComponent.new(kind: :announcement, type: :announce, title: "Changes were not automatically applied for the hotfix") do |ann| %>
+              <% ann.with_announcement_button(label: "Create internal build",
+                                              scheme: :default,
+                                              type: :button,
+                                              options: pre_prod_internal_run_path(run),
+                                              size: :xxs,
+                                              turbo: false,
+                                              html_options: html_opts(:post, "Are you sure you want to create the internal build?")) %>
+              <div class="flex flex-col gap-2">
+                <%= render V2::CommitComponent.new(commit: applicable_commit(run), detailed: false) %>
+                <span class="text-sm">Internal builds are not automatically triggered for hotfixes. But you can manually apply the latest commit and kickoff the build.</span>
+              </div>
+            <% end %>
+          <% else %>
+            <%= render V2::EmptyStateComponent.new(
+              title: "Not ready yet",
+              text: "Please wait for changes to be applied before starting.",
+              banner_image: icon,
+              type: :subdued) %>
+          <% end %>
         <% else %>
-          <div></div>
-          <%= render V2::ButtonComponent.new(
-            scheme: :success,
-            options: run_pre_prod_internal_path(release_platform_run),
-            type: :button,
-            size: :xxs,
-            turbo: false,
-            html_options: html_opts(:post, "Are you sure you want to start the internal release?")) %>
+          <div><!-- grid maintenance --></div>
         <% end %>
       <% end %>
 

--- a/app/components/v2/live_release/internal_builds_component.html.erb
+++ b/app/components/v2/live_release/internal_builds_component.html.erb
@@ -26,7 +26,14 @@
             banner_image: icon,
             type: :subdued) %>
         <% else %>
-          <div><!-- grid maintenance --></div>
+          <div></div>
+          <%= render V2::ButtonComponent.new(
+            scheme: :success,
+            options: run_pre_prod_internal_path(release_platform_run),
+            type: :button,
+            size: :xxs,
+            turbo: false,
+            html_options: html_opts(:post, "Are you sure you want to start the internal release?")) %>
         <% end %>
       <% end %>
 

--- a/app/components/v2/live_release/internal_builds_component.rb
+++ b/app/components/v2/live_release/internal_builds_component.rb
@@ -13,23 +13,27 @@ class V2::LiveRelease::InternalBuildsComponent < V2::BaseComponent
 
   attr_reader :release
 
-  def configured?(release_platform_run)
-    configuration(release_platform_run).present?
+  def applicable_commit(run)
+    run.release.last_applicable_commit
   end
 
-  def configuration(release_platform_run)
-    release_platform_run.conf.internal_release
+  def configured?(run)
+    configuration(run).present?
   end
 
-  def internal_workflow_config(release_platform_run)
-    release_platform_run.conf.workflows.pick_internal_workflow
+  def configuration(run)
+    run.conf.internal_release
   end
 
-  def latest_internal_release(release_platform_run)
-    release_platform_run.latest_internal_release
+  def internal_workflow_config(run)
+    run.conf.workflows.pick_internal_workflow
   end
 
-  def previous_internal_releases(release_platform_run)
-    release_platform_run.older_internal_releases
+  def latest_internal_release(run)
+    run.latest_internal_release
+  end
+
+  def previous_internal_releases(run)
+    run.older_internal_releases
   end
 end

--- a/app/components/v2/live_release/metadata_component.html.erb
+++ b/app/components/v2/live_release/metadata_component.html.erb
@@ -3,7 +3,7 @@
     <%= render V2::AlertComponent.new(type: :info, title: "You can edit the release notes until the review process has begun on the stores.", full_screen: false) %>
   <% else %>
     <%= render V2::AlertComponent.new(kind: :announcement, type: :announce, title: "Release notes cannot be edited") do %>
-      Unfortunately, you can't edit the release notes once the review process has begun on the stores.
+      ❌ You can't edit the release notes once the review process has begun on the stores.
     <% end %>
   <% end %>
 </div>

--- a/app/components/v2/live_release/overview_component.html.erb
+++ b/app/components/v2/live_release/overview_component.html.erb
@@ -1,4 +1,12 @@
 <div class="flex flex-col section-gap-default">
+  <% if hotfix_banner? %>
+    <%= render V2::AlertComponent.new(kind: :announcement, type: :announce, title: "No automatic actions were triggered") do %>
+      <div class="flex flex-col gap-2">
+        <span class="text-sm">Since this is a hotfix release with no new changes, please manually rebuild your RC or land new changes to the release branch.</span>
+      </div>
+    <% end %>
+  <% end %>
+
   <div class="flex">
     <%= render V2::HorizontalDataSetComponent.new(separator: :dashed, bg_color: true) do |component| %>
       <% component.with_data_set(title: "Release Captain") do %>

--- a/app/components/v2/live_release/overview_component.rb
+++ b/app/components/v2/live_release/overview_component.rb
@@ -48,4 +48,8 @@ class V2::LiveRelease::OverviewComponent < V2::BaseComponent
       show_y_axis: false
     }
   end
+
+  def hotfix_banner?
+    hotfix? && release.all_commits.exists? && release.pre_prod_releases.none?
+  end
 end

--- a/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
+++ b/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
@@ -7,7 +7,7 @@
       <% ann.with_announcement_button(label: "Create Release Candidate",
                                       scheme: :default,
                                       type: :button,
-                                      options: run_pre_prod_beta_path(release_platform_run),
+                                      options: pre_prod_beta_run_path(release_platform_run),
                                       size: :xxs,
                                       turbo: false,
                                       html_options: html_opts(:post, "Are you sure you want to create the RC?")) %>

--- a/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
+++ b/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
@@ -2,27 +2,6 @@
   <%= render partial: "shared/play_store_review_rejected", locals: {show: show_blocked_message?,
                                                                     build:,
                                                                     actionable: false} %>
-  <% if pre_prod_release.new_build_available? %>
-    <%= render V2::AlertComponent.new(kind: :announcement, type: :announce, title: "New Internal Build is available") do |ann| %>
-      <% ann.with_announcement_button(label: "Start Beta release",
-                                      scheme: :default,
-                                      type: :button,
-                                      options: run_pre_prod_beta_path(release_platform_run),
-                                      size: :xxs,
-                                      turbo: false,
-                                      html_options: html_opts(:post, "Are you sure you want to start the beta release?")) %>
-      <div class="flex flex-col gap-2">
-        <%= render V2::LiveRelease::BuildComponent.new(
-          latest_internal_release.build,
-          show_metadata: false,
-          show_ci: true,
-          show_activity: false,
-          show_commit: false) %>
-        <span class="text-sm">Please start the beta release for the new build.</span>
-      </div>
-    <% end %>
-  <% end %>
-
   <% if pre_prod_release.new_commit_available? %>
     <%= render V2::AlertComponent.new(kind: :announcement, type: :announce, title: "New changes on the release branch") do |ann| %>
       <% ann.with_announcement_button(label: "Create Release Candidate",

--- a/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
+++ b/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
@@ -34,7 +34,7 @@
                                       html_options: html_opts(:post, "Are you sure you want to start the beta release?", params: {pre_prod_release: rc_params})) %>
       <div class="flex flex-col gap-2">
         <%= render V2::CommitComponent.new(commit: latest_commit, detailed: false) %>
-        <span class="text-sm">You can continue to release your existing Release Candidate, or replace it with the new change.</span>
+        <span class="text-sm">You can continue with your existing Release Candidate, or replace it with this new change.</span>
       </div>
     <% end %>
   <% end %>

--- a/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
+++ b/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
@@ -10,7 +10,7 @@
                                       options: run_pre_prod_beta_path(release_platform_run),
                                       size: :xxs,
                                       turbo: false,
-                                      html_options: html_opts(:post, "Are you sure you want to start the beta release?", params: {pre_prod_release: rc_params})) %>
+                                      html_options: html_opts(:post, "Are you sure you want to start the beta release?")) %>
       <div class="flex flex-col gap-2">
         <%= render V2::LiveRelease::BuildComponent.new(
           latest_internal_release.build,
@@ -31,7 +31,7 @@
                                       options: run_pre_prod_beta_path(release_platform_run),
                                       size: :xxs,
                                       turbo: false,
-                                      html_options: html_opts(:post, "Are you sure you want to start the beta release?", params: {pre_prod_release: rc_params})) %>
+                                      html_options: html_opts(:post, "Are you sure you want to start the beta release?")) %>
       <div class="flex flex-col gap-2">
         <%= render V2::CommitComponent.new(commit: latest_commit, detailed: false) %>
         <span class="text-sm">You can continue with your existing Release Candidate, or replace it with this new change.</span>

--- a/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
+++ b/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
@@ -31,7 +31,7 @@
                                       options: run_pre_prod_beta_path(release_platform_run),
                                       size: :xxs,
                                       turbo: false,
-                                      html_options: html_opts(:post, "Are you sure you want to start the beta release?")) %>
+                                      html_options: html_opts(:post, "Are you sure you want to create the RC?")) %>
       <div class="flex flex-col gap-2">
         <%= render V2::CommitComponent.new(commit: latest_commit, detailed: false) %>
         <span class="text-sm">You can continue with your existing Release Candidate, or replace it with this new change.</span>

--- a/app/components/v2/live_release/pre_prod_release/current_release_component.rb
+++ b/app/components/v2/live_release/pre_prod_release/current_release_component.rb
@@ -40,19 +40,11 @@ class V2::LiveRelease::PreProdRelease::CurrentReleaseComponent < V2::BaseCompone
     workflow_run&.may_retry?
   end
 
-  memoize def latest_internal_release
+  def latest_internal_release
     release_platform_run.latest_internal_release(finished: true)
   end
 
-  memoize def latest_commit
+  def latest_commit
     release_platform_run.last_commit
-  end
-
-  def rc_params
-    if pre_prod_release.carried_over?
-      {build_id: latest_internal_release.build.id}
-    else
-      {commit_id: latest_commit.id}
-    end
   end
 end

--- a/app/components/v2/live_release/pre_prod_release/prepare_release_candidate_component.html.erb
+++ b/app/components/v2/live_release/pre_prod_release/prepare_release_candidate_component.html.erb
@@ -6,6 +6,14 @@
     type: :subdued) %>
 <% end %>
 
+<% if release_platform_run.hotfix? %>
+  <%= render V2::AlertComponent.new(kind: :announcement, type: :announce, title: "Changes were not automatically applied for the hotfix") do %>
+    <div class="flex flex-col gap-2">
+      <span class="text-sm">There have been no new changes in this hotfix release branch. To rebuild the latest change, create the RC manually.</span>
+    </div>
+  <% end %>
+<% end %>
+
 <% if ready_for_beta_release? %>
   <%= render V2::CardComponent.new(title: title) do |card| %>
     <% if carryover_build? %>
@@ -38,7 +46,7 @@
       <% end %>
 
       <div class="flex flex-col section-gap-default">
-        <%= render V2::CommitComponent.new(commit:, detailed: false) %>
+        <%= render V2::CommitComponent.new(commit: applicable_commit, detailed: false) %>
       </div>
     <% end %>
   <% end %>

--- a/app/components/v2/live_release/pre_prod_release/prepare_release_candidate_component.html.erb
+++ b/app/components/v2/live_release/pre_prod_release/prepare_release_candidate_component.html.erb
@@ -14,40 +14,20 @@
   <% end %>
 <% end %>
 
-<% if ready_for_beta_release? %>
-  <%= render V2::CardComponent.new(title: title) do |card| %>
-    <% if carryover_build? %>
-      <% if release_platform_run.conf.beta_submissions? %>
-        <% card.with_action do %>
-          <%= render V2::ButtonComponent.new(label: "Start beta release",
-                                             scheme: :default,
-                                             type: :button,
-                                             options: create_release_candidate_path,
-                                             size: :xxs,
-                                             turbo: false,
-                                             html_options: confirmation_opts) %>
-        <% end %>
-      <% end %>
-
-      <div class="flex flex-col section-gap-default">
-        <%= render V2::LiveRelease::BuildComponent.new(build) %>
-      </div>
+<% if create_new_rc? %>
+  <%= render V2::CardComponent.new(title: "Latest Change") do |card| %>
+    <% card.with_action do %>
+      <%= render V2::ButtonComponent.new(label: "Create Release Candidate",
+                                         scheme: :default,
+                                         type: :button,
+                                         options: create_release_candidate_path,
+                                         size: :xxs,
+                                         turbo: false,
+                                         html_options: confirmation_opts) %>
     <% end %>
 
-    <% if create_new_rc? %>
-      <% card.with_action do %>
-        <%= render V2::ButtonComponent.new(label: "Create Release Candidate",
-                                           scheme: :default,
-                                           type: :button,
-                                           options: create_release_candidate_path,
-                                           size: :xxs,
-                                           turbo: false,
-                                           html_options: confirmation_opts) %>
-      <% end %>
-
-      <div class="flex flex-col section-gap-default">
-        <%= render V2::CommitComponent.new(commit: applicable_commit, detailed: false) %>
-      </div>
-    <% end %>
+    <div class="flex flex-col section-gap-default">
+      <%= render V2::CommitComponent.new(commit: applicable_commit, detailed: false) %>
+    </div>
   <% end %>
 <% end %>

--- a/app/components/v2/live_release/pre_prod_release/prepare_release_candidate_component.rb
+++ b/app/components/v2/live_release/pre_prod_release/prepare_release_candidate_component.rb
@@ -10,26 +10,13 @@ class V2::LiveRelease::PreProdRelease::PrepareReleaseCandidateComponent < V2::Ba
   delegate :build, to: :latest_internal_release, allow_nil: true
   delegate :ready_for_beta_release?, to: :release_platform_run
 
-  def title
-    if carryover_build?
-      "Active Release Candidate"
-    else
-      "Latest Change"
-    end
-  end
-
   def applicable_commit
     release_platform_run.release.last_applicable_commit
   end
 
   def create_new_rc?
     return unless ready_for_beta_release?
-    release_platform_run.conf.workflows.separate_rc_workflow? && applicable_commit.present?
-  end
-
-  def carryover_build?
-    return unless ready_for_beta_release?
-    !release_platform_run.conf.workflows.separate_rc_workflow? && latest_internal_release.present?
+    applicable_commit.present?
   end
 
   def confirmation_opts

--- a/app/components/v2/live_release/pre_prod_release/prepare_release_candidate_component.rb
+++ b/app/components/v2/live_release/pre_prod_release/prepare_release_candidate_component.rb
@@ -18,13 +18,13 @@ class V2::LiveRelease::PreProdRelease::PrepareReleaseCandidateComponent < V2::Ba
     end
   end
 
-  def commit
-    release_platform_run.last_commit
+  def applicable_commit
+    release_platform_run.release.last_applicable_commit
   end
 
   def create_new_rc?
     return unless ready_for_beta_release?
-    release_platform_run.conf.workflows.separate_rc_workflow? && commit.present?
+    release_platform_run.conf.workflows.separate_rc_workflow? && applicable_commit.present?
   end
 
   def carryover_build?
@@ -33,17 +33,10 @@ class V2::LiveRelease::PreProdRelease::PrepareReleaseCandidateComponent < V2::Ba
   end
 
   def confirmation_opts
-    rc_params =
-      if carryover_build?
-        {build_id: build.id}
-      else
-        {commit_id: commit.id}
-      end
-
-    html_opts(:post, "Are you sure you want to start the beta release?", params: {pre_prod_release: rc_params})
+    html_opts(:post, "Are you sure you want to start the beta release?")
   end
 
   def create_release_candidate_path
-    run_pre_prod_beta_path(release_platform_run)
+    pre_prod_beta_run_path(release_platform_run)
   end
 end

--- a/app/components/v2/live_release/pre_prod_release/submission_component.html.erb
+++ b/app/components/v2/live_release/pre_prod_release/submission_component.html.erb
@@ -48,14 +48,16 @@
         <%= render V2::HorizontalDataSetComponent.new do |component| %>
           <% component.with_data_set(title: "Status").with_content(external_status) %>
           <% component.with_data_set(title: "Tester groups").with_content(submission.submission_channel.name.truncate(50)) %>
-          <% component.with_data_set(title: "Dashboard") do %>
-            <%= render V2::ButtonComponent.new(scheme: :naked_icon,
-                                               type: :link_external,
-                                               options: submission.store_link,
-                                               html_options: {class: "text-xs"},
-                                               authz: false,
-                                               size: :none) do |b| %>
-              <% b.with_icon("v2/external_link.svg", size: :md) %>
+          <% if active? %>
+            <% component.with_data_set(title: "Dashboard") do %>
+              <%= render V2::ButtonComponent.new(scheme: :naked_icon,
+                                                 type: :link_external,
+                                                 options: submission.store_link,
+                                                 html_options: {class: "text-xs"},
+                                                 authz: false,
+                                                 size: :none) do |b| %>
+                <% b.with_icon("v2/external_link.svg", size: :md) %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/controllers/beta_releases_controller.rb
+++ b/app/controllers/beta_releases_controller.rb
@@ -9,18 +9,7 @@ class BetaReleasesController < SignedInApplicationController
   end
 
   def create
-    build_id = nil
-    commit_id = nil
-    if @release_platform_run.carryover_build?
-      # existing carryover build scenario
-      latest_internal_release = @release_platform_run.latest_internal_release(finished: true)
-      build_id = latest_internal_release.build.id
-    else
-      latest_commit = @release_platform_run.last_commit
-      commit_id = latest_commit.commit_id
-    end
-
-    if (result = Action.start_beta_release!(@release_platform_run, build_id, commit_id)).ok?
+    if (result = Action.start_beta_release!(@release_platform_run)).ok?
       redirect_back fallback_location: root_path, notice: t(".success")
     else
       redirect_back fallback_location: root_path, flash: {error: t(".failure", errors: result.error.message)}
@@ -34,6 +23,6 @@ class BetaReleasesController < SignedInApplicationController
   end
 
   def set_release_platform_run
-    @release_platform_run = ReleasePlatformRun.find(params[:run_id])
+    @release_platform_run = ReleasePlatformRun.find(params[:id])
   end
 end

--- a/app/controllers/beta_releases_controller.rb
+++ b/app/controllers/beta_releases_controller.rb
@@ -9,9 +9,16 @@ class BetaReleasesController < SignedInApplicationController
   end
 
   def create
-    # existing build scenario
-    build_id = default_params[:build_id]
-    commit_id = default_params[:commit_id]
+    build_id = nil
+    commit_id = nil
+    if @release_platform_run.carryover_build?
+      # existing carryover build scenario
+      latest_internal_release = @release_platform_run.latest_internal_release(finished: true)
+      build_id = latest_internal_release.build.id
+    else
+      latest_commit = @release_platform_run.last_commit
+      commit_id = latest_commit.commit_id
+    end
 
     if (result = Action.start_beta_release!(@release_platform_run, build_id, commit_id)).ok?
       redirect_back fallback_location: root_path, notice: t(".success")

--- a/app/controllers/concerns/exceptionable.rb
+++ b/app/controllers/concerns/exceptionable.rb
@@ -45,7 +45,7 @@ module Exceptionable
       @content = t("errors.messages.http_code.#{@code}.content")
       @message = exception.message if code < 500
 
-      format.any { render "errors/show", layout: "errors", status: code, formats: [:html] }
+      format.any { render "errors/show", layout: "errors", status: code, formats: [:html, :turbo_stream] }
       format.json { render json: {code:, error: Rack::Utils::HTTP_STATUS_CODES[code]}, status: code }
     end
   end

--- a/app/controllers/internal_releases_controller.rb
+++ b/app/controllers/internal_releases_controller.rb
@@ -6,6 +6,16 @@ class InternalReleasesController < SignedInApplicationController
     @app = @release.app
   end
 
+  def create
+    commit_id = @release_platform_run.last_commit&.id
+
+    if (result = Action.start_internal_release!(@release_platform_run, commit_id)).ok?
+      redirect_back fallback_location: root_path, notice: t(".success")
+    else
+      redirect_back fallback_location: root_path, flash: {error: t(".failure", errors: result.error.message)}
+    end
+  end
+
   def default_params
     params.require(:pre_prod_release).permit(:build_id, :commit_id)
   end

--- a/app/jobs/releases/pre_release_job.rb
+++ b/app/jobs/releases/pre_release_job.rb
@@ -2,12 +2,14 @@ class Releases::PreReleaseJob < ApplicationJob
   queue_as :high
 
   def perform(release_id)
-    run = Release.find(release_id)
+    release = Release.find(release_id)
 
-    if run.retrigger_for_hotfix?
-      return WebhookProcessors::Push.process(run, run.latest_commit_hash(sha_only: false), [])
+    if release.retrigger_for_hotfix?
+      latest_commit = release.latest_commit_hash(sha_only: false)
+      return WebhookProcessors::Push.process(release, latest_commit, []) unless release.is_v2?
+      return Signal.commits_have_landed!(release, latest_commit, []) if release.is_v2?
     end
 
-    Triggers::PreRelease.call(run)
+    Triggers::PreRelease.call(release)
   end
 end

--- a/app/libs/coordinators.rb
+++ b/app/libs/coordinators.rb
@@ -122,10 +122,22 @@ module Coordinators
       end
     end
 
+    def self.start_internal_release!(release_platform_run, commit_id)
+      Res.new do
+        raise "release is not active" unless release_platform_run.active?
+        commit = release_platform_run.release.all_commits.find(commit_id)
+        Coordinators::ApplyCommit.call(release_platform_run.release, commit, release_step: InternalRelease.to_s)
+      end
+    end
+
     def self.start_beta_release!(release_platform_run, build_id, commit_id)
       Res.new do
         raise "release is not active" unless release_platform_run.active?
-        Coordinators::CreateBetaRelease.call(release_platform_run, build_id, commit_id)
+        if commit_id.present?
+          Coordinators::ApplyCommit.call(release_platform_run.release, commit, release_step: BetaRelease.to_s)
+        else
+          Coordinators::CreateBetaRelease.call(release_platform_run, build_id, nil)
+        end
       end
     end
 

--- a/app/libs/coordinators.rb
+++ b/app/libs/coordinators.rb
@@ -58,10 +58,7 @@ module Coordinators
     end
 
     def self.internal_release_finished!(build)
-      release_platform_run = build.release_platform_run
-      if release_platform_run.conf.auto_start_beta_release?
-        Coordinators::CreateBetaRelease.call(release_platform_run, build, nil)
-      end
+      # manage regression testing here
     end
 
     def self.regression_testing_is_approved!(build)
@@ -134,13 +131,8 @@ module Coordinators
       Res.new do
         raise "release is not active" unless run.active?
 
-        if run.carryover_build?
-          latest_internal_release = run.latest_internal_release(finished: true)
-          Coordinators::CreateBetaRelease.call(run, latest_internal_release.build, nil)
-        else
-          commit = run.release.last_applicable_commit
-          Coordinators::ApplyCommit.call(run.release, commit, release_step: BetaRelease.to_s)
-        end
+        commit = run.release.last_applicable_commit
+        Coordinators::ApplyCommit.call(run.release, commit, release_step: BetaRelease.to_s)
       end
     end
 

--- a/app/libs/coordinators.rb
+++ b/app/libs/coordinators.rb
@@ -123,16 +123,15 @@ module Coordinators
       Res.new do
         raise "release is not active" unless release_platform_run.active?
         commit = release_platform_run.release.last_applicable_commit
-        Coordinators::ApplyCommit.call(release_platform_run.release, commit, release_step: InternalRelease.to_s)
+        Coordinators::CreateInternalRelease.call(release_platform_run, commit)
       end
     end
 
     def self.start_beta_release!(run)
       Res.new do
         raise "release is not active" unless run.active?
-
         commit = run.release.last_applicable_commit
-        Coordinators::ApplyCommit.call(run.release, commit, release_step: BetaRelease.to_s)
+        Coordinators::CreateBetaRelease.call(run, commit)
       end
     end
 

--- a/app/libs/coordinators/apply_commit.rb
+++ b/app/libs/coordinators/apply_commit.rb
@@ -1,18 +1,20 @@
 class Coordinators::ApplyCommit
   include Loggable
+  RELEASE_STEPS = %w[InternalRelease BetaRelease]
 
-  def self.call(release, commit)
-    new(release, commit).call
+  def self.call(release, commit, release_step: nil)
+    new(release, commit, release_step:).call
   end
 
-  def initialize(release, commit)
+  def initialize(release, commit, release_step: nil)
+    raise ArgumentError, "release_step must be one of #{RELEASE_STEPS}" unless RELEASE_STEPS.include?(release_step)
     @release = release
     @commit = commit
+    @release_step = release_step
   end
 
   def call
     return unless commit.applicable?
-
     release.release_platform_runs.each do |run|
       trigger_release_for(run)
     end
@@ -21,19 +23,30 @@ class Coordinators::ApplyCommit
   private
 
   def trigger_release_for(run)
-    return if release.hotfix?
     return unless run.on_track?
-
     run.bump_version!
     run.update!(last_commit: commit)
 
-    if run.conf.internal_release?
+    if release.hotfix?
+      case release_step
+      when "InternalRelease"
+        Coordinators::CreateInternalRelease.call(run, commit)
+      when "BetaRelease"
+        Coordinators::CreateBetaRelease.call(run, nil, commit.id)
+      else
+        Coordinators::CreateInternalRelease.call(run, commit)
+      end
+
+      return
+    end
+
+    if run.conf.internal_release? && release_step.nil?
       Coordinators::CreateInternalRelease.call(run, commit)
     else
       Coordinators::CreateBetaRelease.call(run, nil, commit.id)
     end
   end
 
-  attr_reader :release, :commit
+  attr_reader :release, :commit, :release_step
   delegate :train, to: :release
 end

--- a/app/libs/coordinators/apply_commit.rb
+++ b/app/libs/coordinators/apply_commit.rb
@@ -35,6 +35,5 @@ class Coordinators::ApplyCommit
     release.hotfixed_from.last_commit.commit_hash != commit.commit_hash
   end
 
-  delegate :train, to: :release
-  attr_reader :release, :commit, :release_step
+  attr_reader :release, :commit
 end

--- a/app/libs/coordinators/apply_commit.rb
+++ b/app/libs/coordinators/apply_commit.rb
@@ -35,9 +35,9 @@ class Coordinators::ApplyCommit
     when "InternalRelease"
       Coordinators::CreateInternalRelease.call(run, commit)
     when "BetaRelease"
-      Coordinators::CreateBetaRelease.call(run, nil, commit)
+      Coordinators::CreateBetaRelease.call(run, commit)
     else
-      Coordinators::CreateBetaRelease.call(run, nil, commit)
+      Coordinators::CreateBetaRelease.call(run, commit)
     end
   end
 
@@ -45,7 +45,7 @@ class Coordinators::ApplyCommit
     if run.conf.internal_release? && release_step.nil?
       Coordinators::CreateInternalRelease.call(run, commit)
     else
-      Coordinators::CreateBetaRelease.call(run, nil, commit)
+      Coordinators::CreateBetaRelease.call(run, commit)
     end
   end
 

--- a/app/libs/coordinators/apply_commit.rb
+++ b/app/libs/coordinators/apply_commit.rb
@@ -1,15 +1,11 @@
 class Coordinators::ApplyCommit
-  include Loggable
-  RELEASE_STEPS = %w[InternalRelease BetaRelease]
-
-  def self.call(release, commit, release_step: nil)
-    new(release, commit, release_step:).call
+  def self.call(release, commit)
+    new(release, commit).call
   end
 
-  def initialize(release, commit, release_step: nil)
+  def initialize(release, commit)
     @release = release
     @commit = commit
-    @release_step = release_step
   end
 
   def call
@@ -17,11 +13,8 @@ class Coordinators::ApplyCommit
     release.release_platform_runs.each do |run|
       next unless run.on_track?
 
-      run.bump_version!
-      run.update!(last_commit: commit)
-
       if release.hotfix?
-        pre_select_trigger(run) if trigger_hotfix?
+        Coordinators::CreateBetaRelease.call(run, commit) if trigger_hotfix?
       else
         trigger(run)
       end
@@ -30,19 +23,8 @@ class Coordinators::ApplyCommit
 
   private
 
-  def pre_select_trigger(run)
-    case release_step
-    when "InternalRelease"
-      Coordinators::CreateInternalRelease.call(run, commit)
-    when "BetaRelease"
-      Coordinators::CreateBetaRelease.call(run, commit)
-    else
-      Coordinators::CreateBetaRelease.call(run, commit)
-    end
-  end
-
   def trigger(run)
-    if run.conf.internal_release? && release_step.nil?
+    if run.conf.internal_release?
       Coordinators::CreateInternalRelease.call(run, commit)
     else
       Coordinators::CreateBetaRelease.call(run, commit)

--- a/app/libs/coordinators/create_beta_release.rb
+++ b/app/libs/coordinators/create_beta_release.rb
@@ -1,15 +1,13 @@
 class Coordinators::CreateBetaRelease
-  def self.call(release_platform_run, build, commit)
-    new(release_platform_run, build, commit).call
+  def self.call(release_platform_run, commit)
+    new(release_platform_run, commit).call
   end
 
-  def initialize(release_platform_run, build, commit)
-    raise ArgumentError, "Only expects one of build or commit" if build.present? && commit.present?
-    raise ArgumentError, "At least expects one of build or commit" if build.blank? && commit.blank?
+  def initialize(release_platform_run, commit)
+    raise ArgumentError, "Commit is required" if commit.blank?
     raise ArgumentError, "Beta release is blocked" unless release_platform_run.ready_for_beta_release?
 
     @release_platform_run = release_platform_run
-    @build = build
     @commit = commit
   end
 
@@ -17,21 +15,9 @@ class Coordinators::CreateBetaRelease
     return unless release_platform_run.on_track?
 
     transaction do
-      beta_release = release_platform_run.beta_releases.new(config:, previous:)
-
-      if build.present? && workflows_config.carryover_build?
-        beta_release.commit = build.commit
-        beta_release.parent_internal_release = build.workflow_run.triggering_release
-        beta_release.save!
-        beta_release.trigger_submissions!
-      else
-        beta_release.commit = commit
-        beta_release.save!
-        auto_promote = true
-        release_platform_run.correct_version!
-        WorkflowRun.create_and_trigger!(rc_workflow_config, beta_release, commit, release_platform_run, auto_promote:)
-      end
-
+      release_platform_run.correct_version!
+      beta_release = release_platform_run.beta_releases.create!(config:, previous:, commit:)
+      WorkflowRun.create_and_trigger!(rc_workflow_config, beta_release, commit, release_platform_run)
       beta_release.previous&.workflow_run&.cancel_workflow!
     end
   end

--- a/app/libs/coordinators/create_beta_release.rb
+++ b/app/libs/coordinators/create_beta_release.rb
@@ -1,18 +1,16 @@
 class Coordinators::CreateBetaRelease
-  def self.call(release_platform_run, build_id, commit_id)
-    new(release_platform_run, build_id, commit_id).call
+  def self.call(release_platform_run, build, commit)
+    new(release_platform_run, build, commit).call
   end
 
-  def initialize(release_platform_run, build_id, commit_id)
-    raise ArgumentError, "Only expects one of build or commit" if build_id.present? && commit_id.present?
-    raise ArgumentError, "At least expects one of build or commit" if build_id.blank? && commit_id.blank?
+  def initialize(release_platform_run, build, commit)
+    raise ArgumentError, "Only expects one of build or commit" if build.present? && commit.present?
+    raise ArgumentError, "At least expects one of build or commit" if build.blank? && commit.blank?
     raise ArgumentError, "Beta release is blocked" unless release_platform_run.ready_for_beta_release?
 
     @release_platform_run = release_platform_run
-    @build = nil
-    @build = release_platform_run.builds.find(build_id) if build_id.present?
-    @commit = nil
-    @commit = release_platform_run.release.all_commits.find(commit_id) if commit_id.present?
+    @build = build
+    @commit = commit
   end
 
   def call

--- a/app/libs/coordinators/create_beta_release.rb
+++ b/app/libs/coordinators/create_beta_release.rb
@@ -15,6 +15,8 @@ class Coordinators::CreateBetaRelease
     return unless release_platform_run.on_track?
 
     transaction do
+      release_platform_run.update_last_commit!(commit)
+      release_platform_run.bump_version!
       release_platform_run.correct_version!
       beta_release = release_platform_run.beta_releases.create!(config:, previous:, commit:)
       WorkflowRun.create_and_trigger!(rc_workflow_config, beta_release, commit, release_platform_run)

--- a/app/libs/coordinators/create_beta_release.rb
+++ b/app/libs/coordinators/create_beta_release.rb
@@ -21,7 +21,7 @@ class Coordinators::CreateBetaRelease
     transaction do
       beta_release = release_platform_run.beta_releases.new(config:, previous:)
 
-      if carryover_build?
+      if build.present? && workflows_config.carryover_build?
         beta_release.commit = build.commit
         beta_release.parent_internal_release = build.workflow_run.triggering_release
         beta_release.save!
@@ -39,10 +39,6 @@ class Coordinators::CreateBetaRelease
   end
 
   private
-
-  def carryover_build?
-    build.present? && !workflows_config.separate_rc_workflow?
-  end
 
   def previous
     release_platform_run.latest_beta_release

--- a/app/libs/coordinators/create_internal_release.rb
+++ b/app/libs/coordinators/create_internal_release.rb
@@ -9,7 +9,11 @@ class Coordinators::CreateInternalRelease
   end
 
   def call
+    return unless release_platform_run.on_track?
+
     transaction do
+      release_platform_run.update_last_commit!(commit)
+      release_platform_run.bump_version!
       release_platform_run.correct_version!
       internal_release = release_platform_run.internal_releases.create!(config:, previous:, commit:)
       WorkflowRun.create_and_trigger!(workflow_config, internal_release, commit, release_platform_run)

--- a/app/libs/coordinators/create_internal_release.rb
+++ b/app/libs/coordinators/create_internal_release.rb
@@ -32,6 +32,6 @@ class Coordinators::CreateInternalRelease
     release_platform_run.conf.workflows.pick_internal_workflow
   end
 
+  delegate :transaction, to: InternalRelease
   attr_reader :release_platform_run, :commit
-  delegate :transaction, to: BetaRelease
 end

--- a/app/libs/coordinators/create_internal_release.rb
+++ b/app/libs/coordinators/create_internal_release.rb
@@ -12,8 +12,7 @@ class Coordinators::CreateInternalRelease
     transaction do
       release_platform_run.correct_version!
       internal_release = release_platform_run.internal_releases.create!(config:, previous:, commit:)
-      auto_promote = internal_release.conf.auto_promote?
-      WorkflowRun.create_and_trigger!(workflow_config, internal_release, commit, release_platform_run, auto_promote:)
+      WorkflowRun.create_and_trigger!(workflow_config, internal_release, commit, release_platform_run)
       internal_release.previous&.workflow_run&.cancel_workflow!
     end
   end

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -215,6 +215,9 @@ module Installations
         # It returns a single element if there is an exact match
         !@client.ref(repo, "tags/#{tag_name}").is_a?(Array)
       end
+    rescue Installations::Github::Error => e
+      raise e if e.reason != :not_found
+      false
     end
 
     def branch_exists?(repo, branch_name)

--- a/app/libs/installations/github/error.rb
+++ b/app/libs/installations/github/error.rb
@@ -58,7 +58,7 @@ module Installations
     def initialize(api_exception)
       @api_exception = api_exception
       Rails.logger.debug { "Github error: #{api_exception}" }
-      super(errors.first&.fetch("message", nil) || error_message, reason: handle)
+      super(errors&.first&.fetch("message", nil) || error_message, reason: handle)
     end
 
     def handle

--- a/app/libs/release_config/platform.rb
+++ b/app/libs/release_config/platform.rb
@@ -19,10 +19,6 @@ class ReleaseConfig::Platform < Struct.new(:conf)
     beta_release.submissions?
   end
 
-  def auto_start_beta_release?
-    workflows.separate_rc_workflow? && !beta_submissions?
-  end
-
   def beta_release
     ReleaseStep.new(value[:beta_release])
   end
@@ -141,14 +137,6 @@ class ReleaseConfig::Platform < Struct.new(:conf)
 
     def release_candidate_workflow
       Workflow.new(value[:release_candidate], :release_candidate)
-    end
-
-    def separate_rc_workflow?
-      internal_workflow.present?
-    end
-
-    def carryover_build?
-      !separate_rc_workflow?
     end
 
     def pick_internal_workflow

--- a/app/libs/release_config/platform.rb
+++ b/app/libs/release_config/platform.rb
@@ -147,6 +147,10 @@ class ReleaseConfig::Platform < Struct.new(:conf)
       internal_workflow.present?
     end
 
+    def carryover_build?
+      !separate_rc_workflow?
+    end
+
     def pick_internal_workflow
       internal_workflow || release_candidate_workflow
     end

--- a/app/libs/triggers/release.rb
+++ b/app/libs/triggers/release.rb
@@ -76,7 +76,7 @@ class Triggers::Release
       hotfix_platform: (hotfix_platform if hotfix?),
       custom_version: custom_version,
       release_pilot_id: Current.user&.id,
-      is_v2: train.product_v2?
+      is_v2: train.product_v2? && !hotfix?
     )
   end
 

--- a/app/libs/triggers/release.rb
+++ b/app/libs/triggers/release.rb
@@ -38,6 +38,7 @@ class Triggers::Release
     if kickoff.ok?
       Response.new(:ok, release)
     else
+      Rails.logger.error(kickoff.error)
       Response.new(:unprocessable_entity, "Could not kickoff a release • #{kickoff.error.message}")
     end
   end
@@ -75,7 +76,7 @@ class Triggers::Release
       hotfix_platform: (hotfix_platform if hotfix?),
       custom_version: custom_version,
       release_pilot_id: Current.user&.id,
-      is_v2: train.product_v2? && !hotfix?
+      is_v2: train.product_v2?
     )
   end
 

--- a/app/models/beta_release.rb
+++ b/app/models/beta_release.rb
@@ -15,8 +15,6 @@
 #  release_platform_run_id    :uuid             not null, indexed
 #
 class BetaRelease < PreProdRelease
-  belongs_to :parent_internal_release, class_name: "InternalRelease", optional: true
-
   STAMPABLE_REASONS = %w[created finished failed]
 
   def tester_notes? = false
@@ -42,15 +40,8 @@ class BetaRelease < PreProdRelease
     end
   end
 
-  def new_build_available?
-    return unless release_platform_run.on_track?
-    return unless carryover_build?
-    release_platform_run.latest_internal_release(finished: true) != parent_internal_release
-  end
-
   def new_commit_available?
     return unless release_platform_run.on_track?
-    return if carryover_build?
     release_platform_run.last_commit != commit
   end
 end

--- a/app/models/beta_release.rb
+++ b/app/models/beta_release.rb
@@ -6,13 +6,13 @@
 #  config                     :jsonb            not null
 #  status                     :string           default("created"), not null
 #  tester_notes               :text
-#  type                       :string           not null
+#  type                       :string           not null, indexed => [release_platform_run_id, commit_id]
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  commit_id                  :uuid             not null, indexed
+#  commit_id                  :uuid             not null, indexed => [release_platform_run_id, type], indexed
 #  parent_internal_release_id :uuid             indexed
 #  previous_id                :uuid             indexed
-#  release_platform_run_id    :uuid             not null, indexed
+#  release_platform_run_id    :uuid             not null, indexed => [commit_id, type], indexed
 #
 class BetaRelease < PreProdRelease
   STAMPABLE_REASONS = %w[created finished failed]

--- a/app/models/beta_release.rb
+++ b/app/models/beta_release.rb
@@ -44,17 +44,13 @@ class BetaRelease < PreProdRelease
 
   def new_build_available?
     return unless release_platform_run.on_track?
-    return unless carried_over?
+    return unless carryover_build?
     release_platform_run.latest_internal_release(finished: true) != parent_internal_release
-  end
-
-  def carried_over?
-    parent_internal_release.present?
   end
 
   def new_commit_available?
     return unless release_platform_run.on_track?
-    return if carried_over?
+    return if carryover_build?
     release_platform_run.last_commit != commit
   end
 end

--- a/app/models/internal_release.rb
+++ b/app/models/internal_release.rb
@@ -6,13 +6,13 @@
 #  config                     :jsonb            not null
 #  status                     :string           default("created"), not null
 #  tester_notes               :text
-#  type                       :string           not null
+#  type                       :string           not null, indexed => [release_platform_run_id, commit_id]
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  commit_id                  :uuid             not null, indexed
+#  commit_id                  :uuid             not null, indexed => [release_platform_run_id, type], indexed
 #  parent_internal_release_id :uuid             indexed
 #  previous_id                :uuid             indexed
-#  release_platform_run_id    :uuid             not null, indexed
+#  release_platform_run_id    :uuid             not null, indexed => [commit_id, type], indexed
 #
 class InternalRelease < PreProdRelease
   STAMPABLE_REASONS = %w[created finished failed]

--- a/app/models/pre_prod_release.rb
+++ b/app/models/pre_prod_release.rb
@@ -6,6 +6,7 @@
 #  config                     :jsonb            not null
 #  status                     :string           default("created"), not null
 #  tester_notes               :text
+
 #  type                       :string           not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
@@ -159,6 +160,12 @@ class PreProdRelease < ApplicationRecord
       release_version: release.release_version,
       submission_channels: store_submissions.map { |s| "#{s.provider.display} - #{s.submission_channel.name}" }.join(", ")
     )
+  end
+
+  protected
+
+  def carryover_build?
+    release_platform_run.conf.workflows.carryover_build?
   end
 
   private

--- a/app/models/pre_prod_release.rb
+++ b/app/models/pre_prod_release.rb
@@ -6,16 +6,14 @@
 #  config                     :jsonb            not null
 #  status                     :string           default("created"), not null
 #  tester_notes               :text
-
-#  type                       :string           not null
+#  type                       :string           not null, indexed => [release_platform_run_id, commit_id]
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  commit_id                  :uuid             not null, indexed
+#  commit_id                  :uuid             not null, indexed => [release_platform_run_id, type], indexed
 #  parent_internal_release_id :uuid             indexed
 #  previous_id                :uuid             indexed
-#  release_platform_run_id    :uuid             not null, indexed
+#  release_platform_run_id    :uuid             not null, indexed => [commit_id, type], indexed
 #
-# TODO: [v2] missing unique check on commit_id and type
 class PreProdRelease < ApplicationRecord
   include AASM
   include Loggable

--- a/app/models/pre_prod_release.rb
+++ b/app/models/pre_prod_release.rb
@@ -15,6 +15,7 @@
 #  previous_id                :uuid             indexed
 #  release_platform_run_id    :uuid             not null, indexed
 #
+# TODO: [v2] missing unique check on commit_id and type
 class PreProdRelease < ApplicationRecord
   include AASM
   include Loggable

--- a/app/models/pre_prod_release.rb
+++ b/app/models/pre_prod_release.rb
@@ -38,6 +38,8 @@ class PreProdRelease < ApplicationRecord
   delegate :release, :train, :platform, to: :release_platform_run
   delegate :notify!, :notify_with_snippet!, to: :train
 
+  alias_method :workflow_run, :triggered_workflow_run
+
   STATES = {
     created: "created",
     failed: "failed",
@@ -61,10 +63,6 @@ class PreProdRelease < ApplicationRecord
 
   def actionable?
     created? && release_platform_run.on_track?
-  end
-
-  def workflow_run
-    triggered_workflow_run || parent_internal_release&.workflow_run
   end
 
   def build
@@ -140,10 +138,6 @@ class PreProdRelease < ApplicationRecord
     previous.previous_successful
   end
 
-  def new_build_available? = false
-
-  def carried_over? = false
-
   def new_commit_available? = false
 
   def stamp_data
@@ -161,12 +155,6 @@ class PreProdRelease < ApplicationRecord
       release_version: release.release_version,
       submission_channels: store_submissions.map { |s| "#{s.provider.display} - #{s.submission_channel.name}" }.join(", ")
     )
-  end
-
-  protected
-
-  def carryover_build?
-    release_platform_run.conf.workflows.carryover_build?
   end
 
   private

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -112,6 +112,7 @@ class Release < ApplicationRecord
 
   has_many :store_rollouts, through: :release_platform_runs
   has_many :store_submissions, through: :release_platform_runs
+  has_many :pre_prod_releases, through: :release_platform_runs
   has_many :production_releases, through: :release_platform_runs
   has_many :production_store_rollouts, -> { production }, through: :release_platform_runs
 
@@ -277,6 +278,11 @@ class Release < ApplicationRecord
   def applied_commits
     return all_commits if active_build_queue.blank?
     all_commits.where.not(build_queue_id: active_build_queue.id).or(all_commits.where(build_queue_id: nil))
+  end
+
+  def last_applicable_commit
+    return unless committable?
+    applied_commits.last
   end
 
   def committable?

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -136,10 +136,6 @@ class ReleasePlatformRun < ApplicationRecord
       .first
   end
 
-  def carryover_build?
-    conf.workflows.carryover_build?
-  end
-
   def latest_production_release
     production_releases.order(created_at: :desc).first
   end

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -256,6 +256,16 @@ class ReleasePlatformRun < ApplicationRecord
     train.hotfix_release.next_version if train.hotfix_release&.version_ahead?(self)
   end
 
+  # TODO: [V2] this is a workaround to handle drifted cross-platform releases
+  # Figure out of a way to deprecate last_commit from rpr and rely on release instead
+  def update_last_commit!(commit)
+    return if commit.blank?
+    return if last_commit.commit_hash == commit.commit_hash
+    return if last_commit.present? && last_commit.timestamp > commit.timestamp
+
+    update!(last_commit: commit)
+  end
+
   def bump_version!
     return unless version_bump_required?
 

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -115,6 +115,7 @@ class ReleasePlatformRun < ApplicationRecord
   end
 
   def ready_for_beta_release?
+    return true if release.hotfix?
     return true if conf.only_beta_release?
     latest_internal_release(finished: true).present?
   end

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -135,6 +135,10 @@ class ReleasePlatformRun < ApplicationRecord
       .first
   end
 
+  def carryover_build?
+    conf.workflows.carryover_build?
+  end
+
   def latest_production_release
     production_releases.order(created_at: :desc).first
   end

--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -112,14 +112,14 @@ class WorkflowRun < ApplicationRecord
     end
   end
 
-  def self.create_and_trigger!(workflow, triggering_release, commit, release_platform_run, auto_promote: false)
+  def self.create_and_trigger!(workflow, triggering_release, commit, release_platform_run)
     workflow_run = create!(workflow_config: workflow.value,
       triggering_release:,
       release_platform_run:,
       commit:,
       kind: workflow.kind)
     workflow_run.create_build!(version_name: workflow_run.release_version, release_platform_run:, commit:)
-    workflow_run.initiate! if auto_promote
+    workflow_run.initiate!
   end
 
   def active?

--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -13,9 +13,9 @@
 #  workflow_config         :jsonb
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  commit_id               :uuid             not null, indexed
+#  commit_id               :uuid             not null, indexed, indexed => [pre_prod_release_id]
 #  external_id             :string
-#  pre_prod_release_id     :uuid             not null, indexed
+#  pre_prod_release_id     :uuid             not null, indexed, indexed => [commit_id]
 #  release_platform_run_id :uuid             not null, indexed
 #
 class WorkflowRun < ApplicationRecord

--- a/app/presenters/production_release_presenter.rb
+++ b/app/presenters/production_release_presenter.rb
@@ -54,7 +54,7 @@ class ProductionReleasePresenter < SimpleDelegator
     when :review_failed
       {text: "Review rejected", status: :failure}
     when :failed, :failed_with_action_required, :failed_prepare
-      {text: "Failed to prepare for release", status: :failure}
+      {text: "Failed to prepare release", status: :failure}
     when :finished_manually
       {text: "Finished manually", status: :inert}
     else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,10 @@ en:
     create:
       success: "Beta release was successfully created."
       failure: "Failed to create beta release — %{errors}."
+  internal_releases:
+    create:
+      success: "Internal release was successfully created."
+      failure: "Failed to create internal release — %{errors}."
   release_health_rules:
     create:
       success: "Rule was successfully created."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,7 +204,11 @@ Rails.application.routes.draw do
   end
 
   resources :release_platform_runs, path: :runs, as: :runs, only: [] do
-    post :pre_prod_beta, to: "beta_releases#create"
+    member do
+      post :pre_prod_internal, to: "internal_releases#create"
+      post :pre_prod_beta, to: "beta_releases#create"
+    end
+
     post :production, to: "production_releases#create"
 
     resources :pre_prod_releases, shallow: true, only: [] do

--- a/db/migrate/20240924101907_add_unique_index_for_commit_in_pre_prod_releases.rb
+++ b/db/migrate/20240924101907_add_unique_index_for_commit_in_pre_prod_releases.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexForCommitInPreProdReleases < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :pre_prod_releases, [:release_platform_run_id, :commit_id, :type], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240924104432_add_unique_index_for_commit_in_workflow_runs.rb
+++ b/db/migrate/20240924104432_add_unique_index_for_commit_in_workflow_runs.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexForCommitInWorkflowRuns < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :workflow_runs, [:pre_prod_release_id, :commit_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_16_105018) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_24_104432) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -439,6 +439,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_16_105018) do
     t.index ["commit_id"], name: "index_pre_prod_releases_on_commit_id"
     t.index ["parent_internal_release_id"], name: "index_pre_prod_releases_on_parent_internal_release_id"
     t.index ["previous_id"], name: "index_pre_prod_releases_on_previous_id"
+    t.index ["release_platform_run_id", "commit_id", "type"], name: "idx_on_release_platform_run_id_commit_id_type_78e050198a", unique: true
     t.index ["release_platform_run_id"], name: "index_pre_prod_releases_on_release_platform_run_id"
   end
 
@@ -903,6 +904,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_16_105018) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["commit_id"], name: "index_workflow_runs_on_commit_id"
+    t.index ["pre_prod_release_id", "commit_id"], name: "index_workflow_runs_on_pre_prod_release_id_and_commit_id", unique: true
     t.index ["pre_prod_release_id"], name: "index_workflow_runs_on_pre_prod_release_id"
     t.index ["release_platform_run_id"], name: "index_workflow_runs_on_release_platform_run_id"
   end


### PR DESCRIPTION
This PR sets the base to handle hotfixes for the new release models.

There are more tasks to be done after this:
- [ ] Checking for hotfixability
- [ ] Add a staleness check when starting internal or beta release to ensure user's intention
- [ ] Mark hotfixes as v2 releases if train allows v2

Testing scenarios:

- Hotfix on: Partially completed release
- Hotfix on: Fully completed release
- Hotfix on: Completed release, when ongoing in pre-prod
- Hotfix on: Completed release, when ongoing to production
- Hotfix on: Completed release, when ongoing to production and halted