### PR TITLE
App Variants with their own integrations

### DIFF
--- a/app/components/v2/live_release/submission_config_component.html.erb
+++ b/app/components/v2/live_release/submission_config_component.html.erb
@@ -27,7 +27,7 @@
       <div class="grid justify-self-start grid-flow-col items-center">
         <div class="border-t mr-1 border-main-300 border-dashed w-5"></div>
         <%= render V2::BadgeComponent.new(text: submission.submission_external.name, kind: :badge) do |badge| %>
-          <% badge.with_icon("integrations/logo_#{submission.submission_class.new(release_platform_run:).provider}.png") %>
+          <% badge.with_icon("integrations/logo_#{submission.submission_class.new(release_platform_run:, config: submission.as_json).provider}.png") %>
         <% end %>
       </div>
       <% submission = submission.next %>

--- a/app/controllers/app_variants_controller.rb
+++ b/app/controllers/app_variants_controller.rb
@@ -1,51 +1,115 @@
 class AppVariantsController < SignedInApplicationController
   using RefinedString
+  include Tabbable
+
   before_action :require_write_access!, only: %i[create update index]
+  before_action :set_app_config_tabs, only: %i[index]
+  before_action :set_app_variant, only: %i[edit update destroy]
+  before_action :ensure_valid_providable_params, only: %i[create]
   around_action :set_time_zone
 
   def index
-    @tab_configuration = [
-      [1, "General", edit_app_path(@app), "v2/cog.svg"],
-      [2, "Integrations", app_integrations_path(@app), "v2/blocks.svg"],
-      [3, "App Variants", app_app_config_app_variants_path(@app), "dna.svg"]
-    ]
     @config = @app.config
     @app_variants = @config.variants.to_a
     @new_app_variant = @config.variants.build
-    setup_config = @app.integrations.firebase_build_channel_provider&.setup
+    @none = @app_variants.empty?
+  end
 
-    if setup_config
-      @firebase_android_apps, @firebase_ios_apps = setup_config[:android], setup_config[:ios]
-    else
-      @unconfigured = true
-    end
+  def edit
+    @app_config = @app_variant.app_config
+    @app = @app_config.app
+    set_firebase_app_configs
   end
 
   def create
-    @config = @app.config
-    @app_variant = @config.variants.new(parsed_app_variant_params)
+    @app_variant = @app.config.variants.new(create_params)
+    set_firebase_integration
 
     if @app_variant.save
-      redirect_to edit_app_app_config_path, notice: "App Variant was successfully created."
+      redirect_to default_path, notice: "App Variant was successfully created."
     else
-      redirect_back fallback_location: edit_app_app_config_path, flash: {error: @app_variant.errors.full_messages.to_sentence}
+      redirect_back fallback_location: default_path, flash: {error: @app_variant.errors.full_messages.to_sentence}
     end
   end
 
   def update
+    if @app_variant.update(update_params)
+      redirect_to default_path, notice: "App Variant was successfully updated."
+    else
+      redirect_back fallback_location: default_path, flash: {error: @app_variant.errors.full_messages.to_sentence}
+    end
+  end
+
+  def destroy
+    if @app_variant.destroy
+      redirect_to default_path, notice: "App Variant was deleted."
+    else
+      redirect_to default_path, flash: {error: "There was an error: #{@app_variant.errors.full_messages.to_sentence}"}
+    end
   end
 
   private
 
-  def app_variant_params
-    params.require(:app_variant)
-      .permit(:name, :bundle_identifier, :firebase_android_config, :firebase_ios_config)
+  def set_app_variant
+    @app_variant = AppVariant.find(params[:id])
+    @app_config = @app_variant.app_config
+    @app = @app_config.app
   end
 
-  def parsed_app_variant_params
-    app_variant_params
-      .merge(firebase_ios_config: app_variant_params[:firebase_ios_config]&.safe_json_parse)
-      .merge(firebase_android_config: app_variant_params[:firebase_android_config]&.safe_json_parse)
+  def app_variant_params
+    @app_variant_params ||=
+      params
+        .require(:app_variant)
+        .permit(:name,
+          :bundle_identifier,
+          :firebase_android_config,
+          :firebase_ios_config,
+          integrations: [:category, providable: [:json_key_file, :type, :project_number]])
+  end
+
+  def create_params
+    app_variant_params.except(:integrations)
+  end
+
+  def update_params
+    create_params
+      .merge(firebase_ios_config: create_params[:firebase_ios_config]&.safe_json_parse)
+      .merge(firebase_android_config: create_params[:firebase_android_config]&.safe_json_parse)
       .compact
+  end
+
+  def json_key_file
+    @json_key_file ||= integration_providable_params[:json_key_file]
+  end
+
+  def providable_params_errors
+    @providable_params_errors ||= Validators::KeyFileValidator.validate(json_key_file).errors
+  end
+
+  def set_firebase_integration
+    integration_params = app_variant_params[:integrations].except(:providable)
+    providable = integration_providable_params[:type].constantize.new(integration: @integration)
+    providable_params = {json_key: json_key_file.read, project_number: integration_providable_params[:project_number]}
+    @integration = @app_variant.integrations.new(integration_params.merge(providable:))
+    @integration.providable.assign_attributes(providable_params)
+  end
+
+  def integration_providable_params
+    app_variant_params[:integrations][:providable]
+  end
+
+  def ensure_valid_providable_params
+    if providable_params_errors.present?
+      redirect_back fallback_location: default_path, flash: {error: providable_params_errors.first}
+    end
+  end
+
+  def set_firebase_app_configs
+    config = @app_variant.integrations.firebase_build_channel_provider.setup
+    @firebase_android_apps, @firebase_ios_apps = config[:android], config[:ios]
+  end
+
+  def default_path
+    app_app_config_app_variants_path(@app)
   end
 end

--- a/app/controllers/app_variants_controller.rb
+++ b/app/controllers/app_variants_controller.rb
@@ -28,6 +28,7 @@ class AppVariantsController < SignedInApplicationController
     if @app_variant.save
       redirect_to default_path, notice: "App Variant was successfully created."
     else
+      @app_variant.errors.merge!(@integration)
       redirect_back fallback_location: default_path, flash: {error: @app_variant.errors.full_messages.to_sentence}
     end
   end

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -1,10 +1,11 @@
 class AppsController < SignedInApplicationController
   include Pagy::Backend
   include Filterable
+  include Tabbable
 
   before_action :require_write_access!, only: %i[create edit update destroy]
   before_action :set_integrations, only: %i[show destroy]
-  before_action :set_tab_config, only: %i[edit update]
+  before_action :set_app_config_tabs, only: %i[edit update]
   around_action :set_time_zone
 
   def index
@@ -70,14 +71,6 @@ class AppsController < SignedInApplicationController
   end
 
   private
-
-  def set_tab_config
-    @tab_configuration = [
-      [1, "General", edit_app_path(@app), "v2/cog.svg"],
-      [2, "Integrations", app_integrations_path(@app), "v2/blocks.svg"],
-      [3, "App Variants", app_app_config_app_variants_path(@app), "dna.svg"]
-    ]
-  end
 
   def set_integrations
     @integrations = @app.integrations

--- a/app/controllers/concerns/tabbable.rb
+++ b/app/controllers/concerns/tabbable.rb
@@ -4,6 +4,14 @@ module Tabbable
   AUTO_SELECTABLE_LIVE_RELEASE_TABS = [:internal_builds, :release_candidate, :app_submission, :rollout_to_users, :wrap_up_automations]
   included { helper_method :live_release_tab_configuration, :live_release_overall_status }
 
