### PR TITLE
Handle missing millisecond-precision for multi-commit push

### DIFF
--- a/app/libs/coordinators/process_commits.rb
+++ b/app/libs/coordinators/process_commits.rb
@@ -61,12 +61,12 @@ class Coordinators::ProcessCommits
       .merge(parents: commit_log.find { _1[:commit_hash] == attributes[:commit_hash] }&.dig(:parents))
   end
 
-  # To ensure that the HEAD commit is always on top
-  # We fudge it to be 1 millisecond after the original timestamp
+  # To ensure that the HEAD commit is always on the top
+  # We fudge it to add 100 ms after the original timestamp
   def fudge_timestamp(commit)
-    original_time = commit[:timestamp]
-    new_time = original_time + 0.001
-    commit[:timestamp] = new_time
+    original_time = Time.zone.parse(commit[:timestamp])
+    new_time = original_time + 0.1
+    commit[:timestamp] = new_time.iso8601(5) # 5 digit ms precision
     commit
   end
 

--- a/app/libs/coordinators/process_commits.rb
+++ b/app/libs/coordinators/process_commits.rb
@@ -63,6 +63,7 @@ class Coordinators::ProcessCommits
 
   # To ensure that the HEAD commit is always on the top
   # We fudge it to add 100 ms after the original timestamp
+  # This can happen in a rare scenario when all the commits are on the same second
   def fudge_timestamp(commit)
     original_time = Time.zone.parse(commit[:timestamp])
     new_time = original_time + 0.1

--- a/app/libs/coordinators/process_commits.rb
+++ b/app/libs/coordinators/process_commits.rb
@@ -61,9 +61,8 @@ class Coordinators::ProcessCommits
       .merge(parents: commit_log.find { _1[:commit_hash] == attributes[:commit_hash] }&.dig(:parents))
   end
 
-  # In some VCS providers, there is no millisecond precision in the timestamp
-  # So we fudge it to be 1 millisecond after the original timestamp
-  # This is to ensure that the head commit is always the one on the top
+  # To ensure that the HEAD commit is always on top
+  # We fudge it to be 1 millisecond after the original timestamp
   def fudge_timestamp(commit)
     original_time = commit[:timestamp]
     new_time = original_time + 0.001

--- a/app/libs/coordinators/process_commits.rb
+++ b/app/libs/coordinators/process_commits.rb
@@ -66,8 +66,7 @@ class Coordinators::ProcessCommits
   # This is to ensure that the head commit is always the one on the top
   def fudge_timestamp(commit)
     original_time = commit[:timestamp]
-    ms = 0.001
-    new_time = original_time + ms
+    new_time = original_time + 0.001
     commit[:timestamp] = new_time
     commit
   end

--- a/spec/factories/release_platform_runs.rb
+++ b/spec/factories/release_platform_runs.rb
@@ -14,7 +14,8 @@ FactoryBot.define do
           release_candidate: {
             name: Faker::FunnyName.name,
             id: Faker::Number.number(digits: 8),
-            artifact_name_pattern: nil
+            artifact_name_pattern: nil,
+            kind: "release_candidate"
           }
         },
         internal_release: nil,
@@ -55,7 +56,8 @@ FactoryBot.define do
             release_candidate: {
               name: Faker::FunnyName.name,
               id: Faker::Number.number(digits: 8),
-              artifact_name_pattern: nil
+              artifact_name_pattern: nil,
+              kind: "release_candidate"
             }
           },
           internal_release: nil,
@@ -115,10 +117,10 @@ FactoryBot.define do
   end
 end
 
-def create_production_rollout_tree(train, release_platform, release_status: :finished, rollout_status: :completed, submission_status: :created, skip_rollout: false)
-  release = create(:release, release_status, train:)
+def create_production_rollout_tree(train, release_platform, release_traits: [:finished], run_status: :finished, rollout_status: :completed, submission_status: :created, skip_rollout: false)
+  release = create(:release, *release_traits, train:)
   platform = release_platform.platform
