### PR TITLE
Enable Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    open-pull-requests-limit: 5
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "23:30" # check for updates at 23:30 UTC / 5 AM IST to avoid main working hours


### PR DESCRIPTION
The `scan_ruby` CI check helps us catch CVEs in dependencies, but doesn't update them proactively. This PR enables Dependabot PRs to bump up gems when there is a vulnerability.