+  def set_app_config_tabs
+    @tab_configuration = [
+      [1, "General", edit_app_path(@app), "v2/cog.svg"],
+      [2, "Integrations", app_integrations_path(@app), "v2/blocks.svg"],
+      [3, "App Variants", app_app_config_app_variants_path(@app), "dna.svg"]
+    ]
+  end
+
   def set_train_config_tabs
     @tab_configuration = [
       [1, "Release Settings", edit_app_train_path(@app, @train), "v2/cog.svg"],

--- a/app/controllers/integrations/app_store_controller.rb
+++ b/app/controllers/integrations/app_store_controller.rb
@@ -11,7 +11,7 @@ class Integrations::AppStoreController < IntegrationsController
     if providable_params_errors.present?
       flash.now[:error] = providable_params_errors.first
       set_integrations_by_categories
-      set_tab_configuration
+      set_app_config_tabs
       render :index, status: :unprocessable_entity
     else
       super

--- a/app/controllers/integrations/google_firebase_controller.rb
+++ b/app/controllers/integrations/google_firebase_controller.rb
@@ -19,7 +19,7 @@ class Integrations::GoogleFirebaseController < IntegrationsController
     if providable_params_errors.present?
       flash.now[:error] = providable_params_errors.first
       set_integrations_by_categories
-      set_tab_configuration
+      set_app_config_tabs
       render :index, status: :unprocessable_entity
     else
       super

--- a/app/controllers/integrations/google_play_store_controller.rb
+++ b/app/controllers/integrations/google_play_store_controller.rb
@@ -11,7 +11,7 @@ class Integrations::GooglePlayStoreController < IntegrationsController
     if providable_params_errors.present?
       flash.now[:error] = providable_params_errors.first
       set_integrations_by_categories
-      set_tab_configuration
+      set_app_config_tabs
       render :index, status: :unprocessable_entity
     else
       super

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,7 +1,9 @@
 class IntegrationsController < SignedInApplicationController
   using RefinedString
+  include Tabbable
 
   before_action :require_write_access!, only: %i[connect create index build_artifact_channels destroy]
+  before_action :set_app_config_tabs, only: %i[index]
   before_action :set_integration, only: %i[connect create]
   before_action :set_providable, only: %i[connect create]
 
@@ -12,7 +14,6 @@ class IntegrationsController < SignedInApplicationController
   def index
     @pre_open_category = Integration.categories[params[:integration_category]]
     set_integrations_by_categories
-    set_tab_configuration
   end
 
   def create
@@ -64,14 +65,6 @@ class IntegrationsController < SignedInApplicationController
 
   def set_providable_params
     @integration.providable.assign_attributes(providable_params)
-  end
-
-  def set_tab_configuration
-    @tab_configuration = [
-      [1, "General", edit_app_path(@app), "v2/cog.svg"],
-      [2, "Integrations", app_integrations_path(@app), "v2/blocks.svg"],
-      [3, "App Variants", app_app_config_app_variants_path(@app), "dna.svg"]
-    ]
   end
 
   def integration_params

--- a/app/javascript/controllers/multi_level_select_controller.js
+++ b/app/javascript/controllers/multi_level_select_controller.js
@@ -1,0 +1,64 @@
+import {Controller} from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["select"];
+  static values = {
+    options: Object // The hierarchical data structure
+  };
+
+  connect() {
+    this.populateDropdown(this.selectTargets[0], this.optionsValue[this.selectTargets[0].dataset.level], true);
+    this.updateNextOptions(this.selectTargets[0], true);
+  }
+
+  update(event) {
+    this.updateNextOptions(event.target, false);
+  }
+
+  updateNextOptions(currentSelect, selected) {
+    const targetLevel = currentSelect.dataset.targetLevel;
+    const matchingTargetSelect = this.selectTargets.find(select => select.dataset.level === targetLevel);
+    if (!matchingTargetSelect) return;
+    let nextOptions = this.optionsValue;
+
+    const currentLevelIndex = this.selectTargets.indexOf(currentSelect);
+    for (let nodeIndex = 0; nodeIndex <= currentLevelIndex; nodeIndex++) {
+      const nodeSelect = this.selectTargets[nodeIndex];
+      const nodeLevel = nodeSelect.dataset.level;
+      const nodeKey = nodeSelect.dataset.levelKey;
+      const nodeValue = this.__safeJSONParse(nodeSelect.value);
+
+      nextOptions = nextOptions[nodeLevel].find(o => o[nodeKey] === nodeValue);
+    }
+
+    this.populateDropdown(matchingTargetSelect, nextOptions[targetLevel], selected);
+    this.updateNextOptions(matchingTargetSelect, selected);
+  }
+
+  populateDropdown(target, options, selected) {
+    const valueKey = target.dataset.levelKey
+    const displayKey = target.dataset.levelDisplayKey
+    let selectedValue;
+    if (selected) selectedValue = target.dataset.selectedValue
+    target.innerHTML = options.map(option => this.__createOption(option, valueKey, displayKey, selectedValue)).join("");
+    target.disabled = options.length === 0; // Disable if no options available
+  }
+
+  __createOption(option, valueKey, displayKey, selectedValue) {
+    const optionValue = option[valueKey];
+    const optionName = option[displayKey];
+    return `<option value=${JSON.stringify(optionValue)} ${(selectedValue && selectedValue !== "" && selectedValue === optionValue) ? "selected" : ""}>${optionName}</option>`;
+  }
+
+  __safeJSONParse(str) {
+    let parsedJSON = null;
+
+    try {
+      parsedJSON = JSON.parse(str);
+    } catch (e) {
+      return str;
+    }
+
+    return parsedJSON;
+  }
+}

--- a/app/libs/deployments/google_firebase/release.rb
+++ b/app/libs/deployments/google_firebase/release.rb
@@ -57,7 +57,7 @@ module Deployments
           return if run.uploaded?
 
           run.build_artifact.with_open do |file|
-            result = provider.upload(file, run.build_artifact.file.filename.to_s, platform:, variant: step_run.app_variant)
+            result = provider.upload(file, run.build_artifact.file.filename.to_s, platform:)
             if result.ok?
               run.start_upload!(op_name: result.value!)
             else

--- a/app/libs/installations/google/firebase/error.rb
+++ b/app/libs/installations/google/firebase/error.rb
@@ -26,6 +26,12 @@ module Installations
         code: 404,
         message_matcher: /Requested entity was not found/i,
         decorated_reason: :not_found
+      },
+      {
+        status: "FAILED_PRECONDITION",
+        code: 400,
+        message_matcher: /Precondition check failed/i,
+        decorated_reason: :failed_precondition
       }
     ]
 

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -31,7 +31,6 @@ class App < ApplicationRecord
   has_one :config, class_name: "AppConfig", dependent: :destroy
   has_many :variants, through: :config
   has_many :external_apps, inverse_of: :app, dependent: :destroy
-  has_many :integrations, inverse_of: :app, dependent: :destroy
   has_many :trains, -> { sequential }, dependent: :destroy, inverse_of: :app
   has_many :releases, through: :trains
   has_many :step_runs, through: :releases

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -57,6 +57,12 @@ class App < ApplicationRecord
   scope :with_trains, -> { joins(:trains).distinct }
   scope :sequential, -> { reorder("apps.created_at ASC") }
 
+  delegate :vcs_provider,
+    :ci_cd_provider,
+    :monitoring_provider,
+    :notification_provider,
+    :slack_notifications?, to: :integrations, allow_nil: true
+
   def self.allowed_platforms
     {
       android: "Android",

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -94,6 +94,18 @@ class App < ApplicationRecord
     releases.pending_release
   end
 
+  def bitrise_connected?
+    integrations.bitrise_integrations.any?
+  end
+
+  def bugsnag_connected?
+    integrations.bugsnag_integrations.any?
+  end
+
+  def bitbucket_connected?
+    integrations.bitbucket_integrations.any?
+  end
+
   def ready?
     integrations.ready? and config&.ready?
   end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -55,17 +55,6 @@ class App < ApplicationRecord
   friendly_id :name, use: :slugged
   normalizes :name, with: ->(name) { name.squish }
 
-  delegate :vcs_provider,
-    :ci_cd_provider,
-    :monitoring_provider,
-    :notification_provider,
-    :ios_store_provider,
-    :android_store_provider,
-    :slack_build_channel_provider,
-    :firebase_build_channel_provider,
-    :slack_notifications?, to: :integrations, allow_nil: true
-  delegate :draft_check?, to: :android_store_provider, allow_nil: true
-
   scope :with_trains, -> { joins(:trains).distinct }
   scope :sequential, -> { reorder("apps.created_at ASC") }
 
@@ -143,22 +132,6 @@ class App < ApplicationRecord
 
   def notifications_set_up?
     notification_provider.present?
-  end
-
-  def bitrise_connected?
-    integrations.bitrise_integrations.any?
-  end
-
-  def bugsnag_connected?
-    integrations.bugsnag_integrations.any?
-  end
-
-  def bitbucket_connected?
-    integrations.bitbucket_integrations.any?
-  end
-
-  def firebase_connected?
-    integrations.google_firebase_integrations.any?
   end
 
   # this helps power initial setup instructions after an app is created

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -18,8 +18,9 @@
 #
 class App < ApplicationRecord
   has_paper_trail
-  include Displayable
   extend FriendlyId
+  include Integrable
+  include Displayable
 
   GOOGLE_PLAY_STORE_URL_TEMPLATE = Addressable::Template.new("https://play.google.com/store/apps/details{?query*}")
   APP_STORE_URL_TEMPLATE = Addressable::Template.new("https://apps.apple.com/app/ueno/id{id}")
@@ -74,6 +75,10 @@ class App < ApplicationRecord
       ios: "iOS",
       cross_platform: "Cross Platform"
     }.invert
+  end
+
+  def app_id
+    id
   end
 
   def has_recent_activity?

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -20,7 +20,7 @@
 class AppConfig < ApplicationRecord
   has_paper_trail
   include Notifiable
-  include PlatformAwareness
+  include AppConfigurable
 
   PLATFORM_AWARE_CONFIG_SCHEMA = Rails.root.join("config/schema/platform_aware_integration_config.json")
   # self.ignored_columns += ["bugsnag_project_id"]
@@ -100,10 +100,6 @@ class AppConfig < ApplicationRecord
     end
 
     categories
-  end
-
-  def firebase_app(platform)
-    pick_firebase_app_id(platform)
   end
 
   def bugsnag_project(platform)

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -102,8 +102,7 @@ class AppConfig < ApplicationRecord
     categories
   end
 
-  def firebase_app(platform, variant: nil)
-    return variant.pick_firebase_app_id(platform) if variant&.in?(variants)
+  def firebase_app(platform)
     pick_firebase_app_id(platform)
   end
 

--- a/app/models/app_store_submission.rb
+++ b/app/models/app_store_submission.rb
@@ -251,7 +251,8 @@ class AppStoreSubmission < StoreSubmission
     save!
   end
 
