### PR TITLE
Create tags on rollout start

### DIFF
--- a/app/jobs/release_platform_runs/create_tag_job.rb
+++ b/app/jobs/release_platform_runs/create_tag_job.rb
@@ -2,8 +2,9 @@ module ReleasePlatformRuns
   class CreateTagJob < ApplicationJob
     queue_as :high
 
-    def perform(platform_run_id)
-      ReleasePlatformRun.find(platform_run_id).create_tag!
+    def perform(platform_run_id, commit_id)
+      commit = Commit.find(commit_id)
+      ReleasePlatformRun.find(platform_run_id).create_tag!(commit)
     end
   end
 end

--- a/app/libs/coordinators/finish_platform_run.rb
+++ b/app/libs/coordinators/finish_platform_run.rb
@@ -20,7 +20,7 @@ class Coordinators::FinishPlatformRun
     end
 
     RefreshPlatformBreakdownJob.perform_later(release_platform_run.id) if release.is_v2?
-    ReleasePlatformRuns::CreateTagJob.perform_later(release_platform_run.id) if train.tag_platform_at_release_end?
+    ReleasePlatformRuns::CreateTagJob.perform_later(release_platform_run.id, last_commit) if train.tag_platform_at_release_end?
     release_platform_run.event_stamp!(reason: :finished, kind: :success, data: {version: release_platform_run.release_version})
     app.refresh_external_app
     V2::FinalizeReleaseJob.perform_later(release.id)
@@ -28,5 +28,5 @@ class Coordinators::FinishPlatformRun
 
   attr_reader :release_platform_run
   delegate :train, :with_lock, to: :release
-  delegate :release, :app, to: :release_platform_run
+  delegate :release, :app, :last_commit, to: :release_platform_run
 end

--- a/app/libs/coordinators/finish_platform_run.rb
+++ b/app/libs/coordinators/finish_platform_run.rb
@@ -20,7 +20,7 @@ class Coordinators::FinishPlatformRun
     end
 
     RefreshPlatformBreakdownJob.perform_later(release_platform_run.id) if release.is_v2?
-    ReleasePlatformRuns::CreateTagJob.perform_later(release_platform_run.id, last_commit) if train.tag_platform_at_release_end?
+    ReleasePlatformRuns::CreateTagJob.perform_later(release_platform_run.id, last_commit.id) if train.tag_platform_at_release_end?
     release_platform_run.event_stamp!(reason: :finished, kind: :success, data: {version: release_platform_run.release_version})
     app.refresh_external_app
     V2::FinalizeReleaseJob.perform_later(release.id)

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -9,9 +9,8 @@ module Taggable
   # ...and so on
   #
   # note: avoids appending increasing numbers to avoid keeping state
-  # note: relies on last_commit and base_tag_name methods
-  def unique_tag_name(currently)
-    sha = last_commit.short_sha
+  # note: relies on a 'base_tag_name' method
+  def unique_tag_name(currently, sha)
     return [base_tag_name, "-", sha].join if currently.end_with?(base_tag_name)
     [base_tag_name, "-", sha, "-", Time.now.to_i].join
   end

--- a/app/models/deployment_run.rb
+++ b/app/models/deployment_run.rb
@@ -526,7 +526,7 @@ class DeploymentRun < ApplicationRecord
 
   def on_release_started
     event_stamp!(reason: :release_started, kind: :notice, data: stamp_data)
-    ReleasePlatformRuns::CreateTagJob.perform_later(release_platform_run.id) if production_channel? && train.tag_all_store_releases?
+    ReleasePlatformRuns::CreateTagJob.perform_later(release_platform_run.id, step_run.commit.id) if production_channel? && train.tag_all_store_releases?
     Releases::FetchHealthMetricsJob.perform_later(id) if app.monitoring_provider.present?
   end
 

--- a/app/models/production_release.rb
+++ b/app/models/production_release.rb
@@ -111,7 +111,7 @@ class ProductionRelease < ApplicationRecord
     notify!("Production release was started!", :production_rollout_started, store_rollout.notification_params)
 
     if train.tag_all_store_releases?
-      ReleasePlatformRuns::CreateTagJob.perform_later(release_platform_run.id, commit)
+      ReleasePlatformRuns::CreateTagJob.perform_later(release_platform_run.id, commit.id)
     end
 
     if !beyond_monitoring_period? && monitoring_provider.present?

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -354,7 +354,7 @@ class Release < ApplicationRecord
     event_stamp!(reason: :vcs_release_created, kind: :notice, data: {provider: vcs_provider.display, tag: tag_name})
   rescue Installations::Error => ex
     raise unless [:tag_reference_already_exists, :tagged_release_already_exists].include?(ex.reason)
-    create_vcs_release!(unique_tag_name(input_tag_name))
+    create_vcs_release!(unique_tag_name(input_tag_name, last_commit.short_sha))
   end
 
   def release_diff

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -425,15 +425,15 @@ class ReleasePlatformRun < ApplicationRecord
     train.vcs_provider&.tag_url(tag_name)
   end
 
-  # recursively attempt to create a release tag until a unique one gets created
-  # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
-  def create_tag!(input_tag_name = base_tag_name)
-    train.create_tag!(input_tag_name, last_commit.commit_hash)
+  # # recursively attempt to create a release tag until a unique one gets created
+  # # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
+  def create_tag!(commit, input_tag_name = base_tag_name)
+    train.create_tag!(input_tag_name, commit.commit_hash)
     update!(tag_name: input_tag_name)
     event_stamp!(reason: :tag_created, kind: :notice, data: {tag: tag_name})
   rescue Installations::Error => ex
     raise unless ex.reason == :tag_reference_already_exists
