### PR TITLE
Fixes running specs on docker

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,7 +15,7 @@ lint:
   bin/rubocop --autocorrect
 
 pre-setup:
-  docker compose run pre-setup
+  docker compose run --rm pre-setup
 
 rails +command="console":
   docker exec -it tramline-web-1 bundle exec rails {{ command }}

--- a/Justfile
+++ b/Justfile
@@ -5,7 +5,7 @@ restart container="web":
   docker compose restart {{ container }}
 
 spec:
-  bundle exec rspec
+  docker compose run --rm rspec
 
 lint:
   bin/rubocop --autocorrect

--- a/Justfile
+++ b/Justfile
@@ -4,8 +4,12 @@ start:
 restart container="web":
   docker compose restart {{ container }}
 
-spec:
-  docker compose run --rm rspec
+spec file="":
+  if [ -z {{ file }} ]; then \
+    docker compose run --rm rspec; \
+  else \
+    docker compose run --rm rspec bundle exec rspec {{ file }}; \
+  fi
 
 lint:
   bin/rubocop --autocorrect

--- a/Justfile
+++ b/Justfile
@@ -6,9 +6,9 @@ restart container="web":
 
 spec file="":
   if [ -z {{ file }} ]; then \
-    docker compose run --rm rspec; \
+    docker compose run --rm spec; \
   else \
-    docker compose run --rm rspec bundle exec rspec {{ file }}; \
+    docker compose run --rm spec bundle exec rspec {{ file }}; \
   fi
 
 lint:

--- a/Justfile
+++ b/Justfile
@@ -18,13 +18,13 @@ pre-setup:
   docker compose run pre-setup
 
 rails +command="console":
-  docker exec -it site-web-1 bundle exec rails {{ command }}
+  docker exec -it tramline-web-1 bundle exec rails {{ command }}
 
 rake +command:
-  docker exec -it site-web-1 bundle exec rake {{ command }}
+  docker exec -it tramline-web-1 bundle exec rake {{ command }}
 
 bundle +command:
-  docker exec -it site-web-1 bundle {{ command }}
+  docker exec -it tramline-web-1 bundle {{ command }}
 
 devlog log_lines="1000":
   tail -f -n {{ log_lines }} log/development.log
@@ -33,7 +33,7 @@ bglog log_lines="100":
   tail -f -n {{ log_lines }} log/sidekiq.log
 
 attach container="web":
-  docker attach --detach-keys "ctrl-d" site-{{ container }}-1
+  docker attach --detach-keys "ctrl-d" tramline-{{ container }}-1
 
 shell container="web":
-  docker exec -it site-{{ container }}-1 /bin/bash
+  docker exec -it tramline-{{ container }}-1 /bin/bash

--- a/compose.yml
+++ b/compose.yml
@@ -126,6 +126,19 @@ services:
       retries: 2
       start_period: 3s
 
+  rspec:
+    <<: *backend
+    command: bash -c "RAILS_ENV=test bin/rails db:create && bundle exec rspec"
+    environment:
+      <<: *env
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/tramline_site_test
+    depends_on:
+      postgres:
+        condition: service_healthy
+      setup:
+        condition: service_completed_successfully
+
 volumes:
   bundle:
   rails_cache:

--- a/compose.yml
+++ b/compose.yml
@@ -93,7 +93,7 @@ services:
       web:
         condition: service_healthy
 
-  sidekiq:
+  worker:
     <<: *backend
     command: bundle exec sidekiq -C config/sidekiq.yml
 
@@ -126,7 +126,7 @@ services:
       retries: 2
       start_period: 3s
 
-  rspec:
+  spec:
     <<: *backend
     command: bash -c "RAILS_ENV=test bin/rails db:create && bundle exec rspec"
     environment:

--- a/config/database.yml
+++ b/config/database.yml
@@ -61,6 +61,9 @@ development:
 test:
   <<: *default
   database: tramline_site_test
+  host: postgres
+  username: postgres
+  password: postgres
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
**Closes:** https://github.com/tramlinehq/site/issues/707

## Because

Specs were failing on docker due to missing database host in test environment

## This addresses

This allows developers to now run specs by using the command `just spec` as specified in readme. Also, specific files can be run using the docker service rspec e.g. `docker compose run --rm rspec bundle exec rspec spec/models/release_spec.rb`