-  def provider = app.ios_store_provider
+  # app.ios_store_provider
+  def provider = conf.integrable.ios_store_provider
 
   def notification_params
     super.merge(

--- a/app/models/app_variant.rb
+++ b/app/models/app_variant.rb
@@ -22,6 +22,7 @@ class AppVariant < ApplicationRecord
   validates :bundle_identifier, presence: true, uniqueness: {scope: :app_config_id}
   validate :duplicate_bundle_identifier
   validate :single_variant_per_app_config, on: :create
+  validates :name, presence: true, length: {maximum: 30}
 
   delegate :app, to: :app_config
   delegate :organization, :active_runs, :platform, to: :app

--- a/app/models/app_variant.rb
+++ b/app/models/app_variant.rb
@@ -21,9 +21,10 @@ class AppVariant < ApplicationRecord
 
   validates :bundle_identifier, presence: true, uniqueness: {scope: :app_config_id}
   validate :duplicate_bundle_identifier, on: :create
+  validate :single_variant_per_app_config, on: :create
 
   delegate :app, to: :app_config
-  delegate :organization, :active_runs, to: :app
+  delegate :organization, :active_runs, :platform, to: :app
   delegate :id, to: :app, prefix: true
 
   def display_text
@@ -34,5 +35,11 @@ class AppVariant < ApplicationRecord
 
   def duplicate_bundle_identifier
     errors.add(:bundle_identifier, :same_as_parent) if app.bundle_identifier == bundle_identifier
+  end
+
+  def single_variant_per_app_config
+    if AppVariant.exists?(app_config_id: app_config_id)
+      errors.add(:app_config_id, "can only have one variant")
+    end
   end
 end

--- a/app/models/app_variant.rb
+++ b/app/models/app_variant.rb
@@ -20,7 +20,7 @@ class AppVariant < ApplicationRecord
   has_many :steps, dependent: :nullify
 
   validates :bundle_identifier, presence: true, uniqueness: {scope: :app_config_id}
-  validate :duplicate_bundle_identifier, on: :create
+  validate :duplicate_bundle_identifier
   validate :single_variant_per_app_config, on: :create
 
   delegate :app, to: :app_config

--- a/app/models/app_variant.rb
+++ b/app/models/app_variant.rb
@@ -14,7 +14,7 @@
 class AppVariant < ApplicationRecord
   has_paper_trail
   include Integrable
-  include PlatformAwareness
+  include AppConfigurable
 
   belongs_to :app_config
   has_many :steps, dependent: :nullify
@@ -31,6 +31,8 @@ class AppVariant < ApplicationRecord
   def display_text
     "#{name} (#{bundle_identifier})"
   end
+
+  def config = self
 
   private
 

--- a/app/models/app_variant.rb
+++ b/app/models/app_variant.rb
@@ -13,6 +13,7 @@
 #
 class AppVariant < ApplicationRecord
   has_paper_trail
+  include Integrable
   include PlatformAwareness
 
   belongs_to :app_config
@@ -22,6 +23,8 @@ class AppVariant < ApplicationRecord
   validate :duplicate_bundle_identifier, on: :create
 
   delegate :app, to: :app_config
+  delegate :organization, :active_runs, to: :app
+  delegate :id, to: :app, prefix: true
 
   def display_text
     "#{name} (#{bundle_identifier})"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,6 +2,7 @@ class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
   self.implicit_order_column = :created_at
   Signal = Coordinators::Signals
+  INTEGRABLE_TYPES = %w[App AppVariant]
 
   # - column used is always `status`
   # - row-lock is always taken before update

--- a/app/models/concerns/app_configurable.rb
+++ b/app/models/concerns/app_configurable.rb
@@ -1,0 +1,7 @@
+module AppConfigurable
+  include PlatformAwareness
+
+  def firebase_app(platform)
+    pick_firebase_app_id(platform)
+  end
+end

--- a/app/models/concerns/integrable.rb
+++ b/app/models/concerns/integrable.rb
@@ -11,18 +11,6 @@ module Integrable
     :firebase_build_channel_provider, to: :integrations, allow_nil: true
   delegate :draft_check?, to: :android_store_provider, allow_nil: true
 
-  def bitrise_connected?
-    integrations.bitrise_integrations.any?
-  end
-
-  def bugsnag_connected?
-    integrations.bugsnag_integrations.any?
-  end
-
-  def bitbucket_connected?
-    integrations.bitbucket_integrations.any?
-  end
-
   def firebase_connected?
     integrations.google_firebase_integrations.any?
   end

--- a/app/models/concerns/integrable.rb
+++ b/app/models/concerns/integrable.rb
@@ -1,0 +1,7 @@
+module Integrable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :integrations, as: :integrable, dependent: :destroy
+  end
+end

--- a/app/models/concerns/integrable.rb
+++ b/app/models/concerns/integrable.rb
@@ -5,15 +5,10 @@ module Integrable
     has_many :integrations, as: :integrable, dependent: :destroy
   end
 
-  delegate :vcs_provider,
-    :ci_cd_provider,
-    :monitoring_provider,
-    :notification_provider,
-    :ios_store_provider,
+  delegate :ios_store_provider,
     :android_store_provider,
     :slack_build_channel_provider,
-    :firebase_build_channel_provider,
-    :slack_notifications?, to: :integrations, allow_nil: true
+    :firebase_build_channel_provider, to: :integrations, allow_nil: true
   delegate :draft_check?, to: :android_store_provider, allow_nil: true
 
   def bitrise_connected?

--- a/app/models/concerns/integrable.rb
+++ b/app/models/concerns/integrable.rb
@@ -4,4 +4,31 @@ module Integrable
   included do
     has_many :integrations, as: :integrable, dependent: :destroy
   end
+
+  delegate :vcs_provider,
+    :ci_cd_provider,
+    :monitoring_provider,
+    :notification_provider,
+    :ios_store_provider,
+    :android_store_provider,
+    :slack_build_channel_provider,
+    :firebase_build_channel_provider,
+    :slack_notifications?, to: :integrations, allow_nil: true
+  delegate :draft_check?, to: :android_store_provider, allow_nil: true
+
+  def bitrise_connected?
+    integrations.bitrise_integrations.any?
+  end
+
+  def bugsnag_connected?
+    integrations.bugsnag_integrations.any?
+  end
+
+  def bitbucket_connected?
+    integrations.bitbucket_integrations.any?
+  end
+
+  def firebase_connected?
+    integrations.google_firebase_integrations.any?
+  end
 end

--- a/app/models/concerns/platform_awareness.rb
+++ b/app/models/concerns/platform_awareness.rb
@@ -1,20 +1,8 @@
 module PlatformAwareness
-  def platform_aware_config(ios, android)
-    if app.android?
-      {android: android}
-    elsif app.ios?
-      {ios: ios}
-    elsif app.cross_platform?
-      {ios: ios, android: android}
-    end
-  end
-
   def pick_firebase_app_id(platform)
     case platform
-    when "android"
-      firebase_android_config["app_id"]
-    when "ios"
-      firebase_ios_config["app_id"]
+    when "android" then firebase_android_config["app_id"]
+    when "ios" then firebase_ios_config["app_id"]
     else
       raise ArgumentError, "platform must be valid"
     end
@@ -22,10 +10,8 @@ module PlatformAwareness
 
   def pick_bugsnag_release_stage(platform)
     case platform
-    when "android"
-      bugsnag_android_config["release_stage"]
-    when "ios"
-      bugsnag_ios_config["release_stage"]
+    when "android" then bugsnag_android_config["release_stage"]
+    when "ios" then bugsnag_ios_config["release_stage"]
     else
       raise ArgumentError, "platform must be valid"
     end
@@ -33,10 +19,8 @@ module PlatformAwareness
 
   def pick_bugsnag_project_id(platform)
     case platform
-    when "android"
-      bugsnag_android_config["project_id"]
-    when "ios"
-      bugsnag_ios_config["project_id"]
+    when "android" then bugsnag_android_config["project_id"]
+    when "ios" then bugsnag_ios_config["project_id"]
     else
       raise ArgumentError, "platform must be valid"
     end

--- a/app/models/config/release_step.rb
+++ b/app/models/config/release_step.rb
@@ -37,13 +37,11 @@ class Config::ReleaseStep < ApplicationRecord
   end
 
   def fetch_submission_by_number(number)
-    # rubocop:disable Performance/Detect
-    submissions.filter { |s| s.number == number }.first
-    # rubocop:enable Performance/Detect
+    submissions.detect { |s| s.number == number }
   end
 
   def fetch_by_number(num)
-    found = value.find { |d| d[:number] == num }
+    found = value.detect { |d| d[:number] == num }
     found ? Submission.new(found, value) : nil
   end
 

--- a/app/models/config/submission.rb
+++ b/app/models/config/submission.rb
@@ -28,6 +28,7 @@ class Config::Submission < ApplicationRecord
   validates :submission_type, presence: true
   validates :number, presence: true, uniqueness: {scope: :release_step_config_id}
   validate :correct_rollout_stages, if: :rollout_enabled?
+  validate :production_release_submission
 
   accepts_nested_attributes_for :submission_external, allow_destroy: true
 
@@ -66,6 +67,12 @@ class Config::Submission < ApplicationRecord
 
   def display
     submission_type.classify.constantize.model_name.human
+  end
+
+  def production_release_submission
+    if release_step_config.production?
+      errors.add(:integrable_type, :variant_not_allowed) if integrable_type == "AppVariant"
+    end
   end
 
   def correct_rollout_stages

--- a/app/models/config/submission.rb
+++ b/app/models/config/submission.rb
@@ -4,12 +4,14 @@
 #
 #  id                     :bigint           not null, primary key
 #  auto_promote           :boolean          default(FALSE)
+#  integrable_type        :string
 #  number                 :integer          indexed, indexed => [release_step_config_id]
 #  rollout_enabled        :boolean          default(FALSE)
 #  rollout_stages         :decimal(8, 5)    default([]), is an Array
 #  submission_type        :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  integrable_id          :uuid
 #  release_step_config_id :bigint           indexed, indexed => [number]
 #
 class Config::Submission < ApplicationRecord
@@ -18,6 +20,7 @@ class Config::Submission < ApplicationRecord
 
   belongs_to :release_step_config, class_name: "Config::ReleaseStep"
   has_one :submission_external, class_name: "Config::SubmissionExternal", inverse_of: :submission_config, dependent: :destroy
+  delegated_type :integrable, types: INTEGRABLE_TYPES, validate: false
 
   before_validation :set_number_one, if: :production?
   before_validation :set_default_rollout_for_ios, if: [:ios?, :rollout_enabled?]
@@ -35,6 +38,8 @@ class Config::Submission < ApplicationRecord
       submission_type: submission_type,
       number: number,
       auto_promote: auto_promote,
+      integrable_id: integrable.id,
+      integrable_type: integrable.class.name,
       submission_config: submission_external.as_json,
       rollout_config: {
         enabled: rollout_enabled,

--- a/app/models/google_firebase_submission.rb
+++ b/app/models/google_firebase_submission.rb
@@ -137,7 +137,8 @@ class GoogleFirebaseSubmission < StoreSubmission
     end
   end
 
-  def provider = app.firebase_build_channel_provider
+  # app.firebase_build_channel_provider
+  def provider = conf.integrable.firebase_build_channel_provider
 
   def notification_params
     super.merge(submission_channel: "#{display} - #{submission_channel.name}")

--- a/app/models/google_firebase_submission.rb
+++ b/app/models/google_firebase_submission.rb
@@ -93,9 +93,8 @@ class GoogleFirebaseSubmission < StoreSubmission
 
     result = nil
     filename = build.artifact.file.filename.to_s
-    variant = nil # TODO: [V2] [post-alpha] attach it from the right place
     build.artifact.with_open do |file|
-      result = provider.upload(file, filename, platform:, variant:)
+      result = provider.upload(file, filename, platform:)
       unless result.ok?
         fail_with_error!(result.error)
       end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -88,11 +88,11 @@ class Integration < ApplicationRecord
     build_channels: [{id: :external, name: "External"}]
   }
 
-  validate :allowed_integrations_for_app
+  validate :allowed_integrations_for_app, on: :create
   validate :validate_providable, on: :create
   validate :app_variant_restriction, on: :create
   validates :category, presence: true
-  validates :providable_type, uniqueness: {scope: [:integrable_id, :category, :status], message: :unique_connected_integration_category, if: :connected?}
+  validates :providable_type, uniqueness: {scope: [:integrable_id, :category, :status], message: :unique_connected_integration_category, if: -> { integrable_id.present? && connected? }}
 
   attr_accessor :current_user, :code
 

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -25,7 +25,6 @@ class Integration < ApplicationRecord
   belongs_to :app, optional: true
 
   PROVIDER_TYPES = %w[GithubIntegration GitlabIntegration SlackIntegration AppStoreIntegration GooglePlayStoreIntegration BitriseIntegration GoogleFirebaseIntegration BugsnagIntegration BitbucketIntegration]
-  INTEGRABLE_TYPES = %w[App AppVariant]
   delegated_type :providable, types: PROVIDER_TYPES, autosave: true, validate: false
   delegated_type :integrable, types: INTEGRABLE_TYPES, autosave: true, validate: false
 

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -32,6 +32,8 @@ class Integration < ApplicationRecord
   UnsupportedAction = Class.new(StandardError)
   NoBuildArtifactAvailable = Class.new(StandardError)
 
+  APP_VARIANT_PROVIDABLE_TYPES = %w[GoogleFirebaseIntegration]
+
   ALLOWED_INTEGRATIONS_FOR_APP = {
     ios: {
       "version_control" => %w[GithubIntegration GitlabIntegration BitbucketIntegration],
@@ -257,6 +259,10 @@ class Integration < ApplicationRecord
 
     if category != Integration.categories[:build_channel]
       errors.add(:category, "must be 'build_channel' when integrable is an AppVariant")
+    end
+
+    if APP_VARIANT_PROVIDABLE_TYPES.exclude?(providable_type)
+      errors.add(:providable_type, :not_allowed_for_app_variant)
     end
   end
 end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -3,14 +3,16 @@
 # Table name: integrations
 #
 #  id              :uuid             not null, primary key
-#  category        :string           not null, indexed => [app_id, providable_type, status]
+#  category        :string           not null, indexed => [integrable_id, providable_type, status]
 #  discarded_at    :datetime
+#  integrable_type :string
 #  metadata        :jsonb
-#  providable_type :string           indexed => [providable_id], indexed => [app_id, category, status]
-#  status          :string           indexed => [app_id, category, providable_type]
+#  providable_type :string           indexed => [providable_id], indexed => [integrable_id, category, status]
+#  status          :string           indexed => [integrable_id, category, providable_type]
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  app_id          :uuid             not null, indexed, indexed => [category, providable_type, status]
+#  app_id          :uuid             indexed
+#  integrable_id   :uuid             indexed => [category, providable_type, status]
 #  providable_id   :uuid             indexed => [providable_type]
 #
 class Integration < ApplicationRecord

--- a/app/models/play_store_submission.rb
+++ b/app/models/play_store_submission.rb
@@ -198,7 +198,8 @@ class PlayStoreSubmission < StoreSubmission
     end
   end
 
-  def provider = app.android_store_provider
+  # app.android_store_provider
+  def provider = conf.integrable.android_store_provider
 
   def update_external_status
     # return if sandbox_mode?

--- a/app/models/store_submission.rb
+++ b/app/models/store_submission.rb
@@ -180,7 +180,7 @@ class StoreSubmission < ApplicationRecord
 
   def stamp_data(failure_message: nil)
     failure_reason_data =
-      if failure_reason != :unknown_failure
+      if failure_reason.present? && failure_reason != :unknown_failure
         display_attr(:failure_reason)
       else
         failure_message || self.class.human_attr_value(:failure_reason, :unknown_failure)

--- a/app/models/test_flight_submission.rb
+++ b/app/models/test_flight_submission.rb
@@ -143,7 +143,8 @@ class TestFlightSubmission < StoreSubmission
     @build ||= provider.find_build(build_number)
   end
 
-  def provider = app.ios_store_provider
+  # app.ios_store_provider
+  def provider = conf.integrable.ios_store_provider
 
   def notification_params
     super.merge(submission_channel: "#{display} - #{submission_channel.name}")

--- a/app/views/app_configs/_firebase_form.html.erb
+++ b/app/views/app_configs/_firebase_form.html.erb
@@ -1,4 +1,4 @@
-<% if app.firebase_connected? %>
+<% if integrable.firebase_connected? %>
   <% f.with_section(heading: "Select Firebase Apps") do |section| %>
     <% section.with_description do %>
       Apps against your connected Firebase project.
@@ -9,10 +9,8 @@
       <div class="mb-4">
         <%= section.F.labeled_select :firebase_android_config,
                                      "Android App",
-                                     options_for_select(
-                                       display_channels(firebase_android_apps) { |app| "#{app[:display_name]} #{app[:app_id]}" },
-                                       config.firebase_android_config.to_json
-                                     ) %>
+                                     options_for_select(display_channels(firebase_android_apps) { |app| "#{app[:display_name]} #{app[:app_id]}" },
+                                                        integrable.firebase_android_config.to_json) %>
       </div>
     <% end %>
 
@@ -20,10 +18,8 @@
       <div>
         <%= section.F.labeled_select :firebase_ios_config,
                                      "iOS App",
-                                     options_for_select(
-                                       display_channels(firebase_ios_apps) { |app| "#{app[:display_name]} #{app[:app_id]}" },
-                                       config.firebase_ios_config.to_json
-                                     ) %>
+                                     options_for_select(display_channels(firebase_ios_apps) { |app| "#{app[:display_name]} #{app[:app_id]}" },
+                                                        integrable.firebase_ios_config.to_json) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/app_configs/build_channel.html+turbo_frame.erb
+++ b/app/views/app_configs/build_channel.html+turbo_frame.erb
@@ -1,6 +1,6 @@
 <%= render V2::EnhancedTurboFrameComponent.new("#{@integration_category}_config") do %>
   <%= render V2::FormComponent.new(model: [@app, @config], url: app_app_config_path(@app), method: :patch) do |f| %>
-    <%= render partial: "app_configs/firebase_form", locals: { f:, config: @config, app: @app, firebase_ios_apps: @firebase_ios_apps, firebase_android_apps: @firebase_android_apps } %>
+    <%= render partial: "app_configs/firebase_form", locals: { f:, config: @config, integrable: @app, firebase_ios_apps: @firebase_ios_apps, firebase_android_apps: @firebase_android_apps } %>
     <% f.with_action do %>
       <%= f.F.authz_submit "Update", "plus.svg" %>
     <% end %>

--- a/app/views/app_variants/_create.html.erb
+++ b/app/views/app_variants/_create.html.erb
@@ -1,0 +1,27 @@
+<%= render V2::FormComponent.new(model: [app, app_config, app_variant], url: app_app_config_app_variants_path(app), method: :post) do |f| %>
+  <%= render partial: "form", locals: {form: f, bundle_id: app.bundle_identifier} %>
+
+  <% f.with_section(heading: "Setup Firebase") do |section| %>
+    <% section.with_description do %>
+      <p>Your Service Account Key</p>
+      <p class="mt-2 text-xs">
+        <%= link_to_external "How to create a firebase service account?",
+                             "https://docs.tramline.app/integrations/distribution/firebase",
+                             class: "underline" %>
+      </p>
+    <% end %>
+
+    <% section.F.fields_for :integrations do |integrationForm| %>
+      <%= integrationForm.hidden_field :category, value: "build_channel" %>
+      <% integrationForm.fields_for :providable do |providableForm| %>
+        <%= providableForm.hidden_field :type, value: "GoogleFirebaseIntegration" %>
+        <div><%= providableForm.labeled_text_field :project_number, "Project Number", required: true %></div>
+        <div><%= providableForm.labeled_file_field :json_key_file, "Upload Service Account JSON Key", "Only .json files.", accept: "application/json", required: true %></div>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% f.with_action do %>
+    <%= f.F.authz_submit "Save", "v2/plus.svg" %>
+  <% end %>
+<% end %>

--- a/app/views/app_variants/_form.html.erb
+++ b/app/views/app_variants/_form.html.erb
@@ -1,28 +1,21 @@
-<%= render V2::FormComponent.new(model: [app, app.config, app_variant], url: app_app_config_app_variants_path(app), method: :post) do |f| %>
-  <% f.with_section(heading: "Basic") do |section| %>
-    <% section.with_description do %>
-      <div>
-        App variants are akin to <strong>product flavors</strong> or <strong>build variants</strong>, but with an
-        explicit requirement of having a different bundle identifier. For example, you can setup a staging variant
-        <code><%= app.bundle_identifier + ".staging" %></code> that gets deployed to a different Firebase app than the
-        primary <code><%= app.bundle_identifier %></code> app.
-      </div>
-    <% end %>
-    <div>
-      <%= section.F.labeled_text_field :name, "Name", placeholder: "Enter app name...", required: true %>
-    </div>
-
-    <div>
-      <%= section.F.labeled_text_field :bundle_identifier, "Bundle Identifier", placeholder: "eg., com.just.use.rails", required: true %>
-      <div class="text-sm mt-1">If you're going to deploy to the App Store or Play Store, this <strong>must</strong>
-        match the identifier in the store listing.
-      </div>
+<% form.with_section(heading: "Settings") do |section| %>
+  <% section.with_description do %>
+    <div class="flex flex-col gap-2.5">
+      <p>App variants are akin to <strong>product flavors</strong> or <strong>build variants</strong>, but with an
+        explicit requirement of having a different bundle identifier and their own integrations.</p>
+      <p>For example, you can setup a staging variant with bundle identifier:
+        <code><%= bundle_id + ".staging" %></code> that gets deployed to an entirely different Firebase
+        account.</p>
+      <p>Save the variant first, and then you can configure the integrations for it.</p>
     </div>
   <% end %>
 
-  <%= render partial: "app_configs/firebase_form", locals: { f:, config: app.config, app: app, firebase_ios_apps: firebase_ios_apps, firebase_android_apps: firebase_android_apps } %>
+  <div><%= section.F.labeled_text_field :name, "Name", placeholder: "Enter app name...", required: true %></div>
 
-  <% f.with_action do %>
-    <%= f.F.authz_submit "Save", "v2/archive.svg" %>
-  <% end %>
+  <div>
+    <%= section.F.labeled_text_field :bundle_identifier, "Bundle Identifier", placeholder: "eg., com.just.use.rails", required: true %>
+    <div class="text-sm mt-1">If you're going to deploy to the App Store or Play Store, this <strong>must</strong>
+      match the identifier in the store listing.
+    </div>
+  </div>
 <% end %>

--- a/app/views/app_variants/_index.html.erb
+++ b/app/views/app_variants/_index.html.erb
@@ -1,42 +1,73 @@
-<% if @unconfigured %>
-  <%= render V2::EmptyStateComponent.new(title: "App Variants are unavailable",
-                                         text: "App Variants can only be configured for Firebase App Distribution at the moment.",
-                                         banner_image: "dna.svg",
-                                         type: :subdued) %>
-<% else %>
-  <% subtitle = "Akin to product flavors or build variants, with an explicit requirement of having a different bundle id." %>
-  <%= render V2::SectionComponent.new(style: :titled, title: "App Variants", subtitle: subtitle) do |section| %>
+<%= render V2::AlertComponent.new(kind: :banner, type: :notice, title: "Only one variant allowed", full_screen: false) do %>
+  Tramline currently only supports one variant with one integration per app. If you need to configure multiple variants, please contact us.
+<% end %>
+
+<% subtitle = "Akin to product flavors or build variants, with an explicit requirement of having a different bundle id and separate integrations." %>
+<%= render V2::SectionComponent.new(style: :titled, title: "App Variants", subtitle: subtitle) do |section| %>
+  <% if @app.variants.none? %>
     <% section.with_sidenote do %>
       <%= render V2::ModalComponent.new(title: "Add a new App Variant") do |modal| %>
-        <% modal.with_button(label: "Add", scheme: :light, type: :action, size: :xxs, arrow: :none)
-                .with_icon("v2/plus.svg", size: :md) %>
+        <% modal.with_button(label: "Add", scheme: :light, type: :action, size: :xxs, arrow: :none).with_icon("v2/plus.svg", size: :md) %>
         <% modal.with_body do %>
-          <%= render partial: "form", locals: { app: @app, app_variant: @new_app_variant, firebase_ios_apps: @firebase_ios_apps, firebase_android_apps: @firebase_android_apps } %>
+          <%= render partial: "create", locals: {app: @app, app_config: @app.config, app_variant: @new_app_variant, firebase_ios_apps: @firebase_ios_apps, firebase_android_apps: @firebase_android_apps} %>
         <% end %>
       <% end %>
     <% end %>
+  <% end %>
 
-    <%= render V2::TableComponent.new(columns: ["name", "bundle identifier"]) do |table| %>
-      <% @app_variants.each do |variant| %>
-        <% table.with_row do |row| %>
-          <% row.with_cell do %>
-            <%= variant.name %>
-          <% end %>
+  <%= render V2::TableComponent.new(columns: ["name", "bundle identifier", "Connections", ""]) do |table| %>
+    <% @app_variants.each do |variant| %>
+      <% table.with_row do |row| %>
+        <% row.with_cell do %>
+          <%= variant.name %>
+        <% end %>
 
-          <% row.with_cell do %>
-            <%= variant.bundle_identifier %>
+        <% row.with_cell do %>
+          <%= variant.bundle_identifier %>
+        <% end %>
+
+        <% row.with_cell do %>
+          <% variant.integrations.each do |integration| %>
+            <%= render V2::BadgeComponent.new(text: integration.providable.display, kind: :badge) do |badge| %>
+              <% badge.with_icon("integrations/logo_#{integration.providable}.png") %>
+            <% end %>
           <% end %>
+        <% end %>
+
+        <% row.with_cell(wrap: true) do %>
+
+          <div class="flex gap-x-2 justify-end">
+            <%= render V2::ModalComponent.new(title: "Edit variant") do |modal| %>
+              <% modal.with_button(scheme: :light, type: :action, size: :xxs, arrow: :none).with_icon("v2/pencil.svg") %>
+              <% modal.with_body do %>
+                <%= tag.turbo_frame id: dom_id(variant, :edit_variant),
+                                    src: edit_app_app_config_app_variant_path(@app, variant),
+                                    loading: :lazy,
+                                    class: "with-turbo-frame-loader" do %>
+                  <%= render V2::LoadingIndicatorComponent.new(skeleton_only: true, turbo_frame: true) %>
+                <% end %>
+              <% end %>
+            <% end %>
+
+            <%= render V2::ButtonComponent.new(
+              scheme: :light,
+              options: app_app_config_app_variant_path(@app, variant),
+              type: :link,
+              html_options: {method: :delete, data: {turbo_method: :delete, turbo_confirm: "Are you sure you want to delete the variant? This will also destroy the associated integrations."}}) do |b|
+              b.with_icon("v2/trash.svg")
+            end %>
+          </div>
         <% end %>
       <% end %>
     <% end %>
+  <% end %>
 
-    <% if @app_variants.blank? %>
-      <div class="text-secondary text-sm">
-        <%= render V2::EmptyStateComponent.new(title: "Add new to begin",
-                                               text: "No app variants have been configured yet.",
-                                               banner_image: "dna.svg",
-                                               type: :subdued) %>
-      </div>
-    <% end %>
+  <% if @none %>
+    <div class="text-secondary text-sm">
+      <%= render V2::EmptyStateComponent.new(title: "Add new to begin",
+                                             text: "No app variants have been configured yet.",
+                                             banner_image: "dna.svg",
+                                             type: :subdued) %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/app_variants/edit.html.erb
+++ b/app/views/app_variants/edit.html.erb
@@ -1,0 +1,15 @@
+<%= render V2::EnhancedTurboFrameComponent.new(dom_id(@app_variant, :edit_variant)) do %>
+  <%= render V2::FormComponent.new(model: [@app, @app_config, @app_variant], url: app_app_config_app_variant_path(@app, @app_variant), method: :patch) do |f| %>
+    <%= render partial: "form", locals: {form: f, bundle_id: @app.bundle_identifier} %>
+    <%= render partial: "app_configs/firebase_form",
+               locals: {f:,
+                        config: @app_config,
+                        integrable: @app_variant,
+                        firebase_ios_apps: @firebase_ios_apps,
+                        firebase_android_apps: @firebase_android_apps} %>
+
+    <% f.with_action do %>
+      <%= f.F.authz_submit "Update", "v2/archive.svg" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/config/release_platforms/_submissions_form.html.erb
+++ b/app/views/config/release_platforms/_submissions_form.html.erb
@@ -1,30 +1,64 @@
 <div class="flex flex-row item-gap-default items-center w-full box-padding-md border border-dashed border-main-200 dark:border-main-600 rounded-lg"
-     data-controller="nested-select"
-     data-nested-select-selected-nested-option-value="<%= form.object.submission_external&.identifier %>"
-     data-nested-select-options-value="<%= submission_types.to_json %>"
-     data-nested-select-option-key-value="type"
-     data-nested-select-nested-option-key-value="channels">
+     data-controller="multi-level-select"
+     data-multi-level-select-selected-nested-option-value="<%= form.object.submission_external&.identifier %>"
+     data-multi-level-select-options-value="<%= submission_types.to_json %>">
 
   <div class="flex justify-start">
     <%= render V2::IconComponent.new("grip.svg", size: :lg, classes: "handle cursor-grabbing") %>
   </div>
 
-  <div class="flex flex-row flex-grow item-gap-default">
-    <%= form.select_without_label :submission_type,
-                                  options_for_select(submission_types.pluck(:type).map { |t| [t.display, t.to_s] }, form.object.submission_type),
-                                  {},
-                                  {data: {nested_select_target: "primary", action: "nested-select#updateNestedOptions"}} %>
+  <div class="flex flex-1 justify-start">
+    <div class="grid grid-cols-3 item-gap-default">
+      <%= form.select_without_label :integrable_id,
+                                    options_for_select(submission_types["variants"].map { |t| [t["name"], t["id"]] }),
+                                    {},
+                                    {
+                                      data: {
+                                        multi_level_select_target: "select",
+                                        action: "multi-level-select#update",
+                                        selected_value: form.object.integrable_id,
+                                        level: "variants",
+                                        level_key: "id",
+                                        level_display_key: "name",
+                                        target_level: "submissions"
+                                      }
+                                    } %>
 
-    <% form.fields_for :submission_external, form.object.submission_external || Config::SubmissionExternal.new do |s| %>
-      <%= s.hidden_field :id, value: s.object.id %>
-      <%= s.select_without_label :identifier,
-                                 {},
-                                 {},
-                                 {data: {nested_select_target: "nested", controller: "input-select"}} %>
-    <% end %>
+      <%= form.select_without_label :submission_type,
+                                    {},
+                                    {},
+                                    {
+                                      data: {
+                                        multi_level_select_target: "select",
+                                        action: "multi-level-select#update",
+                                        selected_value: form.object.submission_type,
+                                        level: "submissions",
+                                        level_key: "type",
+                                        level_display_key: "name",
+                                        target_level: "channels"
+                                      }
+                                    } %>
+
+      <% form.fields_for :submission_external, form.object.submission_external || Config::SubmissionExternal.new do |s| %>
+        <%= s.hidden_field :id, value: s.object.id %>
+        <%= s.select_without_label :identifier,
+                                   {},
+                                   {},
+                                   {
+                                     data: {
+                                       controller: "input-select",
+                                       multi_level_select_target: "select",
+                                       selected_value: s.object.identifier,
+                                       level: "channels",
+                                       level_key: "id",
+                                       level_display_key: "name"
+                                     }
+                                   } %>
+      <% end %>
+    </div>
   </div>
 
-  <div class="flex item-gap-default justify-end">
+  <div class="flex item-gap-default ml-auto">
     <%= render V2::ButtonComponent.new(
       scheme: :naked_icon,
       type: :action,
@@ -33,7 +67,7 @@
       b.with_icon("v2/trash.svg", size: :md)
     end %>
 
-    <%= render V2::Form::SwitchComponent.new(form: form, field_name: :auto_promote, on_label: "Auto-submit enabled", off_label: "Auto-submit stopped") do |auto_submit| %>
+    <%= render V2::Form::SwitchComponent.new(form: form, field_name: :auto_promote, on_label: "Auto-submit", off_label: "Auto-submit") do |auto_submit| %>
       <% auto_submit.with_info_icon do %>
         When enabled, Tramline will automatically deliver the build to this submission as soon as the previous one is
         delivered. If it's the first submission, the same will happen as soon as the build is ready.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,6 +357,7 @@ en:
           not_found: "the app/project was not found in Firebase App Distribution"
           wrong_package_name: "the build has a different package name than the one configured in Firebase App Distribution. Please ensure you have selected the correct app in the Integrations page when configuring your Firebase integration."
           build_not_found: "the build is not available in Tramline"
+          failed_precondition: "the build failed precondition check"
     attributes:
       integration:
         categories:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -461,6 +461,7 @@ en:
           attributes:
             providable_type:
               unique_connected_integration_category: "only one integration of this category can be connected to the app"
+              not_allowed_for_app_variant: "this provider is not allowed for app variant"
         app_store_integration:
           attributes:
             key_id:
@@ -486,10 +487,10 @@ en:
         google_firebase_integration:
           attributes:
             json_key:
-              key_format: "the supplied key format is incorrect, please check your key!"
-              invalid_config: "configuration is invalid, please check!"
-              permission_denied: "permission denied to access the project using the key!"
-              unknown_failure: "an unrecognized error occurred connecting to Firebase, please try again!"
+              key_format: "the supplied key format is incorrect, please check your key"
+              invalid_config: "configuration is invalid, please check"
+              permission_denied: "permission denied to access the project using the key"
+              unknown_failure: "an unrecognized error occurred connecting to Firebase, please check your project number and key"
         release_health_rule:
           attributes:
             name:
@@ -503,6 +504,8 @@ en:
               zero_rollout: "cannot start with zero rollout"
               increasing_order: "staged rollout should be in increasing order"
               max_100: "staged rollout cannot be more than 100%"
+            integrable_type:
+              variant_not_allowed: "the production release submission must be to the primary app and not an app variant"
         config/release_platform:
           attributes:
             base:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
 
   resources :apps do
     resource :app_config, only: %i[edit update], path: :config do
-      resources :app_variants, only: %i[create update index]
+      resources :app_variants, only: %i[index edit create update destroy]
     end
 
     member do

--- a/db/data/20241009091851_migrate_apps_to_integrables.rb
+++ b/db/data/20241009091851_migrate_apps_to_integrables.rb
@@ -3,7 +3,7 @@
 class MigrateAppsToIntegrables < ActiveRecord::Migration[7.2]
   def up
     Integration.where.not(app_id: nil).find_each do |i|
-      i.integrable_id = i.app_id
+      i.integrable_id = i.attributes["app_id"]
       i.integrable_type = "App"
       i.save!
     end

--- a/db/data/20241009091851_migrate_apps_to_integrables.rb
+++ b/db/data/20241009091851_migrate_apps_to_integrables.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class MigrateAppsToIntegrables < ActiveRecord::Migration[7.2]
+  def up
+    Integration.where.not(app_id: nil).find_each do |i|
+      i.integrable_id = i.app_id
+      i.integrable_type = "App"
+      i.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20241010100712_add_integrables_to_submission_configs.rb
+++ b/db/data/20241010100712_add_integrables_to_submission_configs.rb
@@ -7,6 +7,11 @@ class AddIntegrablesToSubmissionConfigs < ActiveRecord::Migration[7.2]
       submission.integrable = app
       submission.save!
     end
+
+    StoreSubmission.find_each do |submission|
+      app = submission.release_platform_run.app
+      submission.update! config: submission.config.merge(integrable_id: app.id, integrable_type: "App")
+    end
   end
 
   def down

--- a/db/data/20241010100712_add_integrables_to_submission_configs.rb
+++ b/db/data/20241010100712_add_integrables_to_submission_configs.rb
@@ -3,7 +3,6 @@
 class AddIntegrablesToSubmissionConfigs < ActiveRecord::Migration[7.2]
   def up
     Config::Submission.find_each do |submission|
-      next unless submission.valid?
       app = submission.release_step_config.release_platform_config.release_platform.app
       submission.integrable = app
       submission.save!

--- a/db/data/20241010100712_add_integrables_to_submission_configs.rb
+++ b/db/data/20241010100712_add_integrables_to_submission_configs.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddIntegrablesToSubmissionConfigs < ActiveRecord::Migration[7.2]
+  def up
+    Config::Submission.find_each do |submission|
+      next unless submission.valid?
+      app = submission.release_step_config.release_platform_config.release_platform.app
+      submission.integrable = app
+      submission.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20241007191440)
+DataMigrate::Data.define(version: 20241009091851)

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20241009091851)
+DataMigrate::Data.define(version: 20241010100712)

--- a/db/migrate/20240308124921_add_unique_constraints_to_integration.rb
+++ b/db/migrate/20240308124921_add_unique_constraints_to_integration.rb
@@ -2,10 +2,6 @@ class AddUniqueConstraintsToIntegration < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def change
-    add_column :integrations, :providable_id, :uuid
-    add_column :integrations, :providable_type, :string
-    add_index :integrations, [:providable_type, :providable_id], unique: true
-
     add_index :integrations, [:app_id, :category, :providable_type, :status], unique: true, where: "status = 'connected'", name: "unique_connected_integration_category", algorithm: :concurrently
   end
 end

--- a/db/migrate/20240308124921_add_unique_constraints_to_integration.rb
+++ b/db/migrate/20240308124921_add_unique_constraints_to_integration.rb
@@ -2,6 +2,10 @@ class AddUniqueConstraintsToIntegration < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def change
+    add_column :integrations, :providable_id, :uuid
+    add_column :integrations, :providable_type, :string
+    add_index :integrations, [:providable_type, :providable_id], unique: true
+
     add_index :integrations, [:app_id, :category, :providable_type, :status], unique: true, where: "status = 'connected'", name: "unique_connected_integration_category", algorithm: :concurrently
   end
 end

--- a/db/migrate/20241009062158_add_integrations_for_app_variants.rb
+++ b/db/migrate/20241009062158_add_integrations_for_app_variants.rb
@@ -1,0 +1,8 @@
+class AddIntegrationsForAppVariants < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :integrations, :integrable_id, :uuid
+    add_column :integrations, :integrable_type, :string
+  end
+end

--- a/db/migrate/20241009075827_update_uniqueness_index_on_integrations.rb
+++ b/db/migrate/20241009075827_update_uniqueness_index_on_integrations.rb
@@ -1,0 +1,8 @@
+class UpdateUniquenessIndexOnIntegrations < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :integrations, column: [:app_id, :category, :providable_type, :status], name: "unique_connected_integration_category", algorithm: :concurrently, if_exists: true
+    add_index :integrations, [:integrable_id, :category, :providable_type, :status], unique: true, where: "status = 'connected'", name: "unique_connected_integration_category", algorithm: :concurrently
+  end
+end

--- a/db/migrate/20241009082609_make_app_id_nullable_in_integrations.rb
+++ b/db/migrate/20241009082609_make_app_id_nullable_in_integrations.rb
@@ -1,0 +1,5 @@
+class MakeAppIdNullableInIntegrations < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :integrations, :app_id, true
+  end
+end

--- a/db/migrate/20241010094500_add_integrable_to_submission_config.rb
+++ b/db/migrate/20241010094500_add_integrable_to_submission_config.rb
@@ -1,0 +1,6 @@
+class AddIntegrableToSubmissionConfig < ActiveRecord::Migration[7.2]
+  def change
+    add_column :submission_configs, :integrable_id, :uuid, null: true
+    add_column :submission_configs, :integrable_type, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_09_082609) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_10_094500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -820,6 +820,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_082609) do
     t.boolean "auto_promote", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "integrable_id"
