### PR TITLE
Retry trigger submission job on artifact not found error

### DIFF
--- a/app/jobs/v2/trigger_submissions_job.rb
+++ b/app/jobs/v2/trigger_submissions_job.rb
@@ -3,8 +3,20 @@ class V2::TriggerSubmissionsJob < ApplicationJob
 
   queue_as :high
 
-  def perform(workflow_run_id)
+  def perform(workflow_run_id, retry_count = 0)
     workflow_run = WorkflowRun.find(workflow_run_id)
     Coordinators::TriggerSubmissions.call(workflow_run)
+  rescue Installations::Error => ex
+    raise unless ex.reason == :artifact_not_found
+    if retry_count > 3
+      elog(ex)
+      workflow_run&.triggering_release&.fail!
+    else
+      Rails.logger.debug { "Failed to fetch build artifact for workflow run #{workflow_run_id}, retrying in 30 seconds" }
+      V2::TriggerSubmissionsJob.set(wait_time: 30.seconds).perform_later(workflow_run_id, retry_count + 1)
+    end
+  rescue => ex
+    elog(ex)
+    workflow_run&.triggering_release&.fail!
   end
 end

--- a/app/libs/coordinators/trigger_submissions.rb
+++ b/app/libs/coordinators/trigger_submissions.rb
@@ -19,9 +19,6 @@ class Coordinators::TriggerSubmissions
     end
 
     workflow_run.triggering_release.trigger_submissions!
-  rescue => ex
-    elog(ex)
-    workflow_run.triggering_release.fail!
   end
 
   attr_reader :workflow_run, :release_platform_run

--- a/app/models/bitrise_integration.rb
+++ b/app/models/bitrise_integration.rb
@@ -137,15 +137,15 @@ class BitriseIntegration < ApplicationRecord
   end
 
   def get_artifact(artifact_url, _)
-    raise Integration::NoBuildArtifactAvailable if artifact_url.blank?
+    raise Installations::Error.new("Could not find the artifact", reason: :artifact_not_found) if artifact_url.blank?
     Artifacts::Stream.new(installation.artifact_io_stream(artifact_url))
   end
 
   def get_artifact_v2(artifact_url, _, _)
-    raise Integration::NoBuildArtifactAvailable if artifact_url.blank?
+    raise Installations::Error.new("Could not find the artifact", reason: :artifact_not_found) if artifact_url.blank?
 
     artifact = installation.artifact(artifact_url, ARTIFACTS_TRANSFORMATIONS)
-    raise Integration::NoBuildArtifactAvailable if artifact.blank?
+    raise Installations::Error.new("Could not find the artifact", reason: :artifact_not_found) if artifact.blank?
 
     stream = installation.download_artifact(artifact[:archive_download_url])
     {artifact:, stream: Artifacts::Stream.new(stream)}

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -30,7 +30,6 @@ class Integration < ApplicationRecord
 
   IntegrationNotImplemented = Class.new(StandardError)
   UnsupportedAction = Class.new(StandardError)
-  NoBuildArtifactAvailable = Class.new(StandardError)
 
   APP_VARIANT_PROVIDABLE_TYPES = %w[GoogleFirebaseIntegration]
 


### PR DESCRIPTION
- Make all artifact-not-found errors uniform across different CI/CD providers

akin to old step run upload artifact retries - https://github.com/tramlinehq/tramline/blob/main/app/jobs/releases/upload_artifact.rb#L9