### PR TITLE
Disable Dependabot updates except security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
     schedule:
       interval: "daily"
       time: "23:30" # check for updates at 23:30 UTC / 5 AM IST to avoid main working hours
+    ignore:
+      # Disable all updates except security updates
+      # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
Dependabot seems to create too many unnecessary PRs so ignore anything except security updates.