### PR TITLE
Release notes improvements

### DIFF
--- a/app/components/live_release/metadata_component.html.erb
+++ b/app/components/live_release/metadata_component.html.erb
@@ -13,24 +13,24 @@
     <div class="flex flex-col gap-y-2 mb-6">
       <div class="flex gap-x-4">
         <%= render ButtonComponent.new(label: "Play Store metadata requirements",
-                                           scheme: :link,
-                                           type: :link_external,
-                                           options: "https://play.google.com/console/about/storelistings/#best-practices",
-                                           html_options: { class: "text-sm" },
-                                           authz: false,
-                                           size: :none,
-                                           arrow: :none) do |b|
+                                       scheme: :link,
+                                       type: :link_external,
+                                       options: "https://play.google.com/console/about/storelistings/#best-practices",
+                                       html_options: { class: "text-sm" },
+                                       authz: false,
+                                       size: :none,
+                                       arrow: :none) do |b|
           b.with_icon("integrations/logo_google_play_store.png", size: :md, classes: "text-main")
         end %>
 
         <%= render ButtonComponent.new(label: "App Store Connect metadata requirements",
-                                           scheme: :link,
-                                           type: :link_external,
-                                           options: "https://help.apple.com/asc/appsspec/en.lproj/static.html",
-                                           html_options: { class: "text-sm" },
-                                           authz: false,
-                                           size: :none,
-                                           arrow: :none) do |b|
+                                       scheme: :link,
+                                       type: :link_external,
+                                       options: "https://help.apple.com/asc/appsspec/en.lproj/static.html",
+                                       html_options: { class: "text-sm" },
+                                       authz: false,
+                                       size: :none,
+                                       arrow: :none) do |b|
           b.with_icon("integrations/logo_app_store.png", size: :md, classes: "text-main")
         end %>
       </div>
@@ -81,7 +81,11 @@
         <% f.F.fields_for :android, android_metadata do |aF| %>
           <div class="flex flex-col gap-y-4">
             <%= aF.hidden_field :id %>
-            <div><%= aF.labeled_textarea :release_notes, "Release Notes" %></div>
+            <%= render partial: "shared/size_limited_textarea", locals: { form: aF,
+                                                                          obj_method: :release_notes,
+                                                                          label_text: "Release Notes",
+                                                                          max_length: android_max_length,
+                                                                          existing_value: android_metadata.release_notes } %>
           </div>
         <% end %>
       <% elsif component.cross_platform? %>
@@ -94,8 +98,16 @@
         <% f.F.fields_for :ios, ios_metadata do |iosF| %>
           <div class="flex flex-col gap-y-4">
             <%= iosF.hidden_field :id %>
-            <div><%= iosF.labeled_textarea :release_notes, "What's New?" %></div>
-            <div><%= iosF.labeled_textarea :promo_text, "Promo Text" %></div>
+            <%= render partial: "shared/size_limited_textarea", locals: { form: iosF,
+                                                                          obj_method: :release_notes,
+                                                                          label_text: "Release Notes",
+                                                                          max_length: ios_max_length,
+                                                                          existing_value: ios_metadata.release_notes } %>
+            <%= render partial: "shared/size_limited_textarea", locals: { form: iosF,
+                                                                          obj_method: :promo_text,
+                                                                          label_text: "Promo Text",
+                                                                          max_length: promo_text_max_length,
+                                                                          existing_value: ios_metadata.promo_text } %>
             <div><%= iosF.labeled_textarea :keywords, "Keywords", readonly: true, disabled: true %></div>
             <div><%= iosF.labeled_textarea :description, "Description", readonly: true, disabled: true %></div>
           </div>

--- a/app/components/live_release/metadata_component.rb
+++ b/app/components/live_release/metadata_component.rb
@@ -27,4 +27,16 @@ class LiveRelease::MetadataComponent < BaseComponent
   def editable?
     @release.release_platform_runs.any?(&:metadata_editable?)
   end
+
+  def android_max_length
+    ReleaseMetadata::ANDROID_NOTES_MAX_LENGTH
+  end
+
+  def ios_max_length
+    ReleaseMetadata::IOS_NOTES_MAX_LENGTH
+  end
+
+  def promo_text_max_length
+    ReleaseMetadata::PROMO_TEXT_MAX_LENGTH
+  end
 end

