### PR TITLE
Fully release the previous rollout when the next one is about to start

### DIFF
--- a/app/components/v2/live_release/prod_release/rollout_component.html.erb
+++ b/app/components/v2/live_release/prod_release/rollout_component.html.erb
@@ -1,7 +1,10 @@
 <div class="flex flex-col item-gap-default">
-  <%= render partial: "shared/play_store_review_rejected", locals: { show: show_blocked_message?,
-                                                                     build:,
-                                                                     actionable: false } %>
+  <% if cascading_rollout_notice? %>
+    <%= render V2::AlertComponent.new(type: :info, title: CASCADING_ROLLOUTS_NOTICE, full_screen: false) %>
+  <% end %>
+
+  <%= render partial: "shared/play_store_review_rejected", locals: {show: show_blocked_message?, build:, actionable: false} %>
+
   <div class="flex flex-col section-gap-default">
     <%= render V2::CardComponent.new(title: @title, separator: false, fixed_height: card_height, border_style:) do |card| %>
       <% card.with_action do %>
@@ -79,7 +82,7 @@
                                                    scheme: :link,
                                                    type: :link_external,
                                                    options: external_link,
-                                                   html_options: { class: "text-sm" },
+                                                   html_options: {class: "text-sm"},
                                                    authz: false,
                                                    size: :none) do |b|
                   b.with_icon(store_icon, size: :md)

--- a/app/components/v2/live_release/prod_release/rollout_component.rb
+++ b/app/components/v2/live_release/prod_release/rollout_component.rb
@@ -1,4 +1,7 @@
 class V2::LiveRelease::ProdRelease::RolloutComponent < V2::BaseComponent
+  include Memery
+  CASCADING_ROLLOUTS_NOTICE = "Since cascading rollouts are enabled, this release will not fully rollout to 100% until rollout for the next release starts."
+
   def initialize(store_rollout, title: "Rollout Status")
     @store_rollout = store_rollout
     @title = title
@@ -43,6 +46,10 @@ class V2::LiveRelease::ProdRelease::RolloutComponent < V2::BaseComponent
 
   def show_blocked_message?
     release_platform_run.play_store_blocked? && !store_submission.failed_with_action_required?
+  end
+
+  def cascading_rollout_notice?
+    store_submission.finish_rollout_in_next_release? && !store_rollout.created? && !store_rollout.fully_released?
   end
 
   def events

--- a/app/components/v2/live_release/prod_release/submission_component.html.erb
+++ b/app/components/v2/live_release/prod_release/submission_component.html.erb
@@ -3,17 +3,51 @@
 <% end %>
 
 <div class="flex flex-col item-gap-default">
-  <div>
-    <% if release_platform_run.metadata_editable_v2? %>
-      <%= render V2::AlertComponent.new(type: :info, title: "You can edit the release notes until you \"Prepare for review\". Once prepared, you won't be able to change the release notes.", full_screen: false) %>
-    <% else %>
-      <%= render V2::AlertComponent.new(type: :info, title: "Release notes cannot be edited any longer. Cancel the review process to edit the release notes.", full_screen: false) %>
-    <% end %>
-  </div>
+  <% if cascading_rollout_actionable? %>
+    <%= render V2::AlertComponent.new(kind: :announcement,
+                                      type: :announce,
+                                      title: "There's a pending rollout to complete",
+                                      full_screen: false) do %>
 
-  <%= render partial: "shared/play_store_review_rejected", locals: { show: show_blocked_message?,
-                                                                     build: current_build,
-                                                                     actionable: false } %>
+      <div class="flex flex-col gap-2 mt-1 text-sm">
+        <p>
+          Since cascading rollouts are enabled, you must fully release the previous rollout from
+          <span class="font-semibold tracking-wide">release <%= previously_completed_release.release_version %></span>
+          to 100% before
+          starting the current one.
+        </p>
+
+        <div class="flex flex-row items-end gap-2">
+          <%= render V2::ButtonComponent.new(
+            label: "Full release previous rollout",
+            scheme: :default,
+            options: fully_release_previous_rollout_store_submission_path(id),
+            size: :xxs,
+            html_options: html_opts(:patch, "Are you sure you want to fully rollout #{previously_completed_release.release_version}?")
+          ) %>
+
+          <%= render V2::ButtonComponent.new(label: "Go to previous rollout ↗",
+                                             scheme: :link,
+                                             type: :link_external,
+                                             options: previously_completed_release_link,
+                                             html_options: {class: "text-sm"},
+                                             authz: false,
+                                             size: :none,
+                                             arrow: :none) %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% if release_platform_run.metadata_editable_v2? %>
+    <div>
+      <%= render V2::AlertComponent.new(type: :info, title: "You can edit the release notes until you prepare for review. Once prepared, you won't be able to change the release notes.", full_screen: false) %>
+    </div>
+  <% end %>
+
+  <%= render partial: "shared/play_store_review_rejected", locals: {show: show_blocked_message?,
+                                                                    build: current_build,
+                                                                    actionable: false} %>
 
   <% if @new_submission_prompt %>
     <%= render V2::AlertComponent.new(kind: :announcement, type: :announce, title: "New RC Build is available") do |ann| %>