-    create_tag!(unique_tag_name(input_tag_name))
+    create_tag!(commit, unique_tag_name(input_tag_name, commit.short_sha))
   end
 
   # Play Store does not have constraints around version name

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -425,8 +425,8 @@ class ReleasePlatformRun < ApplicationRecord
     train.vcs_provider&.tag_url(tag_name)
   end
 
-  # # recursively attempt to create a release tag until a unique one gets created
-  # # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
+  # recursively attempt to create a release tag until a unique one gets created
+  # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
   def create_tag!(commit, input_tag_name = base_tag_name)
     train.create_tag!(input_tag_name, commit.commit_hash)
     update!(tag_name: input_tag_name)

--- a/spec/libs/coordinators/finish_platform_run_spec.rb
+++ b/spec/libs/coordinators/finish_platform_run_spec.rb
@@ -33,11 +33,13 @@ describe Coordinators::FinishPlatformRun do
       release = create(:release, train:)
       release_platform = create(:release_platform, train:)
       release_platform_run = create(:release_platform_run, :on_track, release:, release_platform:)
+      commit = create(:commit, release:)
+      release_platform_run.update!(last_commit: commit)
       allow(ReleasePlatformRuns::CreateTagJob).to receive(:perform_later)
 
       described_class.call(release_platform_run)
 
-      expect(ReleasePlatformRuns::CreateTagJob).to have_received(:perform_later).with(release_platform_run.id).once
+      expect(ReleasePlatformRuns::CreateTagJob).to have_received(:perform_later).with(release_platform_run.id, commit.id).once
     end
 
     it "does not schedule a platform-specific tag job if cross-platform app tagging all store releases" do

--- a/spec/models/production_release_spec.rb
+++ b/spec/models/production_release_spec.rb
@@ -47,4 +47,28 @@ RSpec.describe ProductionRelease do
       end
     end
   end
+
+  describe "#rollout_started!" do
+    let(:train) { create(:train, tag_all_store_releases: true) }
+    let(:release) { create(:release, train:) }
+    let(:release_platform) { create(:release_platform, train:) }
+    let(:release_platform_run) { create(:release_platform_run, release_platform:, release:) }
+
+    it "marks the inflight production release as active" do
+      production_release = create(:production_release, :inflight, release_platform_run:)
+
+      production_release.rollout_started!
+
+      expect(production_release.active?).to be(true)
+    end
+
+    it "creates a tag for the the production release" do
+      allow(ReleasePlatformRuns::CreateTagJob).to receive(:perform_later)
+
+      production_release = create(:production_release, :inflight, release_platform_run:)
+      production_release.rollout_started!
+
+      expect(ReleasePlatformRuns::CreateTagJob).to have_received(:perform_later).with(release_platform_run)
+    end
+  end
 end

--- a/spec/models/production_release_spec.rb
+++ b/spec/models/production_release_spec.rb
@@ -49,14 +49,22 @@ RSpec.describe ProductionRelease do
   end
 
   describe "#rollout_started!" do
-    let(:train) { create(:train, tag_all_store_releases: true) }
+    let(:train) { create(:train, tag_all_store_releases: true, tag_platform_releases: true) }
     let(:release) { create(:release, train:) }
     let(:release_platform) { create(:release_platform, train:) }
     let(:release_platform_run) { create(:release_platform_run, release_platform:, release:) }
+    let(:build) { create(:build, release_platform_run:) }
+    let(:production_release) { create(:production_release, :inflight, build:, release_platform_run:) }
+
+    before do
+      create(:store_rollout,
+        :play_store,
+        :started,
+        store_submission: create(:play_store_submission, :prepared, parent_release: production_release),
+        release_platform_run:)
+    end
 
     it "marks the inflight production release as active" do
-      production_release = create(:production_release, :inflight, release_platform_run:)
-
       production_release.rollout_started!
 
       expect(production_release.active?).to be(true)
@@ -65,10 +73,9 @@ RSpec.describe ProductionRelease do
     it "creates a tag for the the production release" do
       allow(ReleasePlatformRuns::CreateTagJob).to receive(:perform_later)
 
-      production_release = create(:production_release, :inflight, release_platform_run:)
       production_release.rollout_started!
 
-      expect(ReleasePlatformRuns::CreateTagJob).to have_received(:perform_later).with(release_platform_run)
+      expect(ReleasePlatformRuns::CreateTagJob).to have_received(:perform_later).with(release_platform_run.id, production_release.commit.id)
     end
   end
 end

--- a/spec/models/release_platform_run_spec.rb
+++ b/spec/models/release_platform_run_spec.rb
@@ -615,7 +615,7 @@ describe ReleasePlatformRun do
       release_platform_run.update!(last_commit: commit)
       create(:step_run, release_platform_run:, commit:)
 
-      release_platform_run.create_tag!
+      release_platform_run.create_tag!(commit)
       expect(release_platform_run.tag_name).to eq("v1.2.3-android")
     end
 
@@ -625,7 +625,7 @@ describe ReleasePlatformRun do
       release_platform_run.update!(last_commit: commit)
       create(:step_run, release_platform_run:, commit:)
 
-      release_platform_run.create_tag!
+      release_platform_run.create_tag!(commit)
       expect(release_platform_run.tag_name).to eq("v1.2.3-android-#{commit.short_sha}")
     end
 
@@ -638,7 +638,7 @@ describe ReleasePlatformRun do
         release_platform_run.update!(last_commit: commit)
         create(:step_run, release_platform_run:, commit:)
 
-        release_platform_run.create_tag!
+        release_platform_run.create_tag!(commit)
         expect(release_platform_run.tag_name).to eq("v1.2.3-android-#{commit.short_sha}-#{now}")
       end
     end


### PR DESCRIPTION
When tag-all-store-versions is enabled, production release / rollout start should create store version tags.