--- a/app/javascript/controllers/character_counter_controller.js
+++ b/app/javascript/controllers/character_counter_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+const ERROR_CLASS = "text-rose-700"
+
+export default class extends Controller {
+  static targets = ["input", "counter"]
+  static values = {
+    maxLength: {type: Number, default: 500},
+  }
+
+  connect() {
+    this.update()
+  }
+
+  update() {
+    let value = this.inputTarget.value.length
+
+    if (value > this.maxLengthValue) {
+      this.counterTarget.classList.add(ERROR_CLASS)
+    } else {
+      this.counterTarget.classList.remove(ERROR_CLASS)
+    }
+
+    this.counterTarget.innerHTML = value
+  }
+}

--- a/app/javascript/controllers/character_counter_controller.js
+++ b/app/javascript/controllers/character_counter_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
   }
 
   update() {
-    let value = this.inputTarget.value.length
+    const value = this.inputTarget.value.length
 
     if (value > this.maxLengthValue) {
       this.counterTarget.classList.add(ERROR_CLASS)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -26,3 +26,6 @@ application.register("tabs", Tabs)
 
 import { Popover } from "tailwindcss-stimulus-components"
 application.register("popover", Popover)
+
+import TextareaAutogrow from "stimulus-textarea-autogrow"
+application.register("textarea-autogrow", TextareaAutogrow)

--- a/app/views/shared/_size_limited_textarea.html.erb
+++ b/app/views/shared/_size_limited_textarea.html.erb
@@ -1,0 +1,10 @@
+<div data-controller="character-counter" data-character-counter-max-length-value="<%= max_length %>">
+  <%= form.labeled_textarea obj_method, label_text, data: { character_counter_target: "input",
+                                                            action: "input->character-counter#update",
+                                                            controller: "textarea-autogrow" } %>
+  <p class="text-xs text-secondary">
+    Characters –
+    <strong data-character-counter-target="counter"><%= existing_value&.length || 0 %></strong>
+    /<%= max_length %>
+  </p>
+</div>

--- a/app/views/shared/_size_limited_textarea.html.erb
+++ b/app/views/shared/_size_limited_textarea.html.erb
@@ -5,6 +5,6 @@
   <p class="text-xs text-secondary">
     Characters –
     <strong data-character-counter-target="counter"><%= existing_value&.length || 0 %></strong>
-    /<%= max_length %>
+    / <%= max_length %>
   </p>
 </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -44,3 +44,4 @@ pin "@sentry-internal/feedback", to: "https://ga.jspm.io/npm:@sentry-internal/fe
 pin "@sentry-internal/replay", to: "https://ga.jspm.io/npm:@sentry-internal/replay@8.33.1/build/npm/esm/index.js"
 pin "@sentry-internal/replay-canvas", to: "https://ga.jspm.io/npm:@sentry-internal/replay-canvas@8.33.1/build/npm/esm/index.js"
 pin "tom-select", to: "https://ga.jspm.io/npm:tom-select@2.3.1/dist/js/tom-select.complete.js"
+pin "stimulus-textarea-autogrow", to: "https://ga.jspm.io/npm:stimulus-textarea-autogrow@4.1.0/dist/stimulus-textarea-autogrow.mjs"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,10 +477,11 @@ en:
         release_metadata:
           attributes:
             release_notes:
-              no_special_characters: "only allows letters, numbers, emojis, and some special characters"
+              no_special_characters_ios: "for iOS can only contain letters, numbers, punctuation, basic math symbols, currency symbols, some emojis, and line breaks. The following characters are not allowed – %{denied_characters}"
+              no_special_characters_android: "for Android can only contain letters, numbers, punctuation, basic math symbols, currency symbols, emojis, and line breaks"
               too_long: "is too long for %{platform} (maximum is %{max_length} characters)"
             promo_text:
-              no_special_characters: "only allows letters, numbers, emojis, and some special characters"
+              no_special_characters: "can only contain letters, numbers, punctuation, basic math symbols, currency symbols, some emojis, and line breaks. The following characters are not allowed – %{denied_characters}"
         integration:
           format: "%{message}"
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -477,11 +477,11 @@ en:
         release_metadata:
           attributes:
             release_notes:
-              no_special_characters_ios: "for iOS can only contain letters, numbers, punctuation, basic math symbols, currency symbols, some emojis, and line breaks. The following characters are not allowed – %{denied_characters}"
+              no_special_characters_ios: "for iOS can only contain letters, numbers, punctuation, basic math symbols, currency symbols, and line breaks. The following characters are not allowed – %{denied_characters}"
               no_special_characters_android: "for Android can only contain letters, numbers, punctuation, basic math symbols, currency symbols, emojis, and line breaks"
               too_long: "is too long for %{platform} (maximum is %{max_length} characters)"
             promo_text:
-              no_special_characters: "can only contain letters, numbers, punctuation, basic math symbols, currency symbols, some emojis, and line breaks. The following characters are not allowed – %{denied_characters}"
+              no_special_characters: "can only contain letters, numbers, punctuation, basic math symbols, currency symbols, and line breaks. The following characters are not allowed – %{denied_characters}"
         integration:
           format: "%{message}"
           attributes:

--- a/spec/models/release_metadata_spec.rb
+++ b/spec/models/release_metadata_spec.rb
@@ -3,27 +3,79 @@
 require "rails_helper"
 
 RSpec.describe ReleaseMetadata do
+  let(:locale) { "en-GB" }
+
   it "has a valid factory" do
     expect(build(:release_metadata)).to be_valid
   end
 
-  it "allows emoji characters in notes" do
-    expect(build(:release_metadata, promo_text: "😀")).to be_valid
+  context "when iOS" do
+    let(:release_platform) { create(:release_platform, platform: :ios) }
+    let(:release_platform_run) { create(:release_platform_run, release_platform:) }
+
+    it "disallow emoji characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "➡️ something\n😀 💃🏽")).not_to be_valid
+    end
+
+    it "allows currencies in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "Money money money!! ₹100 off! => $$ bills yo?! (#money)")).to be_valid
+    end
+
+    it "allows accented characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "À la mode, les élèves sont bien à l'aise.")).to be_valid
+    end
+
+    it "allows non-latin characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "दिल ढूँढता है फिर वही फ़ुरसत के रात दिन, बैठे रहे तसव्वुर-ए-जानाँ किये हुए।")).to be_valid
+    end
+
+    it "allows numbers in non-latin languages in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "१२३४५६७८९१०१११२१३, १३ करूँ गिन गिन के")).to be_valid
+    end
+
+    it "allows up to 4000 characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "a" * 4000)).to be_valid
+    end
+
+    it "disallows more than 4000 characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "a" * 4001)).not_to be_valid
+    end
+
+    it "disallows '<' in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "<a>")).not_to be_valid
+    end
   end
 
-  it "allows some special characters in notes" do
-    expect(build(:release_metadata, promo_text: "Money money money!! ₹100 off! $$ bills yo?! (#money)")).to be_valid
-  end
+  context "when android" do
+    let(:release_platform) { create(:release_platform, platform: :android) }
+    let(:release_platform_run) { create(:release_platform_run, release_platform:) }
 
-  it "allows accented characters in notes" do
-    expect(build(:release_metadata, promo_text: "À la mode, les élèves sont bien à l'aise.")).to be_valid
-  end
+    it "allows emoji characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "➡️ something\n😀 💃🏽")).to be_valid
+    end
 
-  it "allows non-latin characters in notes" do
-    expect(build(:release_metadata, promo_text: "दिल ढूँढता है फिर वही फ़ुरसत के रात दिन, बैठे रहे तसव्वुर-ए-जानाँ किये हुए।")).to be_valid
-  end
+    it "allows currencies in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "Money money money!! ₹100 off! => $$ bills yo?! (#money)")).to be_valid
+    end
 
-  it "allows numbers in non-latin languages in notes" do
-    expect(build(:release_metadata, promo_text: "१२३४५६७८९१०१११२१३, १३ करूँ गिन गिन के")).to be_valid
+    it "allows accented characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "À la mode, les élèves sont bien à l'aise.")).to be_valid
+    end
+
+    it "allows non-latin characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "दिल ढूँढता है फिर वही फ़ुरसत के रात दिन, बैठे रहे तसव्वुर-ए-जानाँ किये हुए।")).to be_valid
+    end
+
+    it "allows numbers in non-latin languages in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "१२३४५६७८९१०१११२१३, १३ करूँ गिन गिन के")).to be_valid
+    end
+
+    it "allows up to 500 characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "a" * 500)).to be_valid
+    end
+
+    it "disallows more than 500 characters in notes" do
+      expect(build(:release_metadata, locale:, release_platform_run:, release_notes: "a" * 501)).not_to be_valid
+    end
   end
 end


### PR DESCRIPTION
- platform specific character checks in notes; disallow emojis in iOS
- add UI hints for number of characters used & max allowed
- add textarea auto-resize as the user inputs increases in size

iOS:
![Screenshot 2025-01-20 at 7 01 15 PM](https://github.com/user-attachments/assets/f43d86ba-0fa5-468c-b46f-2051633a327c)
Android:
![Screenshot 2025-01-20 at 7 00 54 PM](https://github.com/user-attachments/assets/69dff819-99ed-4f54-8cd5-a0fe40e65831)