@@ -133,7 +167,7 @@
                                                  type: :button,
                                                  label: "Submit for review",
                                                  options: submit_for_review_store_submission_path(id),
-                                                 html_options: { method: :patch, data: { turbo_method: :patch } }) %>
+                                                 html_options: {method: :patch, data: {turbo_method: :patch}}) %>
             </div>
           <% end %>
         <% end %>
@@ -160,10 +194,10 @@
                                                      show_activity: false,
                                                      show_commit: true) %>
 
-      <%= render partial: "shared/play_store_review_rejected", locals: { show: submission.failed_with_action_required?,
-                                                                         build: current_build,
-                                                                         actionable: true,
-                                                                         channel_name: submission.submission_channel.name } %>
+      <%= render partial: "shared/play_store_review_rejected", locals: {show: submission.failed_with_action_required?,
+                                                                        build: current_build,
+                                                                        actionable: true,
+                                                                        channel_name: submission.submission_channel.name} %>
 
       <%= render V2::SectionComponent.new(style: :titled, title: "External info", size: :micro) do %>
         <div class="flex">
@@ -174,7 +208,7 @@
                 <%= render V2::ButtonComponent.new(scheme: :naked_icon,
                                                    type: :link_external,
                                                    options: external_link,
-                                                   html_options: { class: "text-xs" },
+                                                   html_options: {class: "text-xs"},
                                                    authz: false,
                                                    size: :none) do |b| %>
                   <% b.with_icon("v2/external_link.svg", size: :md) %>

