### PR TITLE
If PR closes during merge, accept and move on

### DIFF
--- a/app/libs/installations/bitbucket/error.rb
+++ b/app/libs/installations/bitbucket/error.rb
@@ -24,6 +24,10 @@ module Installations
       {
         message_matcher: /failed merge check/i,
         decorated_reason: :pull_request_failed_merge_check
+      },
+      {
+        message_matcher: /This pull request is already closed/i,
+        decorated_reason: :pull_request_closed
       }
     ]
 

--- a/app/libs/triggers/pull_request.rb
+++ b/app/libs/triggers/pull_request.rb
@@ -91,6 +91,8 @@ class Triggers::PullRequest
         raise MergeError, "Failed to merge the Pull Request"
       elsif ex.reason == :pull_request_failed_merge_check
         raise RetryableMergeError, "Failed to merge the Pull Request because of merge checks."
+      elsif ex.reason == :pull_request_closed
+        true
       else
         raise ex
       end


### PR DESCRIPTION
This handles this particular [error](https://tramline.sentry.io/issues/6335858992/?alert_rule_id=14005685&alert_type=issue&notification_uuid=922358f6-7007-4703-8f82-2ab45a522b61&project=6541299&referrer=slack) that happened.

It's only handled for Bitbucket because that's only where I've seen this so far.