### PR TITLE
Optimize Crashlytics fetches

### DIFF
--- a/app/libs/installations/crashlytics/api.rb
+++ b/app/libs/installations/crashlytics/api.rb
@@ -69,7 +69,7 @@ module Installations
             event_timestamp,
             bundle_identifier
           FROM `#{table_name}`
-          WHERE event_timestamp >= #{start_timestamp}
+          WHERE event_timestamp >= '#{start_timestamp}'
           AND error_type = 'FATAL'
         ),
         errors_with_version AS (

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -85,6 +85,10 @@ class App < ApplicationRecord
     Flipper.enabled?(:deploy_action_enabled, self)
   end
 
+  def monitoring_disabled?
+    Flipper.enabled?(:monitoring_disabled, self)
+  end
+
   def variant_options
     opts = {"Default (#{bundle_identifier})" => nil}
     opts.merge variants.map.to_h { |v| [v.display_text, v.id] }

--- a/app/models/bugsnag_integration.rb
+++ b/app/models/bugsnag_integration.rb
@@ -100,7 +100,7 @@ class BugsnagIntegration < ApplicationRecord
     list_organizations
   end
 
-  def find_release(platform, version, build_number)
+  def find_release(platform, version, build_number, _start_date = nil)
     installation.find_release(project_id(platform), release_stage(platform), version, build_number, RELEASE_TRANSFORMATIONS)
   end
 

--- a/app/models/crashlytics_integration.rb
+++ b/app/models/crashlytics_integration.rb
@@ -71,9 +71,11 @@ class CrashlyticsIntegration < ApplicationRecord
     {}
   end
 
-  def find_release(platform, version, build_number)
+  # Crashlytics specifically accepts a start_date param because the queries to fetch the release data
+  # are expensive (in $$), so we try to minimize the window of fetch to save on costs.
+  def find_release(platform, version, build_number, start_date)
     return nil if version.blank?
-    installation.find_release(integrable.bundle_identifier, platform, version, build_number, RELEASE_TRANSFORMATIONS)
+    installation.find_release(integrable.bundle_identifier, platform, version, build_number, start_date, RELEASE_TRANSFORMATIONS)
   end
 
   # FIXME: This is an incomplete URL. The full URL should contain the project id.

--- a/app/models/production_release.rb
+++ b/app/models/production_release.rb
@@ -50,9 +50,9 @@ class ProductionRelease < ApplicationRecord
     BugsnagIntegration => 5.minutes,
     CrashlyticsIntegration => 120.minutes
   }
-  RELEASE_MONITORING_PERIOD = {
-    BugsnagIntegration => 15.days,
-    CrashlyticsIntegration => 5.days
+  RELEASE_MONITORING_PERIOD_IN_DAYS = {
+    BugsnagIntegration => 15,
+    CrashlyticsIntegration => 5
   }
 
   enum :status, STATES
@@ -129,7 +129,7 @@ class ProductionRelease < ApplicationRecord
   end
 
   def beyond_monitoring_period?
-    finished? && completed_at < RELEASE_MONITORING_PERIOD[monitoring_provider.class].ago
+    finished? && completed_at && completed_at < release_monitoring_period
   end
 
   def fetch_health_data!
@@ -201,5 +201,9 @@ class ProductionRelease < ApplicationRecord
     else
       changes_since_last_release
     end
+  end
+
+  def release_monitoring_period
+    RELEASE_MONITORING_PERIOD_IN_DAYS[monitoring_provider.class].days.ago
   end
 end

--- a/spec/factories/integrations.rb
+++ b/spec/factories/integrations.rb
@@ -46,5 +46,10 @@ FactoryBot.define do
       category { "project_management" }
       providable factory: %i[jira_integration with_app_config]
     end
+
+    trait :with_crashlytics do
+      category { "monitoring" }
+      providable factory: %i[crashlytics_integration skip_validate_key]
+    end
   end
 end

--- a/spec/factories/release_platform_runs.rb
+++ b/spec/factories/release_platform_runs.rb
@@ -117,11 +117,11 @@ FactoryBot.define do
   end
 end
 
-def create_production_rollout_tree(train, release_platform, release_traits: [:finished], run_status: :finished, rollout_status: :completed, submission_status: :created, skip_rollout: false)
+def create_production_rollout_tree(train, release_platform, release_traits: [:finished], run_status: :finished, parent_release_status: :finished, rollout_status: :completed, submission_status: :created, skip_rollout: false)
   release = create(:release, *release_traits, train:)
   platform = release_platform.platform
   release_platform_run = create(:release_platform_run, platform.to_sym, run_status, release_platform:, release:)
-  parent_release = create(:production_release, :finished, config: release_platform_run.conf.production_release.as_json, release_platform_run:)
+  parent_release = create(:production_release, parent_release_status, config: release_platform_run.conf.production_release.as_json, release_platform_run:)
   store_submission = create(:play_store_submission, status: submission_status, config: parent_release.conf.submissions.first, parent_release:, release_platform_run:)
 
   unless skip_rollout

--- a/spec/libs/installations/crashlytics/api_spec.rb
+++ b/spec/libs/installations/crashlytics/api_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-Dataset = Struct.new(:dataset_id, :project_id)
+Dataset = Data.define(:dataset_id, :project_id)
 APP_IDENTIFIER = "com.example.app"
 APP_ONE = "App One"
 APP_TWO = "App Two"
@@ -62,7 +62,7 @@ describe Installations::Crashlytics::Api, type: :integration do
       end
 
       it "returns the transformed release data" do
-        result = api_instance.find_release(bundle_identifier, platform, version, build_number, transforms)
+        result = api_instance.find_release(bundle_identifier, platform, version, build_number, Time.current, transforms)
         expected_data = {
           "daily_users" => 150,
           "daily_users_with_errors" => 30,
@@ -85,7 +85,7 @@ describe Installations::Crashlytics::Api, type: :integration do
       end
 
       it "returns nil" do
-        result = api_instance.find_release(bundle_identifier, platform, version, build_number, transforms)
+        result = api_instance.find_release(bundle_identifier, platform, version, build_number, Time.current, transforms)
         expect(result).to be_nil
       end
     end

--- a/spec/models/crashlytics_integration_spec.rb
+++ b/spec/models/crashlytics_integration_spec.rb
@@ -44,19 +44,21 @@ describe CrashlyticsIntegration do
     end
 
     it "calls the API find_release method with correct arguments" do
-      crashlytics_integration.find_release(platform, version, build_number)
+      start_date = Time.current
+      crashlytics_integration.find_release(platform, version, build_number, start_date)
 
       expect(api_instance).to have_received(:find_release).with(
         bundle_identifier,
         platform,
         version,
         build_number,
+        start_date,
         CrashlyticsIntegration::RELEASE_TRANSFORMATIONS
       )
     end
 
     it "returns nil if version is blank" do
-      expect(crashlytics_integration.find_release("android", nil, build_number)).to be_nil
+      expect(crashlytics_integration.find_release("android", nil, build_number, Time.current)).to be_nil
     end
   end
 


### PR DESCRIPTION
This is a simple optimization on two-levels:

1. Include a start date before querying for crash/analytics data from BigQuery. The start date is the day when the store rollout gets created.
2. Flag off apps if the `monitoring_disabled` feature flag is enabled for them. This helps us easily stop/start the apps that use Crashlytics for which the queries are too expensive. 