--- a/app/controllers/config/release_platforms_controller.rb
+++ b/app/controllers/config/release_platforms_controller.rb
@@ -75,7 +75,7 @@ class Config::ReleasePlatformsController < SignedInApplicationController
       production_release_attributes: [
         :id,
         submissions_attributes: [
-          :id, :submission_type, :_destroy, :rollout_stages, :rollout_enabled
+          :id, :submission_type, :_destroy, :rollout_stages, :rollout_enabled, :finish_rollout_in_next_release
         ]
       ],
       internal_workflow_attributes: [
@@ -145,6 +145,8 @@ class Config::ReleasePlatformsController < SignedInApplicationController
     submission_attributes = production_release_attributes[:submissions_attributes]["0"]
     if production_release_attributes.present? && submission_attributes[:rollout_enabled] == "true"
       submission_attributes[:rollout_stages] = submission_attributes[:rollout_stages].safe_csv_parse
+    else
+      submission_attributes[:finish_rollout_in_next_release] = false
     end
   end
 

--- a/app/controllers/store_submissions_controller.rb
+++ b/app/controllers/store_submissions_controller.rb
@@ -25,6 +25,14 @@ class StoreSubmissionsController < SignedInApplicationController
     end
   end
 
+  def fully_release_previous_rollout
+    if (res = Action.fully_release_the_previous_rollout!(@submission)).ok?
+      redirect_back fallback_location: root_path, notice: t(".success")
+    else
+      redirect_back fallback_location: root_path, flash: {error: t(".failure", errors: res.error.message)}
+    end
+  end
+
   def submit_for_review
     # return mock_submit_for_review_for_app_store if sandbox_mode?
     if (result = Action.start_production_review!(@submission)).ok?

--- a/app/jobs/store_rollouts/play_store/finish_previous_rollout_job.rb
+++ b/app/jobs/store_rollouts/play_store/finish_previous_rollout_job.rb
@@ -1,8 +1,0 @@
-class StoreRollouts::PlayStore::FinishPreviousRolloutJob
-  include Sidekiq::Job
-  extend Loggable
-
-  def perform(rollout_id)
-    nil
-  end
-end

--- a/app/jobs/store_rollouts/play_store/finish_previous_rollout_job.rb
+++ b/app/jobs/store_rollouts/play_store/finish_previous_rollout_job.rb
@@ -1,0 +1,8 @@
+class StoreRollouts::PlayStore::FinishPreviousRolloutJob
+  include Sidekiq::Job
+  extend Loggable
+
+  def perform(rollout_id)
+    nil
+  end
+end

--- a/app/libs/coordinators.rb
+++ b/app/libs/coordinators.rb
@@ -188,6 +188,15 @@ module Coordinators
       Res.new { Coordinators::StopRelease.call(release) }
     end
 
+    def self.fully_release_the_previous_rollout!(current_submission)
+      return Res.new { raise "release is not actionable" } unless current_submission.release_platform_run.on_track?
+      return Res.new { raise "submission has already started" } unless current_submission.created?
+      previous_rollout = current_submission.fully_release_previous_production_rollout!
+      return Res.new { raise "no previous rollout to complete" } if previous_rollout.nil?
+      return Res.new { raise previous_rollout.errors.full_messages.to_sentence } if previous_rollout.errors?
+      Res.new { true }
+    end
+
     def self.start_the_store_rollout!(rollout)
       return Res.new { raise "release is not actionable" } unless rollout.actionable?
       return Res.new { raise "rollout has already started" } unless rollout.created?

--- a/app/models/config/submission.rb
+++ b/app/models/config/submission.rb
@@ -2,17 +2,18 @@
 #
 # Table name: submission_configs
 #
-#  id                     :bigint           not null, primary key
-#  auto_promote           :boolean          default(FALSE)
-#  integrable_type        :string
-#  number                 :integer          indexed, indexed => [release_step_config_id]
-#  rollout_enabled        :boolean          default(FALSE)
-#  rollout_stages         :decimal(8, 5)    default([]), is an Array
-#  submission_type        :string
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  integrable_id          :uuid
-#  release_step_config_id :bigint           indexed, indexed => [number]
+#  id                             :bigint           not null, primary key
+#  auto_promote                   :boolean          default(FALSE)
+#  finish_rollout_in_next_release :boolean          default(FALSE), not null
+#  integrable_type                :string
+#  number                         :integer          indexed, indexed => [release_step_config_id]
+#  rollout_enabled                :boolean          default(FALSE)
+#  rollout_stages                 :decimal(8, 5)    default([]), is an Array
+#  submission_type                :string
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  integrable_id                  :uuid
+#  release_step_config_id         :bigint           indexed, indexed => [number]
 #
 class Config::Submission < ApplicationRecord
   self.table_name = "submission_configs"

--- a/app/models/play_store_rollout.rb
+++ b/app/models/play_store_rollout.rb
@@ -159,6 +159,7 @@ class PlayStoreRollout < StoreRollout
 
   def on_start!
     update_external_status
+    StoreRollouts::PlayStore::FinishPreviousRolloutJob.perform_later(id)
     super
   end
 

--- a/app/models/play_store_rollout.rb
+++ b/app/models/play_store_rollout.rb
@@ -135,11 +135,6 @@ class PlayStoreRollout < StoreRollout
     end
   end
 
-  def on_start!
-    update_external_status
-    super
-  end
-
   def rollout_in_progress?
     response = provider.find_build_in_track(submission_channel_id, build_number)
     response.present? && response[:status] == "inProgress"
@@ -165,6 +160,11 @@ class PlayStoreRollout < StoreRollout
 
   def rollout(value, retry_on_review_fail: false)
     provider.rollout_release(submission_channel_id, build_number, version_name, value, nil, retry_on_review_fail:)
+  end
+
+  def on_start!
+    update_external_status
+    super
   end
 
   def on_complete!

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -522,6 +522,17 @@ class ReleasePlatformRun < ApplicationRecord
     update!(play_store_blocked: false)
   end
 
+  def previously_completed_rollout_run
+    train
+      .release_platform_runs
+      .includes(:production_store_rollouts)
+      .where.not(id: id)
+      .where(release_platform_id: release_platform_id)
+      .where(production_store_rollouts: {status: %w[completed fully_released]})
+      .reorder(completed_at: :desc, scheduled_at: :desc)
+      .first
+  end
+
   def conf = Config::ReleasePlatform.from_json(config)
 
   private

--- a/app/models/store_rollout.rb
+++ b/app/models/store_rollout.rb
@@ -17,6 +17,7 @@
 class StoreRollout < ApplicationRecord
   has_paper_trail
   using RefinedString
+  using RefinedFloat
   include AASM
   include Loggable
   include Displayable
@@ -92,6 +93,11 @@ class StoreRollout < ApplicationRecord
     return 0.0 unless last_event
     return 100.0 if last_event.reason == "fully_released"
     last_event.metadata["rollout_percentage"].safe_float
+  end
+
+  def hundred_percent?
+    return false if current_stage.nil?
+    config[current_stage].to_f.equal_to?(100.0)
   end
 
   protected

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -57,6 +57,7 @@ class Train < ApplicationRecord
   has_many :deployment_runs, through: :releases
   has_many :external_releases, through: :deployment_runs
   has_many :release_platforms, -> { sequential }, dependent: :destroy, inverse_of: :train
+  has_many :release_platform_runs, -> { sequential }, through: :releases
   has_many :integrations, through: :app
   has_many :steps, through: :release_platforms
   has_many :deployments, through: :steps

--- a/app/refinements/refined_float.rb
+++ b/app/refinements/refined_float.rb
@@ -1,0 +1,9 @@
+module RefinedFloat
+  refine Float do
+    # instead of using direct equality for floats, use a tolerance threshold to check if two
+    # floating-point numbers are "close enough" to be considered equal
+    def equal_to?(other)
+      (self - other).abs < Float::EPSILON
+    end
+  end
+end

--- a/app/views/config/release_platforms/_form.html.erb
+++ b/app/views/config/release_platforms/_form.html.erb
@@ -62,27 +62,34 @@
 
                 <% if platform.android? %>
                   <% rollout.with_child do %>
-                    <div data-controller="domain--staged-rollout-help">
-                      <%= sub_fields.labeled_text_field :rollout_stages,
-                                                        "Rollout sequence",
-                                                        {value: sub_fields.object.rollout_stages.join(", "),
-                                                         placeholder: "1, 2, 5, 10, 20, 50, 100",
-                                                         data: {domain__staged_rollout_help_target: "input",
-                                                                action: "domain--staged-rollout-help#validateString"}} %>
+                    <div class="flex flex-col gap-6">
+                      <div data-controller="domain--staged-rollout-help">
+                        <%= sub_fields.labeled_text_field :rollout_stages,
+                                                          "Rollout sequence",
+                                                          {value: sub_fields.object.rollout_stages.join(", "),
+                                                           placeholder: "1, 2, 5, 10, 20, 50, 100",
+                                                           data: {domain__staged_rollout_help_target: "input",
+                                                                  action: "domain--staged-rollout-help#validateString"}} %>
 
-                      <div class="text-xs text-secondary mt-2">
-                        <span data-domain--staged-rollout-help-target="helpSuccessText"></span>
-                        <span data-domain--staged-rollout-help-target="helpErrorText" class="text-red-600"></span>
+                        <div class="text-xs text-secondary mt-2">
+                          <span data-domain--staged-rollout-help-target="helpSuccessText"></span>
+                          <span data-domain--staged-rollout-help-target="helpErrorText" class="text-red-600"></span>
+                        </div>
                       </div>
+
+                      <%= render V2::Form::SwitchComponent.new(form: sub_fields,
+                                                               field_name: :finish_rollout_in_next_release,
+                                                               on_label: "Cascading rollouts are enabled",
+                                                               off_label: "Cascading rollouts are disabled") do |c| %>
+                        <% c.with_info_icon do %>
+                          Cascading rollouts allow you to ensure that your previous rollout is fully completed before you start the rollouts for the current release.
+                          This is useful when you want to keep the last rollout stage to be less than 100% (like 99.9%) so that you get an opportunity to halt it before the next one starts.
+                        <% end %>
+                      <% end %>
                     </div>
                   <% end %>
                 <% end %>
               <% end %>
-
-              <%= render V2::Form::SwitchComponent.new(form: sub_fields,
-                                                       field_name: :finish_rollout_in_next_release,
-                                                       on_label: "Rollout to 100% only when the next release starts rollout",
-                                                       off_label: "Do not modify the rollout in the next release") %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/config/release_platforms/_form.html.erb
+++ b/app/views/config/release_platforms/_form.html.erb
@@ -78,6 +78,11 @@
                   <% end %>
                 <% end %>
               <% end %>
+
+              <%= render V2::Form::SwitchComponent.new(form: sub_fields,
+                                                       field_name: :finish_rollout_in_next_release,
+                                                       on_label: "Rollout to 100% only when the next release starts rollout",
+                                                       off_label: "Do not modify the rollout in the next release") %>
             <% end %>
           <% end %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,9 @@ en:
       success: "The submission has been created successfully."
       failure: "Failed to create submission — %{errors}"
       invalid_build: "The build is not valid to start a submission."
+    fully_release_previous_rollout:
+      success: "The previous rollout was fully released."
+      failure: "Failed to release the previous rollout — %{errors}"
   store_rollouts:
     switcher:
       ios:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,7 @@ Rails.application.routes.draw do
       patch :prepare
       patch :cancel
       patch :remove_from_review
+      patch :fully_release_previous_rollout
     end
   end
 

--- a/db/migrate/20241104165116_add_flag_to_complete_rollout_next_release_in_config_submission.rb
+++ b/db/migrate/20241104165116_add_flag_to_complete_rollout_next_release_in_config_submission.rb
@@ -1,0 +1,5 @@
+class AddFlagToCompleteRolloutNextReleaseInConfigSubmission < ActiveRecord::Migration[7.2]
+  def change
+    add_column :submission_configs, :finish_rollout_in_next_release, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_28_064604) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_04_165116) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -852,6 +852,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_28_064604) do
     t.datetime "updated_at", null: false
     t.uuid "integrable_id"
     t.string "integrable_type"
