### PR TITLE
Support alternate build number increments

### DIFF
--- a/app/libs/versioning_strategies/codes.rb
+++ b/app/libs/versioning_strategies/codes.rb
@@ -1,0 +1,38 @@
+class VersioningStrategies::Codes
+  using RefinedString
+
+  STRATEGIES = {
+    increment: proc { |v|
+      value = v[:value].to_i
+      (!value.nil?) ? value.abs + 1 : 0
+    },
+
+    semver_pairs_with_build_sequence: proc { |v|
+      value = v[:value].to_i
+      semver = v[:release_version].to_semverish
+      raise ArgumentError.new("could not bump version code because release version is not a valid semver") if semver.nil?
+      initial_digit = 9
+      major, minor, patch = semver.major, semver.minor, semver.patch || 0
+      new_build_number = (initial_digit * 100_000_000) + (major * 1_000_000) + (minor * 10_000) + (patch * 100)
+      new_build_number = new_build_number.succ while new_build_number <= value
+      new_build_number || 0
+    }
+  }
+
+  DEFAULT_STRATEGY = :increment
+
+  def self.bump(params, strategy: DEFAULT_STRATEGY)
+    new(params).bump(strategy:)
+  end
+
+  def initialize(params)
+    raise ArgumentError.new("not a valid version code") if params.is_a?(Hash) && params[:value].blank?
+    @params = params
+  end
+
+  def bump(strategy: DEFAULT_STRATEGY)
+    bumped_value = STRATEGIES[strategy].call(@params)
+    raise ArgumentError.new("could not bump version code") if bumped_value.nil?
+    bumped_value
+  end
+end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -128,10 +128,19 @@ class App < ApplicationRecord
 
   # NOTE: fetches and uses latest build numbers from the stores, if added,
   # to reduce build upload rejection probability
-  def bump_build_number!
+  def bump_build_number!(release_version: nil)
     store_build_number = latest_store_build_number
+
     with_lock do
-      self.build_number = [store_build_number, build_number].compact.max.succ
+      self.build_number =
+        VersioningStrategies::Codes.bump(
+          {
+            value: [store_build_number, build_number].compact.max,
+            release_version: release_version
+          },
+          strategy: build_number_increment_strategy
+        )
+
       save!
       build_number.to_s
     end
@@ -262,6 +271,11 @@ class App < ApplicationRecord
 
   def platform_store_img
     android? ? GooglePlayStoreIntegration::PUBLIC_ICON : AppStoreIntegration::PUBLIC_ICON
+  end
+
+  def build_number_increment_strategy
+    return :semver_pairs_with_build_sequence if Flipper.enabled?(:build_number_increment_strategy, self)
+    :increment
   end
 
   private

--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -204,7 +204,7 @@ class WorkflowRun < ApplicationRecord
   end
 
   def update_build_number!
-    build.update!(build_number: app.bump_build_number!)
+    build.update!(build_number: app.bump_build_number!(release_version:))
   end
 
   def workflow_inputs

--- a/spec/libs/versioning_strategies/codes_spec.rb
+++ b/spec/libs/versioning_strategies/codes_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe VersioningStrategies::Codes do
+  describe "#bump" do
+    context "when strategy: increment" do
+      it "increments the value" do
+        version_code = described_class.new({value: 1, release_version: nil})
+        expect(version_code.bump(strategy: :increment)).to eq(2)
+      end
+
+      it "works on self as well" do
+        params = {value: 100, release_version: nil}
+        expect(described_class.bump(params, strategy: :increment)).to eq(101)
+      end
+    end
+
+    context "when strategy: semver_pairs_with_build_sequence" do
+      [
+        [9_03_48_00_00, "3.48.0", 9_03_48_00_01],
+        [9_03_48_00_00, "3.48.10", 9_03_48_10_00],
+        [9_08_08_00_00, "8.8.1", 9_08_08_01_00],
+        [9_01_00_00_00, "1.0.0", 9_01_00_00_01],
+        [9_08_08_01_10, "8.8.1", 9_08_08_01_11],
+        [9_08_09_48_10, "8.9.48", 9_08_09_48_11],
+        [9_08_08_00_75, "8.8.1", 9_08_08_01_00]
+      ].each do |previous_number, version, expected|
+        it "increments the value for #{previous_number}" do
+          version_code = described_class.new({value: previous_number, release_version: version})
+          expect(version_code.bump(strategy: :semver_pairs_with_build_sequence)).to eq(expected)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In addition to basic numeric increments, this PR adds a new strategy based on the following logic:

For a given build number: `903480001`

The breakdown is as follows:

first fixed digit - 9
next two digits - major version - 03
next two digits - minor version - 48
next two digits - patch version - 00
next two digits - build sequence - 01

it's based on the release version: `3.48.1`

- basically there's a front portion which is fixed
- a middle portion that is 0-padded semver
- an end portion that is a build sequence number (starting from 00)