+    t.string "integrable_type"
     t.index ["number"], name: "index_submission_configs_on_number"
     t.index ["release_step_config_id", "number"], name: "index_submission_configs_on_release_step_config_id_and_number", unique: true
     t.index ["release_step_config_id"], name: "index_submission_configs_on_release_step_config_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_07_102045) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_09_082609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -334,7 +334,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_07_102045) do
   end
 
   create_table "integrations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "app_id", null: false
+    t.uuid "app_id"
     t.string "category", null: false
     t.string "status"
     t.datetime "created_at", null: false
@@ -343,8 +343,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_07_102045) do
     t.string "providable_type"
     t.jsonb "metadata"
     t.datetime "discarded_at"
-    t.index ["app_id", "category", "providable_type", "status"], name: "unique_connected_integration_category", unique: true, where: "((status)::text = 'connected'::text)"
+    t.uuid "integrable_id"
+    t.string "integrable_type"
     t.index ["app_id"], name: "index_integrations_on_app_id"
+    t.index ["integrable_id", "category", "providable_type", "status"], name: "unique_connected_integration_category", unique: true, where: "((status)::text = 'connected'::text)"
     t.index ["providable_type", "providable_id"], name: "index_integrations_on_providable_type_and_providable_id", unique: true
   end
 

--- a/spec/factories/app_store_submissions.rb
+++ b/spec/factories/app_store_submissions.rb
@@ -9,7 +9,9 @@ FactoryBot.define do
     config {
       {
         submission_config: {id: :production, name: "production"},
-        rollout_config: {enabled: true, stages: [1, 5, 10, 50, 100]}
+        rollout_config: {enabled: true, stages: [1, 5, 10, 50, 100]},
+        integrable_id: parent_release.release_platform_run.app.id,
+        integrable_type: "App"
       }
     }
 