+    t.boolean "finish_rollout_in_next_release", default: false, null: false
     t.index ["number"], name: "index_submission_configs_on_number"
     t.index ["release_step_config_id", "number"], name: "index_submission_configs_on_release_step_config_id_and_number", unique: true
     t.index ["release_step_config_id"], name: "index_submission_configs_on_release_step_config_id"

--- a/spec/factories/production_releases.rb
+++ b/spec/factories/production_releases.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     release_platform_run { association :release_platform_run }
     build { association :build, :rc, release_platform_run: }
     status { "inflight" }
+    config { release_platform_run.conf.production_release.as_json }
 
     trait :active do
       status { "active" }

--- a/spec/factories/release_platform_runs.rb
+++ b/spec/factories/release_platform_runs.rb
@@ -47,6 +47,56 @@ FactoryBot.define do
       }
     }
 
+    trait :android do
+      config {
+        {
+          workflows: {
+            internal: nil,
+            release_candidate: {
+              name: Faker::FunnyName.name,
+              id: Faker::Number.number(digits: 8),
+              artifact_name_pattern: nil
+            }
+          },
+          internal_release: nil,
+          beta_release: {
+            auto_promote: false,
+            submissions: [
+              {
+                number: 1,
+                submission_type: "PlayStoreSubmission",
+                submission_config: {id: :internal, name: "internal testing"},
+                rollout_config: {enabled: false},
+                auto_promote: true,
+                integrable_id: release_platform.app.id,
+                integrable_type: "App"
+              }
+            ]
+          },
+          production_release: {
+            auto_promote: false,
+            submissions: [
+              {
+                number: 1,
+                submission_type: "PlayStoreSubmission",
+                submission_config: {
+                  id: :production,
+                  name: "production"
+                },
+                rollout_config: {
+                  enabled: true,
+                  stages: [1, 5, 10, 20, 50, 100]
+                },
+                finish_rollout_in_next_release: true,
+                integrable_id: release_platform.app.id,
+                integrable_type: "App"
+              }
+            ]
+          }
+        }
+      }
+    end
+
     trait :created do
       status { "created" }
     end
