### PR TITLE
Support CalVer

### DIFF
--- a/app/components/v2/live_release/container_component.html.erb
+++ b/app/components/v2/live_release/container_component.html.erb
@@ -7,7 +7,7 @@
     <div class="col-span-2 flex flex-col justify-between !pt-10 pl-8 py-3.5 border-default-b border-default-l 2xl:rounded-bl-lg border-default-r">
       <div>
         <div class="flex justify-between">
-          <div class="my-2 mb-4">
+          <div>
             <%= back_button %>
           </div>
 
@@ -16,7 +16,7 @@
               <span class="self-end"><%= render V2::BadgeComponent.new(text: "Hotfix", kind: :featured) %></span>
             <% end %>
 
-            <div class="flex flex-row gap-2 justify-end items-baseline <%= hotfix_background %>">
+            <div class="flex flex-row flex-wrap gap-2 justify-end items-baseline <%= hotfix_background %>">
               <% if cross_platform? %>
                 <% if release.platform_runs.size > 1 %>
                   <div class="flex items-center gap-1">

--- a/app/components/v2/release_list_component.html.erb
+++ b/app/components/v2/release_list_component.html.erb
@@ -10,7 +10,7 @@
         <% button.with_icon("band_aid.svg") %>
         <% button.with_title_text.with_content("Start a hotfix") %>
         <% modal.with_body do %>
-          <%= render partial: "trains/hotfix_form", locals: {app: app, train: train, hotfix_from: hotfix_from} %>
+          <%= render partial: "trains/hotfix_form", locals: { app: app, train: train, hotfix_from: hotfix_from } %>
         <% end %>
       <% end %>
     <% end %>
@@ -18,13 +18,13 @@
 
   <%= container.with_side_action do %>
     <%= render V2::DropdownComponent.new(authz: false) do |dropdown| %>
-      <% dropdown.with_button(html_options: {class: "-my-5"}).with_title_text do %>
+      <% dropdown.with_button(html_options: { class: "-my-5" }).with_title_text do %>
         <span class="text-xs text-secondary dark:text-secondary-50 font-medium">Switch</span>
       <% end %>
 
       <% dropdown.with_item_group do |group| %>
         <% app.trains.each do |t| %>
-          <% group.with_item(link: {path: app_train_releases_path(app, t)}, selected: train.id == t.id) do %>
+          <% group.with_item(link: { path: app_train_releases_path(app, t) }, selected: train.id == t.id) do %>
             <%= t.name %>
           <% end %>
         <% end %>
@@ -51,21 +51,7 @@
           </div>
         <% end %>
 
-        <%= render V2::FormComponent.new(model: [app, train, train.releases.new], url: app_train_releases_path(app, train), free_form: true) do |form| %>
-          <div data-controller="reveal">
-            <%= render V2::OptionCardsComponent.new(form: form.F, options: release_options) %>
-            <div class="mt-2" hidden data-reveal>
-              <%= form.F.labeled_text_field :custom_release_version,
-                                            "Version Name",
-                                            autocomplete: "off",
-                                            placeholder: "Eg. 1.1.2" %>
-            </div>
-          </div>
-
-          <% form.with_action do %>
-            <%= form.F.authz_submit "Start", "v2/zap.svg" %>
-          <% end %>
-        <% end %>
+        <%= render partial: release_form_partial, locals: { app:, train:, release_options: } %>
       <% end %>
     <% end %>
   <% end %>
@@ -87,9 +73,9 @@
         label: "Activate",
         options: activate_app_train_path(app, train),
         type: :button,
-        html_options: {method: :patch,
-                       data: {turbo_method: :patch,
-                              turbo_confirm: "This will start scheduling release kickoff(s). Are you sure?"}}) do |b|
+        html_options: { method: :patch,
+                        data: { turbo_method: :patch,
+                                turbo_confirm: "This will start scheduling release kickoff(s). Are you sure?" } }) do |b|
         b.with_icon("play.svg")
       end %>
     <% end %>
@@ -102,9 +88,9 @@
         label: "Deactivate",
         options: deactivate_app_train_path(app, train),
         type: :button,
-        html_options: {method: :patch,
-                       data: {turbo_method: :patch,
-                              turbo_confirm: "This will cancel all the scheduled release kickoff(s). Are you sure?"}}) do |b|
+        html_options: { method: :patch,
+                        data: { turbo_method: :patch,
+                                turbo_confirm: "This will cancel all the scheduled release kickoff(s). Are you sure?" } }) do |b|
         b.with_icon("v2/pause.svg")
       end %>
     <% end %>
@@ -117,7 +103,7 @@
         label: "Remove",
         options: app_train_path(app, train),
         type: :link,