--- a/spec/factories/apps.rb
+++ b/spec/factories/apps.rb
@@ -13,28 +13,28 @@ FactoryBot.define do
     trait :android do
       platform { "android" }
       after(:create) do |app, _|
-        create(:integration, category: "version_control", providable: create(:github_integration), app:)
-        create(:integration, category: "ci_cd", providable: create(:github_integration), app:)
-        create(:integration, :with_google_play_store, app:)
+        create(:integration, category: "version_control", providable: create(:github_integration), integrable: app)
+        create(:integration, category: "ci_cd", providable: create(:github_integration), integrable: app)
+        create(:integration, :with_google_play_store, integrable: app)
       end
     end
 
     trait :ios do
       platform { "ios" }
       after(:create) do |app, _|
-        create(:integration, category: "version_control", providable: create(:github_integration), app:)
-        create(:integration, category: "ci_cd", providable: create(:bitrise_integration, :without_callbacks_and_validations), app:)
-        create(:integration, :with_app_store, app:)
+        create(:integration, category: "version_control", providable: create(:github_integration), integrable: app)
+        create(:integration, category: "ci_cd", providable: create(:bitrise_integration, :without_callbacks_and_validations), integrable: app)
+        create(:integration, :with_app_store, integrable: app)
       end
     end
 
     trait :cross_platform do
       platform { "cross_platform" }
       after(:create) do |app, _|
