### PR TITLE
Add a user action to re-fetch workflow status when workflow fails

### DIFF
--- a/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
+++ b/app/components/v2/live_release/pre_prod_release/current_release_component.html.erb
@@ -41,12 +41,23 @@
 
     <% if retriggerable? %>
       <% card.with_action do %>
-
         <%= render V2::ButtonComponent.new(label: "Retrigger build",
                                            scheme: :default,
                                            options: retry_workflow_run_path(workflow_run),
                                            size: :xxs,
                                            html_options: html_opts(:patch, "Are you sure you want to retrigger the build?")) %>
+
+      <% end %>
+    <% end %>
+
+    <% if workflow_run.failed? %>
+      <% card.with_action do %>
+        <%= render V2::ButtonComponent.new(label: "Re-fetch build status",
+                                           scheme: :light,
+                                           options: fetch_status_workflow_run_path(workflow_run),
+                                           size: :xxs,
+                                           html_options: html_opts(:patch, "Are you sure you want to re-fetch the build status?")) %>
+
       <% end %>
     <% end %>
 

--- a/app/controllers/workflow_runs_controller.rb
+++ b/app/controllers/workflow_runs_controller.rb
@@ -1,20 +1,28 @@
 class WorkflowRunsController < SignedInApplicationController
   before_action :require_write_access!
-  before_action :set_workflow_run, only: [:trigger, :retry]
+  before_action :set_workflow_run, only: [:trigger, :retry, :fetch_status]
 
   def trigger
     if (result = Action.start_workflow_run!(@workflow_run)).ok?
-      redirect_back fallback_location: internal_builds_path, notice: t(".trigger.success")
+      redirect_back fallback_location: internal_builds_path, notice: t(".success")
     else
-      redirect_back fallback_location: internal_builds_path, flash: {error: t(".trigger.failure", errors: result.error.message)}
+      redirect_back fallback_location: internal_builds_path, flash: {error: t(".failure", errors: result.error.message)}
     end
   end
 
   def retry
     if (result = Action.retry_workflow_run!(@workflow_run)).ok?
-      redirect_back fallback_location: internal_builds_path, notice: t(".retry.success")
+      redirect_back fallback_location: internal_builds_path, notice: t(".success")
     else
-      redirect_back fallback_location: internal_builds_path, flash: {error: t(".retry.failure", errors: result.error.message)}
+      redirect_back fallback_location: internal_builds_path, flash: {error: t(".failure", errors: result.error.message)}
+    end
+  end
+
+  def fetch_status
+    if (result = Action.fetch_workflow_run_status!(@workflow_run)).ok?
+      redirect_back fallback_location: internal_builds_path, notice: t(".success")
+    else
+      redirect_back fallback_location: internal_builds_path, flash: {error: t(".failure", errors: result.error.message)}
     end
   end
 

--- a/app/libs/coordinators.rb
+++ b/app/libs/coordinators.rb
@@ -115,7 +115,16 @@ module Coordinators
     def self.retry_workflow_run!(workflow_run)
       Res.new do
         raise "release is not actionable" unless workflow_run.triggering_release.actionable?
+        raise "workflow run is not retryable" unless workflow_run.may_retry?
         workflow_run.retry!
+      end
+    end
+
+    def self.fetch_workflow_run_status!(workflow_run)
+      Res.new do
+        raise "release is not actionable" unless workflow_run.triggering_release.actionable?
+        raise "workflow run is not in failed state" unless workflow_run.failed?
+        workflow_run.found!
       end
     end
 

--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -82,7 +82,7 @@ class WorkflowRun < ApplicationRecord
     end
 
     event :found, after_commit: :on_found! do
-      transitions from: :triggered, to: :started
+      transitions from: [:failed, :triggered], to: :started
     end
 
     event :unavailable, after_commit: :on_unavailable! do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,10 @@ en:
     retry:
       success: "Workflow run was successfully retried."
       error: "Failed to retry the CI workflow! Contact support if the issue persists."
+      failure: "Failed to re-trigger the workflow — %{errors}"
+    fetch_status:
+      success: "Workflow run status is being fetched."
+      failure: "Failed to fetch the workflow status — %{errors}"
   authentication:
     sso:
       sessions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,7 @@ Rails.application.routes.draw do
     member do
       patch :retry
       patch :trigger
+      patch :fetch_status
     end
   end
 


### PR DESCRIPTION
- useful when users re-trigger failed jobs from the CI interface instead of re-triggering the entire workflow