-        html_options: {method: :delete, data: {turbo_method: :delete, turbo_confirm: "Are you sure you want to remove this train?"}}) do |b|
+        html_options: { method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to remove this train?" } }) do |b|
         b.with_icon("v2/trash.svg")
       end %>
     <% end %>
@@ -128,7 +114,7 @@
       <%= render V2::AlertComponent.new(kind: :banner,
                                         type: :notice,
                                         title: "App is not ready",
-                                        info: {label: "Configure", link: app_integrations_path(app)},
+                                        info: { label: "Configure", link: app_integrations_path(app) },
                                         full_screen: false) do %>
         Please finish configuring the required integrations before you can start creating releases.
       <% end %>

--- a/app/components/v2/release_list_component.rb
+++ b/app/components/v2/release_list_component.rb
@@ -121,7 +121,8 @@ class V2::ReleaseListComponent < V2::BaseComponent
         opt_name: "has_major_bump",
         opt_value: "true",
         options: {checked: true, data: {action: REVEAL_HIDE_ACTION}}
-      }
+      },
+      custom_version_option
     ]
   end
 

--- a/app/libs/coordinators/start_release.rb
+++ b/app/libs/coordinators/start_release.rb
@@ -23,7 +23,7 @@ class Coordinators::StartRelease
   end
 
   def call
-    raise "Invalid custom release version! Please use a SemVer like x.y.z format." if invalid_custom_version?
+    raise "Invalid custom release version! Please use a SemVer-like x.y.z format based on your configured versioning strategy." if invalid_custom_version?
     raise "Could not kickoff a hotfix because the source tag does not exist" if hotfix_from_new_branch? && !hotfix_tag_exists?
     raise "Could not kickoff a hotfix because the source release branch does not exist" if hotfix_from_previous_branch? && !hotfix_branch_exists?
     raise "Cannot start a train that is not active!" if train.inactive?
@@ -138,8 +138,7 @@ class Coordinators::StartRelease
 
   def invalid_custom_version?
     return false if custom_version.blank?
-    VersioningStrategies::Semverish.new(custom_version)
-    false
+    VersioningStrategies::Semverish.new(custom_version).invalid?(strategy: train.versioning_strategy)
   rescue ArgumentError
     true
   end

--- a/app/libs/versioning_strategies/codes.rb
+++ b/app/libs/versioning_strategies/codes.rb
@@ -12,7 +12,7 @@ class VersioningStrategies::Codes
       semver = v[:release_version].to_semverish
       raise ArgumentError.new("could not bump version code because release version is not a valid semver") if semver.nil?
       initial_digit = 9
-      major, minor, patch = semver.major, semver.minor, semver.patch || 0
+      major, minor, patch = semver.major.to_i, semver.minor.to_i, semver.patch.to_i || 0
       new_build_number = (initial_digit * 100_000_000) + (major * 1_000_000) + (minor * 10_000) + (patch * 100)
       new_build_number = new_build_number.succ while new_build_number <= value
       new_build_number || 0

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -1,3 +1,5 @@
+# Semverish represents a loose/broad range of what we allow in the x.y.z versioning system
+# It bumps and validates in a more tight/specific way depending on the strategy used
 class VersioningStrategies::Semverish
   include Comparable
 

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -32,12 +32,12 @@ class VersioningStrategies::Semverish
   attr_reader :major, :minor, :patch, :version
 
   def bump!(term, strategy: DEFAULT_STRATEGY)
-    bump_strategy = STRATEGIES[strategy].new(major, minor, patch).bump!(term)
+    bump_strategy = STRATEGIES[strategy.to_sym].new(major, minor, patch).bump!(term)
     VersioningStrategies::Semverish.build(bump_strategy.major, bump_strategy.minor, bump_strategy.patch)
   end
 
   def valid?(strategy: DEFAULT_STRATEGY)
-    STRATEGIES[strategy].valid?(version)
+    STRATEGIES[strategy.to_sym].valid?(version)
   end
 
   def <=>(other)

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -3,8 +3,10 @@
 class VersioningStrategies::Semverish
   include Comparable
 
-  SEMVER = VersioningStrategies::Semverish::Semver
-  CALVER = VersioningStrategies::Semverish::Calver
+  STRATEGIES = {
+    semver: VersioningStrategies::Semverish::Semver,
+    calver: VersioningStrategies::Semverish::Calver
+  }
   DEFAULT_STRATEGY = :semver
   # adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
   # - makes the patch version optional
@@ -30,22 +32,12 @@ class VersioningStrategies::Semverish
   attr_reader :major, :minor, :patch, :version
 
   def bump!(term, strategy: DEFAULT_STRATEGY)
-    bump_strategy =
-      case strategy
-      when :semver then SEMVER.new(major, minor, patch).bump!(term)
-      when :calver then CALVER.new(major, minor, patch).bump!(term)
-      else raise ArgumentError, "Unknown strategy: #{strategy}"
-      end
-
+    bump_strategy = STRATEGIES[strategy].new(major, minor, patch).bump!(term)
     VersioningStrategies::Semverish.build(bump_strategy.major, bump_strategy.minor, bump_strategy.patch)
   end
 
   def valid?(strategy: DEFAULT_STRATEGY)
-    case strategy
-    when :semver then SEMVER.valid?(version)
-    when :calver then CALVER.valid?(version)
-    else raise ArgumentError, "Unknown strategy: #{strategy}"
-    end
+    STRATEGIES[strategy].valid?(version)
   end
 
   def <=>(other)