-        create(:integration, category: "version_control", providable: create(:github_integration), app:)
-        create(:integration, category: "ci_cd", providable: create(:github_integration), app:)
-        create(:integration, :with_google_play_store, app:)
-        create(:integration, :with_app_store, app:)
+        create(:integration, category: "version_control", providable: create(:github_integration), integrable: app)
+        create(:integration, category: "ci_cd", providable: create(:github_integration), integrable: app)
+        create(:integration, :with_google_play_store, integrable: app)
+        create(:integration, :with_app_store, integrable: app)
       end
     end
 

--- a/spec/factories/beta_releases.rb
+++ b/spec/factories/beta_releases.rb
@@ -5,14 +5,20 @@ FactoryBot.define do
     type { "BetaRelease" }
     status { "created" }
     config {
-      {auto_promote: false,
-       submissions: [
-         {number: 1,
-          submission_type: "PlayStoreSubmission",
-          submission_config: {id: :beta, name: "open testing"},
-          rollout_config: {enabled: true, stages: [10, 100]},
-          auto_promote: true}
-       ]}
+      {
+        auto_promote: false,
+        submissions: [
+          {
+            number: 1,
+            submission_type: "PlayStoreSubmission",
+            submission_config: {id: :beta, name: "open testing"},
+            rollout_config: {enabled: true, stages: [10, 100]},
+            auto_promote: true,
+            integrable_id: release_platform_run.app.id,
+            integrable_type: "App"
+          }
+        ]
+      }
     }
   end
 end