@@ -63,4 +113,27 @@ FactoryBot.define do
       status { "post_release_started" }
     end
   end
+end
+
+def create_production_rollout_tree(train, release_platform, release_status: :finished, rollout_status: :completed, submission_status: :created, skip_rollout: false)
+  release = create(:release, release_status, train:)
+  platform = release_platform.platform
+  release_platform_run = create(:release_platform_run, platform.to_sym, :finished, release_platform:, release:)
+  parent_release = create(:production_release, :finished, config: release_platform_run.conf.production_release.as_json, release_platform_run:)
+  store_submission = create(:play_store_submission, status: submission_status, config: parent_release.conf.submissions.first, parent_release:, release_platform_run:)
+
+  unless skip_rollout
+    config = store_submission.conf.rollout_stages
+    store_rollout = create(:store_rollout, rollout_status, :play_store, config:, release_platform_run:, store_submission:)
+  end
+
+  {
+    train: train,
+    release: release,
+    release_platform: release_platform,
+    release_platform_run: release_platform_run,
+    production_release: parent_release,
+    store_submission: store_submission,
+    store_rollout: store_rollout
+  }
 end

--- a/spec/factories/release_platform_runs.rb
+++ b/spec/factories/release_platform_runs.rb
@@ -55,6 +55,10 @@ FactoryBot.define do
       status { "on_track" }
     end
 
+    trait :finished do
+      status { "finished" }
+    end
+
     trait :post_release_started do
       status { "post_release_started" }
     end

--- a/spec/factories/store_rollout.rb
+++ b/spec/factories/store_rollout.rb
@@ -19,6 +19,11 @@ FactoryBot.define do
       type { "AppStoreRollout" }
     end
 
+    trait :last_but_not_hundred do
+      config { [1, 99.9] }
+      current_stage { 1 }
+    end
+
     trait :created do
       status { "created" }
     end