--- a/app/libs/versioning_strategies/semverish.rb
+++ b/app/libs/versioning_strategies/semverish.rb
@@ -40,6 +40,10 @@ class VersioningStrategies::Semverish
     STRATEGIES[strategy.to_sym].valid?(version)
   end
 
+  def invalid?(strategy: DEFAULT_STRATEGY)
+    !valid?(strategy:)
+  end
+
   def <=>(other)
     other = new(other) if other.is_a? String
 

--- a/app/libs/versioning_strategies/semverish/calver.rb
+++ b/app/libs/versioning_strategies/semverish/calver.rb
@@ -1,6 +1,12 @@
 class VersioningStrategies::Semverish::Calver
   include Comparable
 
+  CALVER_REGEX = /\A([1-9]\d{3})\.(0[1-9]|1[0-2])\.(0[1-9]|[12]\d|3[01])(0[1-9]|[1-9]\d)?\Z/
+
+  def self.valid?(v)
+    v&.match?(CALVER_REGEX)
+  end
+
   def initialize(major, minor, patch)
     @major = major.to_s
     @minor = minor.to_s
@@ -40,6 +46,8 @@ class VersioningStrategies::Semverish::Calver
 
     "#{zero_pad(day)}#{zero_pad(inc)}"
   end
+
+  private
 
   def day
     zero_pad Time.current.day

--- a/app/libs/versioning_strategies/semverish/calver.rb
+++ b/app/libs/versioning_strategies/semverish/calver.rb
@@ -1,0 +1,59 @@
+class VersioningStrategies::Semverish::Calver
+  include Comparable
+
+  def initialize(major, minor, patch)
+    @major = major.to_s
+    @minor = minor.to_s
+    @patch = patch.to_s
+  end
+
+  attr_accessor :major, :minor, :patch, :seq_number
+
+  def bump!(term)
+    term = term.to_sym
+    new_version = clone
+
+    case term
+    when :major
+      new_version.major = year
+      new_version.minor = month
+      new_version.patch = day
+    when :minor
+      new_version.major = year
+      new_version.minor = month
+      new_version.patch = day
+    when :patch
+      new_version.major = year
+      new_version.minor = month
+      new_version.patch = inc(new_version.patch)
+    else
+      raise
+    end
+
+    new_version
+  end
+
+  def inc(v)
+    day = v[0..1].to_i
+    seq = v[2..].to_i
+    inc = seq.zero? ? 1 : seq.abs + 1
+
+    "#{zero_pad(day)}#{zero_pad(inc)}"
+  end
+
+  def day
+    zero_pad Time.current.day
+  end
+
+  def month
+    zero_pad Time.current.month
+  end
+
+  def year
+    Time.current.year
+  end
+
+  def zero_pad(v)
+    format("%02d", v)
+  end
+end

--- a/app/libs/versioning_strategies/semverish/calver.rb
+++ b/app/libs/versioning_strategies/semverish/calver.rb
@@ -29,8 +29,6 @@ class VersioningStrategies::Semverish::Calver
       new_version.minor = month
       new_version.patch = day
     when :patch
-      new_version.major = year
-      new_version.minor = month
       new_version.patch = inc(new_version.patch)
     else
       raise

--- a/app/libs/versioning_strategies/semverish/semver.rb
+++ b/app/libs/versioning_strategies/semverish/semver.rb
@@ -1,6 +1,9 @@
 class VersioningStrategies::Semverish::Semver
   include Comparable
 