--- a/spec/factories/google_firebase_submissions.rb
+++ b/spec/factories/google_firebase_submissions.rb
@@ -8,7 +8,9 @@ FactoryBot.define do
     status { "created" }
     config {
       {
-        submission_config: {id: :production, name: "production"}
+        submission_config: {id: :production, name: "production"},
+        integrable_id: parent_release.release_platform_run.app.id,
+        integrable_type: "App"
       }
     }
 

--- a/spec/factories/integrations.rb
+++ b/spec/factories/integrations.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :integration do
-    app factory: %i[app android]
+    integrable factory: %i[app android]
     providable factory: %i[google_firebase_integration without_callbacks_and_validations]
     category { "build_channel" }
 
     trait :with_google_play_store do
-      app factory: %i[app android]
+      integrable factory: %i[app android]
       providable factory: %i[google_play_store_integration without_callbacks_and_validations]
       category { "build_channel" }
     end
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     trait :with_app_store do
-      app factory: %i[app ios]
+      integrable factory: %i[app ios]
       providable factory: %i[app_store_integration without_callbacks_and_validations]
       category { "build_channel" }
     end

--- a/spec/factories/internal_releases.rb
+++ b/spec/factories/internal_releases.rb
@@ -5,19 +5,29 @@ FactoryBot.define do
     type { "InternalRelease" }
     status { "created" }
     config {
-      {auto_promote: true,
-       submissions: [
-         {number: 1,
-          submission_type: "PlayStoreSubmission",
-          submission_config: {id: :internal, name: "internal testing"},
-          rollout_config: {enabled: true, stages: [100]},
-          auto_promote: true},
-         {number: 2,
-          submission_type: "PlayStoreSubmission",
-          submission_config: {id: :alpha, name: "closed testing"},
-          rollout_config: {enabled: true, stages: [10, 100]},
-          auto_promote: true}
-       ]}
+      {
+        auto_promote: true,
+        submissions: [
+          {
+            number: 1,
+            submission_type: "PlayStoreSubmission",
+            submission_config: {id: :internal, name: "internal testing"},
+            rollout_config: {enabled: true, stages: [100]},
+            auto_promote: true,
+            integrable_id: release_platform_run.app.id,
+            integrable_type: "App"
+          },
+          {
+            number: 2,
+            submission_type: "PlayStoreSubmission",
+            submission_config: {id: :alpha, name: "closed testing"},
+            rollout_config: {enabled: true, stages: [10, 100]},
+            auto_promote: true,
+            integrable_id: release_platform_run.app.id,
+            integrable_type: "App"
+          }
+        ]
+      }
     }
   end
 end

--- a/spec/factories/play_store_submissions.rb
+++ b/spec/factories/play_store_submissions.rb
@@ -15,7 +15,9 @@ FactoryBot.define do
         rollout_config: {
           enabled: true,
           stages: [1, 5, 10, 20, 50, 100]
-        }
+        },
+        integrable_id: parent_release.release_platform_run.app.id,
+        integrable_type: "App"
       }
     }
 
@@ -34,7 +36,9 @@ FactoryBot.define do
           submission_config: {
             id: :internal,
             name: "internal testing"
-          }
+          },
+          integrable_id: parent_release.release_platform_run.app.id,
+          integrable_type: "App"
         }
       }
     end

--- a/spec/factories/pre_prod_releases.rb
+++ b/spec/factories/pre_prod_releases.rb
@@ -5,31 +5,47 @@ FactoryBot.define do
     type { "InternalRelease" }
     status { "created" }
     config {
-      {auto_promote: true,
-       submissions: [
-         {number: 1,
-          submission_type: "PlayStoreSubmission",
-          submission_config: {id: :internal, name: "internal testing"},
-          rollout_config: {enabled: true, stages: [100]},
-          auto_promote: true},
-         {number: 2,
-          submission_type: "PlayStoreSubmission",
-          submission_config: {id: :alpha, name: "closed testing"},
-          rollout_config: {enabled: true, stages: [10, 100]},
-          auto_promote: true}
-       ]}
+      {
+        auto_promote: true,
+        submissions: [
+          {
+            number: 1,
+            submission_type: "PlayStoreSubmission",
+            submission_config: {id: :internal, name: "internal testing"},
+            rollout_config: {enabled: true, stages: [100]},
+            auto_promote: true,
+            integrable_id: release_platform_run.app.id,
+            integrable_type: "App"
+          },
+          {
+            number: 2,
+            submission_type: "PlayStoreSubmission",
+            submission_config: {id: :alpha, name: "closed testing"},
+            rollout_config: {enabled: true, stages: [10, 100]},
+            auto_promote: true,
+            integrable_id: release_platform_run.app.id,
+            integrable_type: "App"
+          }
+        ]
+      }
     }
 
     trait :single_submission do
       config {
-        {auto_promote: true,
-         submissions: [
-           {number: 1,
-            submission_type: "PlayStoreSubmission",
-            submission_config: {id: :internal, name: "internal testing"},
-            rollout_config: {enabled: true, stages: [100]},
-            auto_promote: true}
-         ]}
+        {
+          auto_promote: true,
+          submissions: [
+            {
+              number: 1,
+              submission_type: "PlayStoreSubmission",
+              submission_config: {id: :internal, name: "internal testing"},
+              rollout_config: {enabled: true, stages: [100]},
+              auto_promote: true,
+              integrable_id: release_platform_run.app.id,
+              integrable_type: "App"
+            }
+          ]
+        }
       }
     end
   end

--- a/spec/factories/release_platform_runs.rb
+++ b/spec/factories/release_platform_runs.rb
@@ -21,19 +21,27 @@ FactoryBot.define do
         beta_release: {
           auto_promote: false,
           submissions: [
-            {number: 1,
-             submission_type: "TestFlightSubmission",
-             submission_config: {id: Faker::FunnyName.name, name: Faker::FunnyName.name, is_internal: true}}
+            {
+              number: 1,
+              submission_type: "TestFlightSubmission",
+              submission_config: {id: Faker::FunnyName.name, name: Faker::FunnyName.name, is_internal: true},
+              integrable_id: release_platform.app.id,
+              integrable_type: "App"
+            }
           ]
         },
         production_release: {
           auto_promote: false,
           submissions: [
-            {number: 1,
-             submission_type: "AppStoreSubmission",
-             submission_config: AppStoreIntegration::PROD_CHANNEL,
-             rollout_config: {enabled: true, stages: AppStoreIntegration::DEFAULT_PHASED_RELEASE_SEQUENCE},
-             auto_promote: false}
+            {
+              number: 1,
+              submission_type: "AppStoreSubmission",
+              submission_config: AppStoreIntegration::PROD_CHANNEL,
+              rollout_config: {enabled: true, stages: AppStoreIntegration::DEFAULT_PHASED_RELEASE_SEQUENCE},
+              auto_promote: false,
+              integrable_id: release_platform.app.id,
+              integrable_type: "App"
+            }
           ]
         }
       }

