### PR TITLE
Bump net-imap to 0.5.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ gem "descope", "~> 1.0"
 gem "invisible_captcha", "~> 2.3"
 gem "csv", "~> 3.3"
 gem "google-cloud-bigquery", "~> 1.50.0"
+gem "net-imap", "~> 0.5.6"
 
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       railties (>= 6.1)
     datadog-ci (0.8.3)
       msgpack
-    date (3.3.4)
+    date (3.4.1)
     ddtrace (1.23.3)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
@@ -396,7 +396,7 @@ GEM
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
-    net-imap (0.5.0)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -797,6 +797,7 @@ DEPENDENCIES
   letter_opener_web
   lograge (~> 0.12.0)
   memery (~> 1.4)
+  net-imap (~> 0.5.6)
   octokit (~> 4.22)
   oj (~> 3.13)
   ougai (~> 2.0)


### PR DESCRIPTION
There was a vulnerability found in `net-imap`: https://github.com/ruby/net-imap/security/advisories/GHSA-7fc5-f82f-cx69

This was causing the `scan_ruby` Github Action check to fail:

```
❯ just bundle exec bundler-audit --update
docker exec -it tramline-web-1 bundle exec bundler-audit --update
Download ruby-advisory-db ...
Cloning into '/root/.local/share/ruby-advisory-db'...
remote: Enumerating objects: 12291, done.
remote: Counting objects: 100% (1761/1761), done.
remote: Compressing objects: 100% (451/451), done.
remote: Total 12291 (delta 1404), reused 1317 (delta 1308), pack-reused 10530 (from 2)
Receiving objects: 100% (12291/12291), 2.04 MiB | 7.01 MiB/s, done.
Resolving deltas: 100% (6971/6971), done.
ruby-advisory-db:
  advisories:   957 advisories
  last updated: 2025-02-11 12:00:22 -0800
  commit:       44593edd43b5890a2b28b3febf5f18f776615bf1
Name: net-imap
Version: 0.5.0
CVE: CVE-2025-25186
GHSA: GHSA-7fc5-f82f-cx69
Criticality: Medium
URL: https://github.com/ruby/net-imap/security/advisories/GHSA-7fc5-f82f-cx69
Title: Possible DoS by memory exhaustion in net-imap
Solution: update to '~> 0.3.8', '~> 0.4.19', '>= 0.5.6'

Vulnerabilities found!
error: Recipe `bundle` failed on line 30 with exit code 1
```