--- a/spec/libs/coordinators/finish_platform_run_spec.rb
+++ b/spec/libs/coordinators/finish_platform_run_spec.rb
@@ -15,7 +15,8 @@ describe Coordinators::FinishPlatformRun do
     end
 
     it "starts post-release on release if only a single platform" do
-      release = create(:release)
+      release = create(:release, :with_no_platform_runs)
+      create(:release_platform_run, release:)
       release_platform_run = release.release_platform_runs.sole
       release_platform_run.start!
       build = create(:build)

--- a/spec/models/play_store_submission_spec.rb
+++ b/spec/models/play_store_submission_spec.rb
@@ -89,4 +89,94 @@ describe PlayStoreSubmission do
       expect(submission.failed_with_action_required?).to be(true)
     end
   end
+
+  describe "#fully_release_previous_production_rollout!" do
+    let(:train) { create(:train) }
+    let(:release_platform) { create(:release_platform, train:, platform: "android") }
+    let(:providable_dbl) { instance_double(GooglePlayStoreIntegration) }
+
+    before do
+      allow(providable_dbl).to receive(:find_build_in_track).and_return({status: "inProgress"})
+      allow_any_instance_of(PlayStoreRollout).to receive(:provider).and_return(providable_dbl)
+    end
+
+    it "skips if the current rollout exists" do
+      prev_rollout = create_production_rollout_tree(train, release_platform).dig(:store_rollout)
+      create_production_rollout_tree(
+        train,
+        release_platform,
+        release_status: :on_track,
+        rollout_status: :created,
+        skip_rollout: false
+      ) => {store_submission:}
+
+      store_submission.fully_release_previous_production_rollout!
+
+      expect(prev_rollout.reload.status).to eq("completed")
+    end
+
+    it "skips if the config is not set to finish previous rollout" do
+      prev_rollout = create_production_rollout_tree(train, release_platform).dig(:store_rollout)
+      create_production_rollout_tree(
+        train,
+        release_platform,
+        release_status: :on_track,
+        rollout_status: :started,
+        skip_rollout: true
+      ) => {store_submission:}
+      store_submission.update!(config: store_submission.config.merge(finish_rollout_in_next_release: false))
+
+      store_submission.fully_release_previous_production_rollout!
+
+      expect(prev_rollout.reload.status).to eq("completed")
+    end
+
+    it "skips if the submission is not in a created state" do
+      prev_rollout = create_production_rollout_tree(train, release_platform).dig(:store_rollout)
+      create_production_rollout_tree(
+        train,
+        release_platform,
+        release_status: :on_track,
+        rollout_status: :started,
+        submission_status: :preprocessing,
+        skip_rollout: true
+      ) => {store_submission:}
+
+      store_submission.fully_release_previous_production_rollout!
+
+      expect(prev_rollout.reload.status).to eq("completed")
+    end
+
+    it "skips if the previous rollout is not in progress on the store" do
+      prev_rollout = create_production_rollout_tree(train, release_platform).dig(:store_rollout)
+      create_production_rollout_tree(
+        train,
+        release_platform,
+        release_status: :on_track,
+        rollout_status: :started,
+        skip_rollout: true
+      ) => {store_submission:}
+      allow(providable_dbl).to receive(:find_build_in_track).and_return({status: "completed"})
+
+      store_submission.fully_release_previous_production_rollout!
+
+      expect(prev_rollout.reload.status).not_to eq("fully_released")
+    end
+
+    it "completes the previous rollout" do
+      prev_rollout = create_production_rollout_tree(train, release_platform).dig(:store_rollout)
+      create_production_rollout_tree(
+        train,
+        release_platform,
+        release_status: :on_track,
+        rollout_status: :started,
+        skip_rollout: true
+      ) => {store_submission:}
+      allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
+
+      store_submission.fully_release_previous_production_rollout!
+
+      expect(prev_rollout.reload.status).to eq("fully_released")
+    end
+  end
 end

--- a/spec/models/release_platform_run_spec.rb
+++ b/spec/models/release_platform_run_spec.rb
@@ -644,7 +644,7 @@ describe ReleasePlatformRun do
     end
   end
 
-  describe ".previous_rollout_run" do
+  describe ".previously_completed_rollout_run" do
     let(:train) { create(:train) }
 
     it "returns nil when there is no previous rollout run" do
@@ -674,52 +674,58 @@ describe ReleasePlatformRun do
       let(:release_platform) { create(:release_platform, train:) }
       let(:previous_release) { create(:release, :finished, train:) }
       let(:previous_run) { create(:release_platform_run, :finished, release_platform:, release: previous_release) }
