### PR TITLE
Add more passports for production submissions

### DIFF
--- a/app/models/app_store_submission.rb
+++ b/app/models/app_store_submission.rb
@@ -53,11 +53,15 @@ class AppStoreSubmission < StoreSubmission
   CHANGEABLE_STATES = %w[created preprocessing prepared cancelled review_failed failed approved]
   CANCELABLE_STATES = %w[submitted_for_review]
   STAMPABLE_REASONS = %w[
+    triggered
+    prepared
     prepare_release_failed
+    submitting_for_review
     submitted_for_review
     resubmitted_for_review
     review_approved
     review_rejected
+    cancelling
     cancellation_failed
     cancelled
     failed
@@ -81,7 +85,7 @@ class AppStoreSubmission < StoreSubmission
       transitions to: :preparing
     end
 
-    event :finish_prepare do
+    event :finish_prepare, after_commit: :on_finish_prepare! do
       after { set_prepared_at! }
       transitions from: :preparing, to: :prepared
     end
@@ -175,10 +179,6 @@ class AppStoreSubmission < StoreSubmission
 
     update_store_info!(result.value!)
     finish_prepare!
-  end
-
-  def on_start_submission!
-    StoreSubmissions::AppStore::SubmitForReviewJob.perform_async(id)
   end
 
   def submit!
@@ -283,7 +283,17 @@ class AppStoreSubmission < StoreSubmission
   end
 
   def on_start_prepare!
+    event_stamp!(reason: :triggered, kind: :notice, data: stamp_data)
     StoreSubmissions::AppStore::FindBuildJob.perform_async(id)
+  end
+
+  def on_finish_prepare!
+    event_stamp!(reason: :prepared, kind: :notice, data: stamp_data)
+  end
+
+  def on_start_submission!
+    event_stamp!(reason: :submitting_for_review, kind: :notice, data: stamp_data)
+    StoreSubmissions::AppStore::SubmitForReviewJob.perform_async(id)
   end
 
   def on_submit_for_review!(args = {resubmission: false})
@@ -296,6 +306,7 @@ class AppStoreSubmission < StoreSubmission
   end
 
   def on_start_cancellation!
+    event_stamp!(reason: :cancelling, kind: :notice, data: stamp_data)
     StoreSubmissions::AppStore::RemoveFromReviewJob.perform_async(id)
   end
 

--- a/app/models/play_store_submission.rb
+++ b/app/models/play_store_submission.rb
@@ -34,6 +34,7 @@ class PlayStoreSubmission < StoreSubmission
     inverse_of: :play_store_submission
 
   STAMPABLE_REASONS = %w[
+    triggered
     prepared
     review_rejected
     finished_manually
@@ -243,6 +244,7 @@ class PlayStoreSubmission < StoreSubmission
   private
 
   def on_start_prepare!
+    event_stamp!(reason: :triggered, kind: :notice, data: stamp_data)
     StoreSubmissions::PlayStore::PrepareForReleaseJob.perform_later(id)
   end
 

--- a/config/locales/passport/en.yml
+++ b/config/locales/passport/en.yml
@@ -86,16 +86,21 @@ en:
       review_rejected_html: 'Beta review rejected for the TestFlight build <span class="emphasize">%{version} (%{build_number})</span>'
       failed_html: 'Failed to send <span class="emphasize">%{version} (%{build_number})</span> to TestFlight groups <span class="emphasize">%{channels}</span>. Error – <span class="emphasize">%{failure_reason}</span>'
     play_store_submission:
+      triggered_html: 'Triggered a new draft release for <span class="emphasize">%{version} (%{build_number})</span> to the Play Store track <span class="emphasize">%{track}</span>'
       prepared_html: 'Prepared a new draft release for <span class="emphasize">%{version} (%{build_number})</span> to the Play Store track <span class="emphasize">%{track}</span>'
       review_rejected_html: 'Play Store submission for <span class="emphasize">%{version} (%{build_number})</span> was rejected'
       failed_html: 'Failed to create a draft release for <span class="emphasize">%{version} (%{build_number})</span> to the Play Store track <span class="emphasize">%{track}</span>. Error – <span class="emphasize">%{failure_reason}</span>'
       finished_manually_html: 'Marked the release for <span class="emphasize">%{version} (%{build_number})</span> as finished manually'
     app_store_submission:
+      triggered_html: 'Triggered a new store version creation for <span class="emphasize">%{version} (%{build_number})</span> for the App Store'
+      prepared_html: 'Created a new store version for <span class="emphasize">%{version} (%{build_number})</span> in the App Store'
       prepare_release_failed_html: 'Failed to prepare release for <span class="emphasize">%{version} (%{build_number})</span> to submit for review in the App Store'
+      submitting_for_review_html: 'Started a submission for <span class="emphasize">%{version} (%{build_number})</span> for review to the App Store'
       submitted_for_review_html: 'Submitted release for <span class="emphasize">%{version} (%{build_number})</span> for review to the App Store'
       resubmitted_for_review_html: 'Release <span class="emphasize">%{version} (%{build_number})</span> was resubmitted for review to the App Store'
       review_approved_html: 'Review for release for <span class="emphasize">%{version} (%{build_number})</span> approved by the App Store'
       review_rejected_html: 'Review for release for <span class="emphasize">%{version} (%{build_number})</span> was rejected by the App Store'
+      cancelling_html: 'Triggered cancellation for release submission to the App Store for <span class="emphasize">%{version} (%{build_number})</span>'
       cancelled_html: 'Release submission to the App Store for <span class="emphasize">%{version} (%{build_number})</span> was cancelled'
       failed_html: 'Failed to create an inflight store version for <span class="emphasize">%{version} (%{build_number})</span> in the App Store. Error – <span class="emphasize">%{failure_reason}</span>'
     play_store_rollout:


### PR DESCRIPTION
...to distinguish the start and finish of user-triggered async actions.

This is instead of attributing passports correctly for the user actions that trigger an async job.

The Tramline attributed finish of the actions is also necessary since those jobs can potentially fail. And hence, instead of attributing the end of the action to the user who triggered it, we should add passport events for both, the start and the finish.