-  release_platform_run = create(:release_platform_run, platform.to_sym, :finished, release_platform:, release:)
+  release_platform_run = create(:release_platform_run, platform.to_sym, run_status, release_platform:, release:)
   parent_release = create(:production_release, :finished, config: release_platform_run.conf.production_release.as_json, release_platform_run:)
   store_submission = create(:play_store_submission, status: submission_status, config: parent_release.conf.submissions.first, parent_release:, release_platform_run:)
 

--- a/spec/libs/coordinators/process_commits_spec.rb
+++ b/spec/libs/coordinators/process_commits_spec.rb
@@ -4,11 +4,12 @@ require "rails_helper"
 
 describe Coordinators::ProcessCommits do
   let(:head_commit_hash) { SecureRandom.uuid.split("-").join }
+  let(:ts) { Time.current.iso8601(3) }
   let(:head_commit_attributes) do
     {
       commit_hash: head_commit_hash,
       message: Faker::Lorem.sentence,
-      timestamp: Time.current,
+      timestamp: ts,
       author_name: Faker::Name.name,
       author_email: Faker::Internet.email,
       url: Faker::Internet.url,
@@ -20,7 +21,7 @@ describe Coordinators::ProcessCommits do
       {
         commit_hash: "2",
         message: Faker::Lorem.sentence,
-        timestamp: Time.current,
+        timestamp: ts,
         author_name: Faker::Name.name,
         author_email: Faker::Internet.email,
         url: Faker::Internet.url,
@@ -29,7 +30,7 @@ describe Coordinators::ProcessCommits do
       {
         commit_hash: "1",
         message: Faker::Lorem.sentence,
-        timestamp: Time.current,
+        timestamp: ts,
         author_name: Faker::Name.name,
         author_email: Faker::Internet.email,
         url: Faker::Internet.url,
@@ -208,7 +209,7 @@ describe Coordinators::ProcessCommits do
     end
 
     context "when fudging head commit timestamp" do
-      it "adds 1 millisecond" do
+      it "adds 100 milliseconds" do
         release = create(:release, :created, :with_no_platform_runs, train:)
         _release_platform_run = create(:release_platform_run, release_platform:, release:)
 
@@ -218,7 +219,7 @@ describe Coordinators::ProcessCommits do
         commit_attributes = {
           commit_hash: head_commit_hash,
           message: Faker::Lorem.sentence,
-          timestamp: t_minus_ms,
+          timestamp: t_minus_ms.iso8601(3),
           author_name: Faker::Name.name,
           author_email: Faker::Internet.email,
           url: Faker::Internet.url,
@@ -230,7 +231,7 @@ describe Coordinators::ProcessCommits do
 
         commit_ts = release.last_commit.timestamp
         fudged = ((commit_ts - t_minus_ms) * 1000).round
-        expect(fudged).to eq(1)
+        expect(fudged).to eq(100)
       end
 
       it "ensures the commit order is maintained" do
@@ -238,7 +239,7 @@ describe Coordinators::ProcessCommits do
         _release_platform_run = create(:release_platform_run, release_platform:, release:)
 
         t = Time.current
-        t_minus_ms = Time.new(t.year, t.month, t.day, t.hour, t.min, t.sec, t.utc_offset)
+        t_minus_ms = Time.new(t.year, t.month, t.day, t.hour, t.min, t.sec, t.utc_offset).iso8601(3)
 
         commit_attributes = {
           commit_hash: "1",

--- a/spec/libs/coordinators/process_commits_spec.rb
+++ b/spec/libs/coordinators/process_commits_spec.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Coordinators::ProcessCommits do
+  let(:head_commit_hash) { SecureRandom.uuid.split("-").join }
+  let(:head_commit_attributes) do
+    {
+      commit_hash: head_commit_hash,
+      message: Faker::Lorem.sentence,
+      timestamp: Time.current,
+      author_name: Faker::Name.name,
+      author_email: Faker::Internet.email,
+      url: Faker::Internet.url,
+      branch_name: Faker::Lorem.word
+    }
+  end
+  let(:rest_commit_attributes) do
+    [
+      {
+        commit_hash: "2",
+        message: Faker::Lorem.sentence,
+        timestamp: Time.current,
+        author_name: Faker::Name.name,
+        author_email: Faker::Internet.email,
+        url: Faker::Internet.url,
+        branch_name: Faker::Lorem.word
+      },
+      {
+        commit_hash: "1",
+        message: Faker::Lorem.sentence,
+        timestamp: Time.current,
+        author_name: Faker::Name.name,
+        author_email: Faker::Internet.email,
+        url: Faker::Internet.url,
+        branch_name: Faker::Lorem.word
+      }
+    ]
+  end
+
+  before do
+    allow_any_instance_of(described_class).to receive(:commit_log).and_return([])
+  end
+
+  describe "#call" do
+    let(:train) { create(:train) }
+    let(:release_platform) { create(:release_platform, train:) }
+
+    context "when production submission has happened" do
+      it "continues to trigger builds" do
+        create_production_rollout_tree(
+          train,
+          release_platform,
+          release_traits: [:on_track],
+          run_status: :on_track,
+          rollout_status: :created,
+          skip_rollout: false
+        ) => {release:}
+        allow(Coordinators::CreateBetaRelease).to receive(:call)
+
+        described_class.call(release, head_commit_attributes, rest_commit_attributes)
+
+        expect(Coordinators::CreateBetaRelease).to have_received(:call)
+      end
+    end
+
+    context "when hotfix release" do
+      it "does not trigger any submissions for the first commit" do
+        older_release = create(:release, :finished, train:, scheduled_at: 1.day.ago)
+        _last_old_commit = create(:commit, commit_hash: head_commit_hash, release: older_release)
+        create_production_rollout_tree(
+          train,
+          release_platform,
+          release_traits: [:on_track, :hotfix],
+          run_status: :on_track,
+          rollout_status: :created,
+          skip_rollout: false
+        ) => {release:}
+        release.hotfixed_from = older_release
+        release.save!
+
+        allow(Coordinators::CreateBetaRelease).to receive(:call)
+
+        described_class.call(release, head_commit_attributes, rest_commit_attributes)
+
+        expect(Coordinators::CreateBetaRelease).not_to have_received(:call)
+      end
+
+      it "triggers only when there's a new hotfix commit" do
+        older_release = create(:release, :finished, train:, scheduled_at: 1.day.ago)
+        _last_old_commit = create(:commit, release: older_release)
+        create_production_rollout_tree(
+          train,
+          release_platform,
+          release_traits: [:on_track, :hotfix],
+          run_status: :on_track,
+          rollout_status: :created,
+          skip_rollout: false
+        ) => {release:}
+        release.hotfixed_from = older_release
+        release.save!
+
+        allow(Coordinators::CreateBetaRelease).to receive(:call)
+
+        described_class.call(release, head_commit_attributes, rest_commit_attributes)
+
+        expect(Coordinators::CreateBetaRelease).to have_received(:call)
+      end
+    end
+
+    it "starts the release" do
+      release = create(:release, :created, :with_no_platform_runs, train:)
+      _release_platform_run = create(:release_platform_run, release_platform:, release:)
+
+      described_class.call(release, head_commit_attributes, rest_commit_attributes)
+
+      expect(release.reload.on_track?).to be(true)
+    end
+
+    it "creates a new commit" do
+      release = create(:release, :created, :with_no_platform_runs, train:)
+      _release_platform_run = create(:release_platform_run, release_platform:, release:)
+
+      expect {
+        described_class.call(release, head_commit_attributes, [])
+      }.to change(Commit, :count).by(1)
+    end
+
+    it "creates multiple commits if present" do
+      release = create(:release, :created, :with_no_platform_runs, train:)
+      _release_platform_run = create(:release_platform_run, release_platform:, release:)
+
+      expect {
+        described_class.call(release, head_commit_attributes, rest_commit_attributes)
+      }.to change(Commit, :count).by(3)
+    end
+
+    it "triggers builds" do
+      release = create(:release, :created, :with_no_platform_runs, train:)
+      _release_platform_run = create(:release_platform_run, release_platform:, release:)
+      allow(Coordinators::CreateBetaRelease).to receive(:call)
+
+      described_class.call(release, head_commit_attributes, rest_commit_attributes)
+
+      expect(Coordinators::CreateBetaRelease).to have_received(:call)
+    end
+
+    context "when build queue" do
+      let(:queue_size) { 3 }
+      let(:train) { create(:train, :with_build_queue) }
+      let(:release_platform) { create(:release_platform, train:) }
+      let(:release) { create(:release, :created, :with_no_platform_runs, train:) }
+
+      before do
+        create(:release_platform_run, release_platform:, release:)
+        train.update!(build_queue_size: queue_size)
+      end
+
+      it "triggers build for the first commit" do
+        allow(Coordinators::CreateBetaRelease).to receive(:call)
+
+        described_class.call(release, head_commit_attributes, [])
+
+        expect(Coordinators::CreateBetaRelease).to have_received(:call).once
+      end
+
+      it "adds the subsequent commits to the queue" do
+        _old_commit = create(:commit, release:, timestamp: 1.hour.ago)
+        allow(Coordinators::CreateBetaRelease).to receive(:call)
+
+        described_class.call(release, head_commit_attributes, [])
+
+        expect(Coordinators::CreateBetaRelease).not_to have_received(:call)
+        expect(release.applied_commits.reload.size).to be(1)
+        expect(release.all_commits.reload.last.build_queue).to eql(release.active_build_queue)
+      end
+
+      it "adds all commits to the queue when multiple commits" do
+        old_commit = create(:commit, release:)
+        allow(Coordinators::CreateBetaRelease).to receive(:call)
+
+        described_class.call(release, head_commit_attributes, rest_commit_attributes.take(1))
+
+        expect(release.applied_commits.reload.size).to be(1)
+        expect(release.all_commits.reload.size).to be(3)
+        release.all_commits.where.not(id: old_commit.id).find_each do |c|
+          expect(c.build_queue).to eq(release.active_build_queue)
+        end
+      end
+
+      it "applies the build queue if head commit crosses the queue size" do
+        _old_commit = create(:commit, release:)
+        allow(Coordinators::CreateBetaRelease).to receive(:call)
+
+        described_class.call(release, head_commit_attributes, rest_commit_attributes)
+
+        expect(Coordinators::CreateBetaRelease).to have_received(:call).once
+      end
+
+      it "does not apply the build queue if head commit does not cross the queue size" do
+        _old_commit = create(:commit, release:)
+        allow(Coordinators::CreateBetaRelease).to receive(:call)
+
+        described_class.call(release, head_commit_attributes, rest_commit_attributes.take(1))
+
+        expect(Coordinators::CreateBetaRelease).not_to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/models/play_store_submission_spec.rb
+++ b/spec/models/play_store_submission_spec.rb
@@ -106,7 +106,7 @@ describe PlayStoreSubmission do
       create_production_rollout_tree(
         train,
         release_platform,
-        release_status: :on_track,
+        release_traits: [:on_track],
         rollout_status: :created,
         skip_rollout: false
       ) => {store_submission:}
@@ -121,7 +121,7 @@ describe PlayStoreSubmission do
       create_production_rollout_tree(
         train,
         release_platform,
-        release_status: :on_track,
+        release_traits: [:on_track],
         rollout_status: :started,
         skip_rollout: true
       ) => {store_submission:}
@@ -137,7 +137,7 @@ describe PlayStoreSubmission do
       create_production_rollout_tree(
         train,
         release_platform,
-        release_status: :on_track,
+        release_traits: [:on_track],
         rollout_status: :started,
         submission_status: :preprocessing,
         skip_rollout: true
@@ -153,7 +153,7 @@ describe PlayStoreSubmission do
       create_production_rollout_tree(
         train,
         release_platform,
-        release_status: :on_track,
+        release_traits: [:on_track],
         rollout_status: :started,
         skip_rollout: true
       ) => {store_submission:}
@@ -169,7 +169,7 @@ describe PlayStoreSubmission do
       create_production_rollout_tree(
         train,
         release_platform,
-        release_status: :on_track,
+        release_traits: [:on_track],
         rollout_status: :started,
         skip_rollout: true
       ) => {store_submission:}


### PR DESCRIPTION
Add an artificial drift to the HEAD commit to ensure ordering.