-      let(:previous_store_submission) { create(:play_store_submission, release_platform_run: previous_run) }
-
-      it "returns the previous rollout run when there is a previous rollout run" do
-        _previous_rollout = create(:store_rollout, :completed, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
-
-        release = create(:release, :on_track, train:)
-        release_platform_run = create(:release_platform_run, release_platform:, release:)
-        store_submission = create(:play_store_submission, release_platform_run:)
-        _rollout = create(:store_rollout, :started, type: "PlayStoreRollout", release_platform_run:, store_submission:)
-
-        expect(release_platform_run.previously_completed_rollout_run).to eq(previous_run)
-      end
+      let(:previous_parent_release) { create(:production_release, :finished, release_platform_run: previous_run) }
+      let(:previous_store_submission) { create(:play_store_submission, parent_release: previous_parent_release, release_platform_run: previous_run) }
 
       it "returns nil for incomplete production store rollouts" do
         _previous_rollout = create(:store_rollout, :paused, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
 
         release = create(:release, :on_track, train:)
         release_platform_run = create(:release_platform_run, release_platform:, release:)
-        store_submission = create(:play_store_submission, release_platform_run:)
+        parent_release = create(:production_release, :finished, release_platform_run:)
+        store_submission = create(:play_store_submission, parent_release:, release_platform_run:)
         _rollout = create(:store_rollout, :started, type: "PlayStoreRollout", release_platform_run:, store_submission:)
 
         expect(release_platform_run.previously_completed_rollout_run).to be_nil
       end
 
-      it "accepts rollouts that are fully_completed" do
-        _previous_rollout = create(:store_rollout, :fully_released, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
+      it "returns the previous rollout run when there is a previous rollout run" do
+        _previous_rollout = create(:store_rollout, :completed, :last_but_not_hundred, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
 
         release = create(:release, :on_track, train:)
         release_platform_run = create(:release_platform_run, release_platform:, release:)
-        store_submission = create(:play_store_submission, release_platform_run:)
+        parent_release = create(:production_release, :finished, release_platform_run:)
+        store_submission = create(:play_store_submission, parent_release:, release_platform_run:)
         _rollout = create(:store_rollout, :started, type: "PlayStoreRollout", release_platform_run:, store_submission:)
 
         expect(release_platform_run.previously_completed_rollout_run).to eq(previous_run)
       end
 
-      it "returns the last known good run with a completed prod rollout" do
-        _previous_rollout = create(:store_rollout, :completed, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
-
-        last_release = create(:release, :finished, train:)
-        last_run = create(:release_platform_run, :stopped, release_platform:, release: last_release)
-        last_store_submission = create(:play_store_submission, release_platform_run: last_run)
-        _last_rollout = create(:store_rollout, :paused, type: "PlayStoreRollout", release_platform_run: last_run, store_submission: last_store_submission)
+      it "does not return rollouts that are fully_released" do
+        _previous_rollout = create(:store_rollout, :fully_released, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
 
         release = create(:release, :on_track, train:)
         release_platform_run = create(:release_platform_run, release_platform:, release:)
-        store_submission = create(:play_store_submission, release_platform_run:)
+        parent_release = create(:production_release, :finished, release_platform_run:)
+        store_submission = create(:play_store_submission, parent_release:, release_platform_run:)
+        _rollout = create(:store_rollout, :started, type: "PlayStoreRollout", release_platform_run:, store_submission:)
+
+        expect(release_platform_run.previously_completed_rollout_run).to be_nil
+      end
+
+      it "returns the last known good run with a completed prod rollout" do
+        _previous_rollout = create(:store_rollout, :completed, :last_but_not_hundred, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
+
+        last_release = create(:release, :finished, train:)
+        last_run = create(:release_platform_run, :stopped, release_platform:, release: last_release)
+        last_parent_release = create(:production_release, :finished, release_platform_run: last_run)
+        last_store_submission = create(:play_store_submission, parent_release: last_parent_release, release_platform_run: last_run)
+        _last_rollout = create(:store_rollout, :paused, :last_but_not_hundred, type: "PlayStoreRollout", release_platform_run: last_run, store_submission: last_store_submission)
+
+        release = create(:release, :on_track, train:)
+        release_platform_run = create(:release_platform_run, release_platform:, release:)
+        parent_release = create(:production_release, :finished, release_platform_run:)
+        store_submission = create(:play_store_submission, parent_release:, release_platform_run:)
         _rollout = create(:store_rollout, :started, type: "PlayStoreRollout", release_platform_run:, store_submission:)
 
         expect(release_platform_run.previously_completed_rollout_run).to eq(previous_run)
@@ -730,22 +736,61 @@ describe ReleasePlatformRun do
 
         previous_release = create(:release, :finished, train:)
         previous_run = create(:release_platform_run, :finished, release_platform:, release: previous_release, completed_at: Time.current - 2)
-        previous_store_submission = create(:play_store_submission, release_platform_run: previous_run)
-        _previous_rollout = create(:store_rollout, :completed, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
+        previous_parent_release = create(:production_release, :finished, release_platform_run: previous_run)
+        previous_store_submission = create(:play_store_submission, parent_release: previous_parent_release, release_platform_run: previous_run)
+        _previous_rollout = create(:store_rollout, :completed, :last_but_not_hundred, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
 
         last_release = create(:release, :stopped, train:)
         last_run = create(:release_platform_run, :stopped, release_platform:, release: last_release, scheduled_at: Time.current - 1)
-        last_store_submission = create(:play_store_submission, release_platform_run: last_run)
-        _last_rollout = create(:store_rollout, :completed, type: "PlayStoreRollout", release_platform_run: last_run, store_submission: last_store_submission)
+        last_parent_release = create(:production_release, :finished, release_platform_run: last_run)
+        last_store_submission = create(:play_store_submission, parent_release: last_parent_release, release_platform_run: last_run)
+        _last_rollout = create(:store_rollout, :completed, :last_but_not_hundred, type: "PlayStoreRollout", release_platform_run: last_run, store_submission: last_store_submission)
 
         release = create(:release, :on_track, train:)
         release_platform_run = create(:release_platform_run, release_platform:, release:, scheduled_at: Time.current)
-        store_submission = create(:play_store_submission, release_platform_run:)
+        parent_release = create(:production_release, :finished, release_platform_run:)
+        store_submission = create(:play_store_submission, parent_release:, release_platform_run:)
         _rollout = create(:store_rollout, :started, type: "PlayStoreRollout", release_platform_run:, store_submission:)
 
-        puts last_run.id
-        puts previous_run.id
         expect(release_platform_run.previously_completed_rollout_run).to eq(last_run)
+      end
+
+      it "only cares about the completed rollout that is the one before the current run" do
+        release_platform = create(:release_platform, train:)
+
+        previous_release = create(:release, :finished, train:)
+        previous_run = create(:release_platform_run, :finished, release_platform:, release: previous_release, completed_at: Time.current - 2)
+        previous_parent_release = create(:production_release, :finished, release_platform_run: previous_run)
+        previous_store_submission = create(:play_store_submission, parent_release: previous_parent_release, release_platform_run: previous_run)
+        _previous_rollout = create(:store_rollout, :completed, :last_but_not_hundred, type: "PlayStoreRollout", release_platform_run: previous_run, store_submission: previous_store_submission)
+
+        last_release = create(:release, :stopped, train:)
+        last_run = create(:release_platform_run, :stopped, release_platform:, release: last_release, scheduled_at: Time.current - 1)
+        last_parent_release = create(:production_release, :finished, release_platform_run: last_run)
+        last_store_submission = create(:play_store_submission, parent_release: last_parent_release, release_platform_run: last_run)
+        _last_rollout = create(:store_rollout, :fully_released, type: "PlayStoreRollout", release_platform_run: last_run, store_submission: last_store_submission)
+
+        release = create(:release, :on_track, train:)
+        release_platform_run = create(:release_platform_run, release_platform:, release:, scheduled_at: Time.current)
+        parent_release = create(:production_release, :finished, release_platform_run:)
+        store_submission = create(:play_store_submission, parent_release:, release_platform_run:)
+        _rollout = create(:store_rollout, :started, type: "PlayStoreRollout", release_platform_run:, store_submission:)
+
+        expect(release_platform_run.previously_completed_rollout_run).to be_nil
+      end
+
+      it "ignores completed rollouts that are already on 100% rollout" do
+        _previous_rollout = create(:store_rollout, :completed, config: [1, 100], current_stage: 1,
+          type: "PlayStoreRollout",
+          release_platform_run: previous_run, store_submission: previous_store_submission)
+
+        release = create(:release, :on_track, train:)
+        release_platform_run = create(:release_platform_run, release_platform:, release:)
+        parent_release = create(:production_release, :finished, release_platform_run:)
+        store_submission = create(:play_store_submission, parent_release:, release_platform_run:)
+        _rollout = create(:store_rollout, :started, type: "PlayStoreRollout", release_platform_run:, store_submission:)
+
+        expect(release_platform_run.previously_completed_rollout_run).to be_nil
       end
     end
   end


### PR DESCRIPTION
**Closes:** #670 

We're calling this: _cascading rollouts_