+  # adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+  # - makes the patch version optional
+  # - removes support for the prerelease version and the build metadata
   SEMVER_REGEX = /\A(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?\Z/
 
   def self.valid?(v)

--- a/app/libs/versioning_strategies/semverish/semver.rb
+++ b/app/libs/versioning_strategies/semverish/semver.rb
@@ -1,6 +1,12 @@
 class VersioningStrategies::Semverish::Semver
   include Comparable
 
+  SEMVER_REGEX = /\A(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?\Z/
+
+  def self.valid?(v)
+    v.match?(SEMVER_REGEX)
+  end
+
   def initialize(major, minor, patch)
     @major = major.to_i
     @minor = minor.to_i
@@ -22,6 +28,8 @@ class VersioningStrategies::Semverish::Semver
   def inc(v)
     (!v.nil?) ? v.abs + 1 : nil
   end
+
+  private
 
   def proper? = !@patch.nil?
 end

--- a/app/libs/versioning_strategies/semverish/semver.rb
+++ b/app/libs/versioning_strategies/semverish/semver.rb
@@ -1,0 +1,27 @@
+class VersioningStrategies::Semverish::Semver
+  include Comparable
+
+  def initialize(major, minor, patch)
+    @major = major.to_i
+    @minor = minor.to_i
+    @patch = patch.presence && patch.to_i
+  end
+
+  attr_accessor :major, :minor, :patch
+
+  def bump!(term)
+    term = term.to_sym
+    new_version = clone
+    new_value = inc(public_send(term))
+    new_version.public_send(:"#{term}=", new_value)
+    new_version.minor = 0 if term == :major
+    new_version.patch = 0 if proper? && (term == :major || term == :minor)
+    new_version
+  end
+
+  def inc(v)
+    (!v.nil?) ? v.abs + 1 : nil
+  end
+
+  def proper? = !@patch.nil?
+end

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -268,8 +268,8 @@ class ReleasePlatformRun < ApplicationRecord
 
     semverish = newest_release_version.to_semverish
 
-    self.release_version = semverish.bump!(:patch).to_s if semverish.proper?
-    self.release_version = semverish.bump!(:minor).to_s if semverish.partial?
+    self.release_version = semverish.bump!(:patch, strategy: versioning_strategy).to_s if semverish.proper?
+    self.release_version = semverish.bump!(:minor, strategy: versioning_strategy).to_s if semverish.partial?
 
     save!
 

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -516,12 +516,6 @@ class Train < ApplicationRecord
     end
   end
 
-  def semver_compatibility
-    VersioningStrategies::Semverish.new(version_seeded_with)
-  rescue ArgumentError
-    errors.add(:version_seeded_with, "Please choose a valid semver-like format, eg. major.minor.patch or major.minor")
-  end
-
   def set_version_seeded_with
     self.version_seeded_with =
       VersioningStrategies::Semverish.build(major_version_seed, minor_version_seed, patch_version_seed)

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -88,7 +88,7 @@ class Train < ApplicationRecord
   validates :versioning_strategy, presence: true, inclusion: {in: Train.versioning_strategies.values}
   validates :release_backmerge_branch, presence: true, if: -> { branching_strategy == "release_backmerge" }
   validates :release_branch, presence: true, if: -> { branching_strategy == "parallel_working" }
-  validate :semver_compatibility, on: :create
+  validate :version_compatibility, on: :create
   validate :ready?, on: :create
   validate :valid_schedule, if: -> { kickoff_at_changed? || repeat_duration_changed? }
   validate :build_queue_config
@@ -506,6 +506,14 @@ class Train < ApplicationRecord
 
   def set_notifications_config
     self.notifications_enabled = send_notifications?
+  end
+
+  def version_compatibility
+    semverish = VersioningStrategies::Semverish.new(version_seeded_with)
+
+    unless semverish.valid?(strategy: versioning_strategy)
+      errors.add(:version_seeded_with, :"improper_#{versioning_strategy}")
+    end
   end
 
   def semver_compatibility

--- a/app/presenters/train_presenter.rb
+++ b/app/presenters/train_presenter.rb
@@ -1,0 +1,15 @@
+class TrainPresenter < SimpleDelegator
+  VERSIONING_STRATEGIES = {
+    "SemVer" => :semver,
+    "CalVer" => :calver
+  }
+
+  if Set.new(VERSIONING_STRATEGIES.values) != Set.new(VersioningStrategies::Semverish::STRATEGIES.keys)
+    raise ArgumentError, "Displayable versioning strategies do not match the ones specified in Semverish"
+  end
+
+  def initialize(train, view_context = nil)
+    @view_context = view_context
+    super(train)
+  end
+end

--- a/app/views/release_list/_calver_form.html.erb
+++ b/app/views/release_list/_calver_form.html.erb
@@ -9,6 +9,9 @@
                                     "Version Name",
                                     autocomplete: "off",
                                     placeholder: "Eg. 1970.01.01" %>
+      <p class="mt-1 text-secondary text-xs">
+        Be careful when using custom versions with CalVer, because Tramline will not be able to self-correct the version for new versions. Since the version is always based on today's calendar date.
+      </p>
     </div>
   </div>
 

--- a/app/views/release_list/_calver_form.html.erb
+++ b/app/views/release_list/_calver_form.html.erb
@@ -4,6 +4,12 @@
 
   <div data-controller="reveal">
     <%= render V2::OptionCardsComponent.new(form: form.F, options: release_options) %>
+    <div class="mt-2" hidden data-reveal>
+      <%= form.F.labeled_text_field :custom_release_version,
+                                    "Version Name",
+                                    autocomplete: "off",
+                                    placeholder: "Eg. 1970.01.01" %>
+    </div>
   </div>
 
   <% form.with_action do %>

--- a/app/views/release_list/_calver_form.html.erb
+++ b/app/views/release_list/_calver_form.html.erb
@@ -10,7 +10,7 @@
                                     autocomplete: "off",
                                     placeholder: "Eg. 1970.01.01" %>
       <p class="mt-1 text-secondary text-xs">
-        Be careful when using custom versions with CalVer, because Tramline will not be able to self-correct the version for new versions. Since the version is always based on today's calendar date.
+        Be careful when using custom versions with CalVer, since Tramline's automatic versioning will always pick the calendar date when starting a new release.
       </p>
     </div>
   </div>

--- a/app/views/release_list/_calver_form.html.erb
+++ b/app/views/release_list/_calver_form.html.erb
@@ -1,0 +1,12 @@
+<%= render V2::FormComponent.new(model: [app, train, train.releases.new],
+                                 url: app_train_releases_path(app, train),
+                                 free_form: true) do |form| %>
+
+  <div data-controller="reveal">
+    <%= render V2::OptionCardsComponent.new(form: form.F, options: release_options) %>
+  </div>
+
+  <% form.with_action do %>
+    <%= form.F.authz_submit "Start", "v2/zap.svg" %>
+  <% end %>
+<% end %>

--- a/app/views/release_list/_semver_form.html.erb
+++ b/app/views/release_list/_semver_form.html.erb
@@ -1,0 +1,19 @@
+<%= render V2::FormComponent.new(model: [app, train, train.releases.new],
+                                 url: app_train_releases_path(app, train),
+                                 free_form: true) do |form| %>
+
+  <div data-controller="reveal">
+    <%= render V2::OptionCardsComponent.new(form: form.F, options: release_options) %>
+
+    <div class="mt-2" hidden data-reveal>
+      <%= form.F.labeled_text_field :custom_release_version,
+                                    "Version Name",
+                                    autocomplete: "off",
+                                    placeholder: "Eg. 1.1.2" %>
+    </div>
+  </div>
+
+  <% form.with_action do %>
+    <%= form.F.authz_submit "Start", "v2/zap.svg" %>
+  <% end %>
+<% end %>

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -43,8 +43,16 @@
           </span>
       <% end %>
 
+      <div>
+        <%= section.F.labeled_select :versioning_strategy, "Versioning Strategy",
+                                     options_for_select(Train.versioning_strategies, train.versioning_strategy),
+                                     {},
+                                     { disabled: train.persisted? } %>
+      </div>
+
       <div data-domain--version-name-help-disabled-value="<%= train.persisted? %>">
         <%= section.F.label_only :major_version_seed, "Seed with your current version name (build name)" %>
+
         <div class="flex flex-row gap-x-2 items-center">
           <%= section.F.text_field_without_label :major_version_seed, "major",
                                                  disabled: train.persisted?,

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -36,7 +36,7 @@
             Tramline increments the version name for every release build created, which guarantees that every build
             can be uniquely identified. We allow a
             <%= link_to_external "SemVer", "https://semver.org", class: "underline" %>-like scheme, for eg.
-            <code>MAJOR.MINOR.PATCH</code> and <code>MAJOR.MINOR</code>.
+            <code>X.Y.Z</code> and <code>X.Y</code>. Or a CalVer scheme, for eg. <code>YYYY.0M.0D</code>.
             Refer to the
             <%= link_to_external "docs", "https://docs.tramline.app/automations#version-name", class: "underline" %>
             to learn more about versioning.

--- a/app/views/trains/_form.html.erb
+++ b/app/views/trains/_form.html.erb
@@ -45,9 +45,12 @@
 
       <div>
         <%= section.F.labeled_select :versioning_strategy, "Versioning Strategy",
-                                     options_for_select(Train.versioning_strategies, train.versioning_strategy),
+                                     options_for_select(TrainPresenter::VERSIONING_STRATEGIES, train.versioning_strategy),
                                      {},
-                                     { disabled: train.persisted? } %>
+                                     { disabled: train.persisted?,
+                                       data: { domain__version_name_help_strategy_value: train.versioning_strategy,
+                                               domain__version_name_help_target: "versioningStrategy",
+                                               action: "domain--version-name-help#updateStrategy" } } %>
       </div>
 
       <div data-domain--version-name-help-disabled-value="<%= train.persisted? %>">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -464,6 +464,9 @@ en:
               config_not_allowed: "build queue wait time cannot be configured when queue is disabled"
             working_branch:
               not_available: "could not find the working branch in the configured git repo"
+            version_seeded_with:
+              improper_semver: "Please choose a valid semver format, eg. major.minor.patch or major.minor"
+              improper_calver: "Please choose a valid calver format, eg. yyyy.0m.0d"
             backmerge_strategy:
               continuous_not_allowed: "continuous backmerge only allowed for Almost Trunk branching strategy"
               disabled_for_bitbucket: "continuous backmerge is not allowed for Bitbucket at the moment"

--- a/spec/libs/coordinators/start_release_spec.rb
+++ b/spec/libs/coordinators/start_release_spec.rb
@@ -87,7 +87,7 @@ describe Coordinators::StartRelease do
       it "raises an error when the custom version is invalid" do
         expect {
           described_class.call(train, custom_version: "1.2.3-abc")
-        }.to raise_error("Invalid custom release version! Please use a SemVer like x.y.z format.")
+        }.to raise_error("Invalid custom release version! Please use a SemVer-like x.y.z format based on your configured versioning strategy.")
       end
 
       it "raises an error when the train is inactive" do

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -9,10 +9,12 @@ describe VersioningStrategies::Semverish do
     end
 
     it "rejects invalids" do
-      expect { described_class.new("1.02") }.to raise_error(ArgumentError)
       expect { described_class.new("01.02") }.to raise_error(ArgumentError)
-      expect { described_class.new("1.02.1") }.to raise_error(ArgumentError)
       expect { described_class.new("01.2.1") }.to raise_error(ArgumentError)
+      expect { described_class.new("01.002.1") }.to raise_error(ArgumentError)
+      expect { described_class.new("01.002.1") }.to raise_error(ArgumentError)
+      expect { described_class.new("01.2.011") }.to raise_error(ArgumentError)
+      expect { described_class.new("01.02.1") }.to raise_error(ArgumentError)
     end
 
     it "rejects pre-release and build metadata" do
@@ -168,26 +170,26 @@ describe VersioningStrategies::Semverish do
       let(:calver) { described_class.new("2015.12.1") }
 
       it "bumps up the day even if its major" do
-        the_time = Time.new(2015, 12, 2, 0, 0, 0, "+12:00")
+        the_time = Time.new(2015, 12, 2, 0, 0, 0, "+00:00")
 
         travel_to(the_time) do
-          expect(calver.bump!(:major, strategy: :calver).to_s).to eq("2015.12.2")
+          expect(calver.bump!(:major, strategy: :calver).to_s).to eq("2015.12.02")
         end
       end
 
       it "bumps up the day even if its minor" do
-        the_time = Time.new(2015, 12, 3, 0, 0, 0, "+12:00")
+        the_time = Time.new(2015, 12, 3, 0, 0, 0, "+00:00")
 
         travel_to(the_time) do
-          expect(calver.bump!(:minor, strategy: :calver).to_s).to eq("2015.12.3")
+          expect(calver.bump!(:minor, strategy: :calver).to_s).to eq("2015.12.03")
         end
       end
 
       it "adds a sequence number when it's a patch bump" do
-        the_time = Time.new(2015, 12, 3, 0, 0, 0, "+12:00")
+        the_time = Time.new(2015, 12, 3, 0, 0, 0, "+00:00")
 
         travel_to(the_time) do
-          expect(calver.bump!(:patch, strategy: :calver).to_s).to eq("2015.12.301")
+          expect(calver.bump!(:patch, strategy: :calver).to_s).to eq("2015.12.0301")
         end
       end
     end

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -222,24 +222,32 @@ describe VersioningStrategies::Semverish do
     context "when calver" do
       let(:calver) { described_class.new("2015.12.1") }
 
-      it "bumps up the day even if its major" do
-        the_time = Time.new(2015, 12, 2, 0, 0, 0, "+00:00")
+      it "bumps up the day/month/year when bump is major" do
+        the_time = Time.new(2016, 11, 2, 0, 0, 0, "+00:00")
 
         travel_to(the_time) do
-          expect(calver.bump!(:major, strategy: :calver).to_s).to eq("2015.12.02")
+          expect(calver.bump!(:major, strategy: :calver).to_s).to eq("2016.11.02")
         end
       end
 
-      it "bumps up the day even if its minor" do
-        the_time = Time.new(2015, 12, 3, 0, 0, 0, "+00:00")
+      it "bumps up the day/month/year when bump is minor" do
+        the_time = Time.new(2017, 10, 3, 0, 0, 0, "+00:00")
 
         travel_to(the_time) do
-          expect(calver.bump!(:minor, strategy: :calver).to_s).to eq("2015.12.03")
+          expect(calver.bump!(:minor, strategy: :calver).to_s).to eq("2017.10.03")
         end
       end
 
-      it "adds a sequence number when it's a patch bump" do
-        the_time = Time.new(2015, 12, 3, 0, 0, 0, "+00:00")
+      it "adds a sequence number when bump is patch" do
+        the_time = Time.new(2015, 12, 1, 0, 0, 0, "+00:00")
+
+        travel_to(the_time) do
+          expect(calver.bump!(:patch, strategy: :calver).to_s).to eq("2015.12.0101")
+        end
+      end
+
+      it "does not update the day/month/year only sequence number when bump is patch" do
+        the_time = Time.new(2016, 11, 2, 0, 0, 0, "+00:00")
 
         travel_to(the_time) do
           expect(calver.bump!(:patch, strategy: :calver).to_s).to eq("2015.12.0101")

--- a/spec/libs/versioning_strategies/semverish_spec.rb
+++ b/spec/libs/versioning_strategies/semverish_spec.rb
@@ -1,85 +1,30 @@
 require "rails_helper"
 
 describe VersioningStrategies::Semverish do
-  describe "validity" do
-    context "when semverish (during initialization)" do
-      [
-        "1.2.1",
-        "1.2.0",
-        "0.2",
-        "0.02",
-        "1.02.0101",
-        "1.02.0111",
-        "1.02.1299",
-        "1.2.0001",
-        "1.11.01"
-      ].each do |valid|
-        it "follows the semverish rules #{valid}" do
-          expect(described_class.new(valid).to_s).to eq(valid)
-        end
-      end
-
-      [
-        "01.02",
-        "01.2.1",
-        "01.002.1"
-      ].each do |invalid|
-        it "rejects invalidd #{invalid}" do
-          expect { described_class.new(invalid) }.to raise_error(ArgumentError)
-        end
+  describe "validity (during init)" do
+    [
+      "1.2.1",
+      "1.2.0",
+      "0.2",
+      "0.02",
+      "1.02.0101",
+      "1.02.0111",
+      "1.02.1299",
+      "1.2.0001",
+      "1.11.01"
+    ].each do |valid|
+      it "follows the semverish rules #{valid}" do
+        expect(described_class.new(valid).to_s).to eq(valid)
       end
     end
 
-    context "when calver" do
-      [
-        "2015.12.1110",
-        "2015.12.01",
-        "2015.12.3199",
-        "2015.12.0101",
-        "2015.12.0111",
-        "2015.12.1299"
-      ].each do |valid|
-        it "follows the calver rules #{valid}" do
-          expect(described_class.new(valid).valid?(strategy: :calver)).to be(true)
-        end
-      end
-
-      [
-        "30000.12.0101",
-        "2015.12.0001",
-        "3000.2.01",
-        "3000.13.01",
-        "2015.12.101",
-        "2015.12.1100",
-        "2015.12.3200",
-        "2015.12.31100"
-      ].each do |invalid|
-        it "rejects invalid #{invalid}" do
-          expect(described_class.new(invalid).valid?(strategy: :calver)).to be(false)
-        end
-      end
-    end
-
-    context "when semver" do
-      [
-        "1.2.1",
-        "1.2.0",
-        "0.2",
-        "2.0",
-        "12.12.999"
-      ].each do |valid|
-        it "follows the semver rules #{valid}" do
-          expect(described_class.new(valid).valid?(strategy: :semver)).to be(true)
-        end
-      end
-
-      [
-        "1.02.1",
-        "1.2.01"
-      ].each do |invalid|
-        it "rejects invalid #{invalid}" do
-          expect(described_class.new(invalid).valid?(strategy: :semver)).to be(false)
-        end
+    [
+      "01.02",
+      "01.2.1",
+      "01.002.1"
+    ].each do |invalid|
+      it "rejects invalid #{invalid}" do
+        expect { described_class.new(invalid) }.to raise_error(ArgumentError)
       end
     end
 
@@ -91,96 +36,48 @@ describe VersioningStrategies::Semverish do
   end
 
   describe "comparisons" do
-    context "when semver" do
-      it "compares using > or <" do
-        v1 = described_class.new("1.2.1")
-        v2 = described_class.new("1.2.0")
-        v3 = described_class.new("1.2.0")
+    it "compares using > or <" do
+      v1 = described_class.new("1.2.1")
+      v2 = described_class.new("1.2.0")
+      v3 = described_class.new("1.2.0")
 
-        expect(v1 > v2).to be(true)
-        expect(v1 < v2).to be(false)
-        expect(v2 <= v3).to be(true)
-        expect(v3 >= v2).to be(true)
-      end
-
-      it "compares using ==" do
-        v1 = described_class.new("1.2.1")
-        v2 = described_class.new("1.2.1")
-        v3 = described_class.new("1.2.2")
-
-        expect(v1 == v2).to be(true)
-        expect(v2 != v3).to be(true)
-        expect(v1 == v3).to be(false)
-      end
-
-      it "does not compare a partial and a proper semver" do
-        bigger = described_class.new("1.2.1")
-        smaller = described_class.new("1.2")
-
-        expect { bigger > smaller }.to raise_error(ArgumentError)
-      end
-
-      it "determines sort order" do
-        v1 = described_class.new("1.2.1")
-        v2 = described_class.new("1.2.3")
-        v3 = described_class.new("1.1.3")
-        v4 = described_class.new("2.1.3")
-
-        pv1 = described_class.new("2.1")
-        pv2 = described_class.new("2.1")
-        pv3 = described_class.new("1.2")
-        pv4 = described_class.new("1.3")
-        pv5 = described_class.new("0.1")
-
-        expect([v1, v2, v3, v4].sort).to eq([v3, v1, v2, v4])
-        expect([pv1, pv2, pv3, pv4, pv5].sort).to eq([pv5, pv3, pv4, pv1, pv2])
-      end
+      expect(v1 > v2).to be(true)
+      expect(v1 < v2).to be(false)
+      expect(v2 <= v3).to be(true)
+      expect(v3 >= v2).to be(true)
     end
 
-    context "when calendar (year_and_next_week) version" do
-      it "compares using > or <" do
-        v1 = described_class.new("1.2452.1")
-        v2 = described_class.new("1.2452.0")
-        v3 = described_class.new("1.2452.0")
+    it "compares using ==" do
+      v1 = described_class.new("1.2.1")
+      v2 = described_class.new("1.2.1")
+      v3 = described_class.new("1.2.2")
 
-        expect(v1 > v2).to be(true)
-        expect(v1 < v2).to be(false)
-        expect(v2 <= v3).to be(true)
-        expect(v3 >= v2).to be(true)
-      end
+      expect(v1 == v2).to be(true)
+      expect(v2 != v3).to be(true)
+      expect(v1 == v3).to be(false)
+    end
 
-      it "compares using ==" do
-        v1 = described_class.new("0.2452.1")
-        v2 = described_class.new("0.2452.1")
-        v3 = described_class.new("1.2452.1")
+    it "does not compare a partial and a proper semver" do
+      bigger = described_class.new("1.2.1")
+      smaller = described_class.new("1.2")
 
-        expect(v1 == v2).to be(true)
-        expect(v2 != v3).to be(true)
-        expect(v1 == v3).to be(false)
-      end
+      expect { bigger > smaller }.to raise_error(ArgumentError)
+    end
 
-      it "does not compare a partial and a proper semver" do
-        bigger = described_class.new("0.2452.1")
-        smaller = described_class.new("0.2452")
+    it "determines sort order" do
+      v1 = described_class.new("1.2.1")
+      v2 = described_class.new("1.2.3")
+      v3 = described_class.new("1.1.3")
+      v4 = described_class.new("2.1.3")
 
-        expect { bigger > smaller }.to raise_error(ArgumentError)
-      end
+      pv1 = described_class.new("2.1")
+      pv2 = described_class.new("2.1")
+      pv3 = described_class.new("1.2")
+      pv4 = described_class.new("1.3")
+      pv5 = described_class.new("0.1")
 
-      it "determines sort order" do
-        v1 = described_class.new("0.2452.2")
-        v2 = described_class.new("1.2452.0")
-        v3 = described_class.new("0.2252.1")
-        v4 = described_class.new("0.2552.1")
-
-        pv1 = described_class.new("0.2452")
-        pv2 = described_class.new("0.2452")
-        pv3 = described_class.new("0.2202")
-        pv4 = described_class.new("0.2203")
-        pv5 = described_class.new("0.2201")
-
-        expect([v1, v2, v3, v4].sort).to eq([v3, v1, v4, v2])
-        expect([pv1, pv2, pv3, pv4, pv5].sort).to eq([pv5, pv3, pv4, pv1, pv2])
-      end
+      expect([v1, v2, v3, v4].sort).to eq([v3, v1, v2, v4])
+      expect([pv1, pv2, pv3, pv4, pv5].sort).to eq([pv5, pv3, pv4, pv1, pv2])
     end
   end
 
@@ -251,6 +148,61 @@ describe VersioningStrategies::Semverish do
 
         travel_to(the_time) do
           expect(calver.bump!(:patch, strategy: :calver).to_s).to eq("2015.12.0101")
+        end
+      end
+    end
+  end
+
+  describe "#valid?" do
+    context "when calver" do
+      [
+        "2015.12.1110",
+        "2015.12.01",
+        "2015.12.3199",
+        "2015.12.0101",
+        "2015.12.0111",
+        "2015.12.1299"
+      ].each do |valid|
+        it "follows the calver rules #{valid}" do
+          expect(described_class.new(valid).valid?(strategy: :calver)).to be(true)
+        end
+      end
+
+      [
+        "30000.12.0101",
+        "2015.12.0001",
+        "3000.2.01",
+        "3000.13.01",
+        "2015.12.101",
+        "2015.12.1100",
+        "2015.12.3200",
+        "2015.12.31100"
+      ].each do |invalid|
+        it "rejects invalid #{invalid}" do
+          expect(described_class.new(invalid).valid?(strategy: :calver)).to be(false)
+        end
+      end
+    end
+
+    context "when semver" do
+      [
+        "1.2.1",
+        "1.2.0",
+        "0.2",
+        "2.0",
+        "12.12.999"
+      ].each do |valid|
+        it "follows the semver rules #{valid}" do
+          expect(described_class.new(valid).valid?(strategy: :semver)).to be(true)
+        end
+      end
+
+      [
+        "1.02.1",
+        "1.2.01"
+      ].each do |invalid|
+        it "rejects invalid #{invalid}" do
+          expect(described_class.new(invalid).valid?(strategy: :semver)).to be(false)
         end
       end
     end


### PR DESCRIPTION
**Closes:** #584 

We'll do CalVer in the following format:

```
yyyy.0m.0d{0seq-number}-{suffix}
2025.01.02
2025.01.0201
2025.01.0202
2025.01.0203-staging
etc.
```

**Currently decided rules for bumping:**

- Major / minor don't bump anything
- Major / minor only bump if calendar changes
- Patch only bumps sequence number, doesn't change the day

**BNF grammar for CalVer:**

```
<version> ::= <year> "." <month> "." <day-seq> ["-" <suffix>]

<year>    ::= <digit4>
<month>   ::= <digit2>
<day-seq> ::= <day> [<seq-number>]
<day>     ::= <digit2>

<digit4>  ::= <digit> <digit> <digit> <digit>
<digit2>  ::= <digit> <digit>
<digit>   ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"

<seq-number> ::= <digit2>

<suffix>  ::= <alphanum> {<alphanum> | "-"}*
<alphanum> ::= <letter> | <digit>
<letter>  ::= "A" | "B" | "C" | ... | "Z" | "a" | "b" | "c" | ... | "z"

; Additional constraints:
; - <month> must be between "01" and "12"
; - <day> must be between "01" and "31" (depending on month)
; - <seq-number> is optional and starts from "01"
```


**TODO:**

- [x] Validity check for when we use a Custom Version in SemVer
- [x] Test for hotfixes
- [x] Test across cross-platform apps (and version drift between them)
- [x] Change the static text in the train form about `SemVer-like`
- [ ] Starting more than 1 successful production release on the same day