--- a/spec/factories/release_platforms.rb
+++ b/spec/factories/release_platforms.rb
@@ -20,11 +20,15 @@ FactoryBot.define do
         production_release: {
           auto_promote: false,
           submissions: [
-            {number: 1,
-             submission_type: "AppStoreSubmission",
-             submission_config: AppStoreIntegration::PROD_CHANNEL,
-             rollout_config: {enabled: true, stages: AppStoreIntegration::DEFAULT_PHASED_RELEASE_SEQUENCE},
-             auto_promote: false}
+            {
+              number: 1,
+              submission_type: "AppStoreSubmission",
+              submission_config: AppStoreIntegration::PROD_CHANNEL,
+              rollout_config: {enabled: true, stages: AppStoreIntegration::DEFAULT_PHASED_RELEASE_SEQUENCE},
+              auto_promote: false,
+              integrable_id: release_platform.app.id,
+              integrable_type: "App"
+            }
           ]
         }
       }

--- a/spec/factories/test_flight_submissions.rb
+++ b/spec/factories/test_flight_submissions.rb
@@ -13,7 +13,9 @@ FactoryBot.define do
           name: "External Testers",
           is_internal: false
         },
-        auto_promote: true
+        auto_promote: true,
+        integrable_id: parent_release.release_platform_run.app.id,
+        integrable_type: "App"
       }
     }
 

--- a/spec/libs/installations/bitbucket/api_spec.rb
+++ b/spec/libs/installations/bitbucket/api_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "webmock/rspec"
 
 describe Installations::Bitbucket::Api, type: :integration do
-  let(:access_token) { Faker::String.random(length: 8) }
+  let(:access_token) { Faker::Lorem.word }
   let(:repo_slug) { "tramline/ueno" }
   let(:url) { "https://example.com" }
 

--- a/spec/models/app_store_integration_spec.rb
+++ b/spec/models/app_store_integration_spec.rb
@@ -7,7 +7,7 @@ describe AppStoreIntegration do
 
   describe "#find_live_release" do
     let(:app) { create(:app, platform: :ios) }
-    let(:integration) { create(:integration, :with_app_store, app:) }
+    let(:integration) { create(:integration, :with_app_store, integrable: app) }
     let(:app_store_integration) { integration.providable }
     let(:api_double) { instance_double(Installations::Apple::AppStoreConnect::Api) }
     let(:live_release_response) {
@@ -134,7 +134,7 @@ describe AppStoreIntegration do
 
   describe "#find_build" do
     let(:app) { create(:app, platform: :ios) }
-    let(:integration) { create(:integration, :with_app_store, app:) }
+    let(:integration) { create(:integration, :with_app_store, integrable: app) }
     let(:app_store_integration) { integration.providable }
     let(:api_double) { instance_double(Installations::Apple::AppStoreConnect::Api) }
     let(:build_number) { Faker::Number.number(digits: 7).to_s }

--- a/spec/models/config/release_platform_spec.rb
+++ b/spec/models/config/release_platform_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe Config::ReleasePlatform do
+  let(:app) { create(:app, :ios) }
   let(:base_config) {
     {
       workflows: {
@@ -17,6 +18,8 @@ describe Config::ReleasePlatform do
         auto_promote: false,
         submissions: [
           {number: 1,
+           integrable_id: app.id,
+           integrable_type: "App",
            submission_type: "AppStoreSubmission",
            submission_config: AppStoreIntegration::PROD_CHANNEL,
            rollout_config: {enabled: true, stages: AppStoreIntegration::DEFAULT_PHASED_RELEASE_SEQUENCE},
@@ -39,6 +42,14 @@ describe Config::ReleasePlatform do
       release_platform.beta_release = nil
       expect(release_platform).not_to be_valid
       expect(release_platform.errors.messages[:beta_release]).to include("the beta release must be configured")
+    end
+
+    it "validates production release submission to not have AppVariant" do
+      release_platform = described_class.from_json(base_config.merge(release_platform: create(:release_platform)))
+      release_platform.production_release.submissions.first.update(integrable_type: "AppVariant")
+      expect(release_platform).not_to be_valid
+      expect(release_platform.errors.messages[:"production_release.submissions.integrable_type"])
+        .to include("the production release submission must be to the primary app and not an app variant")
     end
   end
 end

--- a/spec/models/google_firebase_submission_spec.rb
+++ b/spec/models/google_firebase_submission_spec.rb
@@ -217,4 +217,22 @@ describe GoogleFirebaseSubmission do
       expect(submission.finished?).to be(false)
     end
   end
+
+  describe "#provider" do
+    let(:app) { create(:app, :android) }
+    let(:app_variant) { create(:app_variant, bundle_identifier: "variant_identifier", app_config: app.config) }
+    let(:submission) { create(:google_firebase_submission) }
+
+    it "return the variant's integration" do
+      app_variant_integration = create(:integration, :with_google_firebase, integrable: app_variant)
+      submission.update!(config: submission.config.merge(integrable_id: app_variant.id, integrable_type: "AppVariant"))
+      expect(submission.reload.provider).to eq(app_variant_integration.providable)
+    end
+
+    it "return the app's integration" do
+      app_integration = create(:integration, :with_google_firebase, integrable: app)
+      submission.update!(config: submission.config.merge(integrable_id: app.id, integrable_type: "App"))
+      expect(submission.reload.provider).to eq(app_integration.providable)
+    end
+  end
 end

--- a/spec/models/google_play_store_integration_spec.rb
+++ b/spec/models/google_play_store_integration_spec.rb
@@ -7,7 +7,7 @@ describe GooglePlayStoreIntegration do
 
   describe "#upload" do
     let(:app) { create(:app, platform: :android) }
-    let(:integration) { create(:integration, :with_google_play_store, app:) }
+    let(:integration) { create(:integration, :with_google_play_store, integrable: app) }
     let(:google_integration) { integration.providable }
     let(:file) { Tempfile.new("test_artifact.aab") }
     let(:api_double) { instance_double(Installations::Google::PlayDeveloper::Api) }
@@ -68,7 +68,7 @@ describe GooglePlayStoreIntegration do
 
   describe "#create_draft_release" do
     let(:app) { create(:app, platform: :android) }
-    let(:integration) { create(:integration, :with_google_play_store, app:) }
+    let(:integration) { create(:integration, :with_google_play_store, integrable: app) }
     let(:google_integration) { integration.providable }
     let(:file) { Tempfile.new("test_artifact.aab") }
     let(:api_double) { instance_double(Installations::Google::PlayDeveloper::Api) }
@@ -95,7 +95,7 @@ describe GooglePlayStoreIntegration do
 
   describe "#rollout_release" do
     let(:app) { create(:app, platform: :android) }
-    let(:integration) { create(:integration, :with_google_play_store, app:) }
+    let(:integration) { create(:integration, :with_google_play_store, integrable: app) }
     let(:google_integration) { integration.providable }
     let(:file) { Tempfile.new("test_artifact.aab") }
     let(:api_double) { instance_double(Installations::Google::PlayDeveloper::Api) }
@@ -122,7 +122,7 @@ describe GooglePlayStoreIntegration do
 
   describe "#halt_release" do
     let(:app) { create(:app, platform: :android) }
-    let(:integration) { create(:integration, :with_google_play_store, app:) }
+    let(:integration) { create(:integration, :with_google_play_store, integrable: app) }
     let(:google_integration) { integration.providable }
     let(:file) { Tempfile.new("test_artifact.aab") }
     let(:api_double) { instance_double(Installations::Google::PlayDeveloper::Api) }

--- a/spec/models/pre_prod_release_spec.rb
+++ b/spec/models/pre_prod_release_spec.rb
@@ -41,22 +41,31 @@ describe PreProdRelease do
     end
 
     context "when auto promote is disabled" do
+      let(:release_platform_run) { create(:release_platform_run) }
       let(:config) {
         {auto_promote: true,
          submissions: [
-           {number: 1,
-            submission_type: "PlayStoreSubmission",
-            submission_config: {id: :internal, name: "internal testing"},
-            rollout_config: {enabled: false},
-            auto_promote: true},
-           {number: 2,
-            submission_type: "PlayStoreSubmission",
-            submission_config: {id: :alpha, name: "closed testing"},
-            rollout_config: {enabled: true, stages: [10, 100]},
-            auto_promote: false}
+           {
+             number: 1,
+             submission_type: "PlayStoreSubmission",
+             submission_config: {id: :internal, name: "internal testing"},
+             rollout_config: {enabled: false},
+             auto_promote: true,
+             integrable_id: release_platform_run.app.id,
+             integrable_type: "App"
+           },
+           {
+             number: 2,
+             submission_type: "PlayStoreSubmission",
+             submission_config: {id: :alpha, name: "closed testing"},
+             rollout_config: {enabled: true, stages: [10, 100]},
+             auto_promote: false,
+             integrable_id: release_platform_run.app.id,
+             integrable_type: "App"
+           }
          ]}
       }
-      let(:pre_prod_release) { create(:pre_prod_release, config:) }
+      let(:pre_prod_release) { create(:pre_prod_release, release_platform_run:, config:) }
 
       it "does not trigger the next submission if auto_promote is false" do
         pre_prod_release.rollout_complete!(submission)

--- a/spec/models/step_run_spec.rb
+++ b/spec/models/step_run_spec.rb
@@ -386,7 +386,7 @@ describe StepRun do
     let(:slack_api_dbl) { instance_double(Installations::Slack::Api) }
 
     before do
-      create(:integration, :notification, app:)
+      create(:integration, :notification, integrable: app)
       train.update!(notification_channel: {id: "123"})
       ci_cd_dbl = instance_double(GithubIntegration)
 


### PR DESCRIPTION
App Variants are limited to only reusing the existing Firebase integrations to support alternate bundle identifiers. This change adds the following improvements:

- Allow each variant to have its own integrations / connections
- Even if they are the same as the primary, force a new connection for every variant

Some intentional regressions / non-improvements for simplicity:

- Currently only allow one variant and one connection per variant. This simplifies the submission/integration configuration logic and helps us ship this slice faster
- Continue to only support Firebase for now

The design is such that it can be extended to support other integrations and multiple-per later, relatively easily.

<img width="1566" alt="Screenshot 2024-10-10 at 10 39 13 AM" src="https://github.com/user-attachments/assets/c8a6ca44-efcd-45c8-9357-9dea1adc070a">