### PR TITLE
Swap out the current redlock library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ gem "active_record_union", "~> 1.3"
 gem "pg_search", "~> 2.3"
 gem "redis_queued_locks", "~> 1.12"
 gem "net-imap", "~> 0.5.6"
+gem "redlock", "~> 2.0"
 
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -541,6 +541,8 @@ GEM
     redis_queued_locks (1.12.1)
       qonfig (~> 0.28)
       redis-client (~> 0.20)
+    redlock (2.0.6)
+      redis-client (>= 0.14.1, < 1.0.0)
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
@@ -837,6 +839,7 @@ DEPENDENCIES
   redis (~> 4.8)
   redis-actionpack (~> 5.3)
   redis_queued_locks (~> 1.12)
+  redlock (~> 2.0)
   requestjs-rails (~> 0.0.9)
   retryable (~> 3.0)
   rspec-rails

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -1,0 +1,17 @@
+module Lockable
+  LockAcquisitionFailureError = Class.new(StandardError)
+
+  def with_lock(lock_name, params, exception: nil)
+    ttl = params[:ttl]
+    params = params.slice(:retry_count, :retry_delay)
+    Rails.application.config.distributed_lock_client.lock(lock_name, ttl, params) do |locked|
+      if locked
+        yield
+      elsif exception
+        raise exception
+      else
+        raise LockAcquisitionFailureError, "Could not acquire lock for #{lock_name}, try again later"
+      end
+    end
+  end
+end

--- a/config/initializers/redlock.rb
+++ b/config/initializers/redlock.rb
@@ -1,11 +1,6 @@
-require "redis_queued_locks"
-
-Rails.application.config.distributed_lock =
-  RedisClient.config(**REDIS_CONFIGURATION.base).new_pool(**REDIS_CONFIGURATION.base_pool).then do |redis_client|
-    RedisQueuedLocks::Client.new(redis_client) do |config|
-      config.default_queue_ttl = 15 # seconds
-      config.default_lock_ttl = 120_000 # milliseconds
-      config.retry_delay = 200 # milliseconds
-      config.retry_count = 25
-    end
-  end
+Rails.application.config.distributed_lock_client =
+  Redlock::Client.new([RedisClient.new(**REDIS_CONFIGURATION.base)], {
+    retry_count: 3,
+    retry_delay: 200, # milliseconds
+    redis_timeout: RedisConfiguration::CONNECT_TIMEOUT
+  })


### PR DESCRIPTION
We're seeing a lot of  internal library errors from https://github.com/0exp/redis_queued_locks/issues/10 so swapping it out for the simpler https://github.com/leandromoreira/redlock-rb library.