### PR TITLE
Prefer external_id over external_number if number

### DIFF
--- a/app/jobs/workflow_runs/find_job.rb
+++ b/app/jobs/workflow_runs/find_job.rb
@@ -21,5 +21,7 @@ class WorkflowRuns::FindJob < ApplicationJob
     workflow_run = WorkflowRun.find(workflow_run_id)
     workflow_run.find_and_update_external
     workflow_run.found! if workflow_run.may_found?
+  rescue WorkflowRun::ExternalUniqueNumberNotFound
+    workflow_run.unavailable!
   end
 end

--- a/app/jobs/workflow_runs/trigger_job.rb
+++ b/app/jobs/workflow_runs/trigger_job.rb
@@ -19,5 +19,7 @@ class WorkflowRuns::TriggerJob < ApplicationJob
     else
       raise
     end
+  rescue WorkflowRun::ExternalUniqueNumberNotFound
+    workflow_run.unavailable!
   end
 end

--- a/app/models/bitbucket_integration.rb
+++ b/app/models/bitbucket_integration.rb
@@ -268,7 +268,8 @@ class BitbucketIntegration < ApplicationRecord
 
   WORKFLOW_RUN_TRANSFORMATIONS = {
     ci_ref: :uuid,
-    number: :build_number
+    number: :build_number,
+    unique_number: :build_number
   }
 
   ARTIFACTS_TRANSFORMATIONS = {

--- a/app/models/bitrise_integration.rb
+++ b/app/models/bitrise_integration.rb
@@ -35,7 +35,8 @@ class BitriseIntegration < ApplicationRecord
   WORKFLOW_RUN_TRANSFORMATIONS = {
     ci_ref: :build_slug,
     ci_link: :build_url,
-    number: :build_number
+    number: :build_number,
+    unique_number: :build_number
   }
 
   ORGANIZATIONS_TRANSFORMATIONS = {

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -47,7 +47,8 @@ class GithubIntegration < ApplicationRecord
   WORKFLOW_RUN_TRANSFORMATIONS = {
     ci_ref: :id,
     ci_link: :html_url,
-    number: :run_number
+    number: :run_number,
+    unique_number: :id
   }
 
   INSTALLATION_TRANSFORMATIONS = {

--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -224,9 +224,14 @@ class WorkflowRun < ApplicationRecord
   end
 
   def update_build_number_from_external_metadata!
-    if external_number.present?
-      build.update!(build_number: external_number)
-      app.bump_build_number!(release_version: build.release_version, workflow_build_number: external_number)
+    # Pick the first one which is a number
+    # Build numbers *must* be numeric
+    # In case of bitrise, external_id is usually a UUID, and in github external_id is a number
+
+    workflow_build_number = [external_id, external_number].find { |e| e =~ /^\d+$/ }
+    if workflow_build_number.present?
+      build.update!(build_number: workflow_build_number)
+      app.bump_build_number!(release_version: build.release_version, workflow_build_number:)
     else
       fail!
     end

--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -5,6 +5,7 @@
 #  id                      :uuid             not null, primary key
 #  artifacts_url           :string
 #  external_number         :string
+#  external_unique_number  :string
 #  external_url            :string
 #  finished_at             :datetime
 #  kind                    :string           default("release_candidate"), not null
@@ -89,9 +90,10 @@ class WorkflowRun < ApplicationRecord
     end
 
     event :unavailable, after_commit: :on_unavailable! do
-      transitions from: [:created, :triggered], to: :unavailable
+      transitions from: [:created, :triggered, :triggering], to: :unavailable
     end
 
+    # this is when the actual workflow run has failed (exit 1)
     event :fail, after_commit: :on_fail! do
       transitions from: :started, to: :failed
     end
@@ -143,7 +145,10 @@ class WorkflowRun < ApplicationRecord
 
   def find_and_update_external
     return if workflow_found?
-    find_external_run.then { |wr| update_external_metadata!(wr) }
+
+    find_external_run
+      .then { |external_workflow_run| check_external_data(external_workflow_run) }
+      .then { |external_workflow_run| update_external_metadata!(external_workflow_run) }
   end
 
   def get_external_run
@@ -211,12 +216,30 @@ class WorkflowRun < ApplicationRecord
 
   private
 
+  class ExternalUniqueNumberNotFound < StandardError
+    def initialize(message = "External unique number not found")
+      super
+    end
+
+    def reason = nil
+  end
+
+  def check_external_data(external_workflow_run)
+    if app.build_number_managed_externally?
+      external_unique_number = external_workflow_run[:unique_number]
+      raise ExternalUniqueNumberNotFound if external_unique_number.blank?
+    end
+
+    external_workflow_run
+  end
+
   def trigger_external_run!
     deploy_action_enabled = organization.deploy_action_enabled? || app.deploy_action_enabled? || train.deploy_action_enabled?
 
     ci_cd_provider
       .trigger_workflow_run!(conf.identifier, release_branch, workflow_inputs, commit_hash, deploy_action_enabled)
-      .then { |wr| update_external_metadata!(wr) }
+      .then { |external_workflow_run| check_external_data(external_workflow_run) }
+      .then { |external_workflow_run| update_external_metadata!(external_workflow_run) }
   end
 
   def update_internally_managed_build_number!
@@ -224,17 +247,8 @@ class WorkflowRun < ApplicationRecord
   end
 
   def update_build_number_from_external_metadata!
-    # Pick the first one which is a number
-    # Build numbers *must* be numeric
-    # In case of bitrise, external_id is usually a UUID, and in github external_id is a number
-
-    workflow_build_number = [external_id, external_number].find { |e| e =~ /^\d+$/ }
-    if workflow_build_number.present?
-      build.update!(build_number: workflow_build_number)
-      app.bump_build_number!(release_version: build.release_version, workflow_build_number:)
-    else
-      fail!
-    end
+    build.update!(build_number: external_unique_number)
+    app.bump_build_number!(release_version: build.release_version, workflow_build_number: external_unique_number)
   end
 
   def workflow_inputs
@@ -247,13 +261,14 @@ class WorkflowRun < ApplicationRecord
     data
   end
 
-  def update_external_metadata!(workflow_run)
-    return if workflow_run.try(:[], :ci_ref).blank?
+  def update_external_metadata!(external_workflow_run)
+    return if external_workflow_run.try(:[], :ci_ref).blank?
 
     update!(
-      external_id: workflow_run[:ci_ref],
-      external_url: workflow_run[:ci_link],
-      external_number: workflow_run[:number]
+      external_id: external_workflow_run[:ci_ref],
+      external_url: external_workflow_run[:ci_link],
+      external_number: external_workflow_run[:number],
+      external_unique_number: external_workflow_run[:unique_number]
     )
 
     update_build_number_from_external_metadata! if app.build_number_managed_externally?

--- a/db/migrate/20250325093941_add_externa_build_number_to_workflow_runs.rb
+++ b/db/migrate/20250325093941_add_externa_build_number_to_workflow_runs.rb
@@ -1,0 +1,5 @@
+class AddExternaBuildNumberToWorkflowRuns < ActiveRecord::Migration[7.2]
+  def change
+    add_column :workflow_runs, :external_unique_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_20_064740) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_25_093941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -1038,6 +1038,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_064740) do
     t.datetime "finished_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "external_unique_number"
     t.index ["commit_id"], name: "index_workflow_runs_on_commit_id"
     t.index ["pre_prod_release_id", "commit_id"], name: "index_workflow_runs_on_pre_prod_release_id_and_commit_id", unique: true
     t.index ["pre_prod_release_id"], name: "index_workflow_runs_on_pre_prod_release_id"

--- a/spec/jobs/workflow_runs/find_job_spec.rb
+++ b/spec/jobs/workflow_runs/find_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe WorkflowRuns::FindJob do
+  let(:workflow_run) { create(:workflow_run, :triggered) }
+
+  context "when build number is managed externally" do
+    before do
+      workflow_run.app.update(build_number_managed_internally: false)
+    end
+
+    it "marks the workflow run as trigger_failed when the external unique number is not found" do
+      allow_any_instance_of(GithubIntegration).to receive(:find_workflow_run).and_return({unique_number: nil})
+
+      described_class.new.perform(workflow_run.id)
+
+      expect(workflow_run.reload.status).to eq("unavailable")
+    end
+  end
+end

--- a/spec/jobs/workflow_runs/trigger_job_spec.rb
+++ b/spec/jobs/workflow_runs/trigger_job_spec.rb
@@ -2,30 +2,36 @@
 
 require "rails_helper"
 
-RSpec.describe WorkflowRuns::TriggerJob do
+describe WorkflowRuns::TriggerJob do
   let(:workflow_run) { create(:workflow_run, :triggering) }
 
   before do
-    allow(WorkflowRun).to receive(:find).and_return(workflow_run)
+    allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!)
   end
 
   context "when trigger does not cause error" do
-    before do
-      allow(workflow_run).to receive(:trigger!)
-    end
-
-    it "triggers successfully" do
+    it "initiates the workflow run" do
       described_class.new.perform(workflow_run.id)
-      expect(workflow_run).to have_received(:trigger!)
+
+      expect(workflow_run.reload.status).to eq("triggered")
     end
   end
 
   context "when trigger results in error" do
     let(:workflow_run) { create(:workflow_run, :triggering) }
 
+    it "marks the workflow run as trigger_failed when the external unique number is not found" do
+      workflow_run.app.update(build_number_managed_internally: false)
+      allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!).and_return({unique_number: nil})
+
+      described_class.new.perform(workflow_run.id)
+
+      expect(workflow_run.reload.status).to eq("unavailable")
+    end
+
     shared_examples "with known error" do |error|
       before do
-        allow(workflow_run).to receive(:trigger!).and_raise(error)
+        allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!).and_raise(error)
       end
 
       context "when error is #{error.message}" do
@@ -36,12 +42,13 @@ RSpec.describe WorkflowRuns::TriggerJob do
       end
     end
 
-    include_examples "with known error", Installations::Github::Error.new(
+    it_behaves_like "with known error", Installations::Github::Error.new(
       OpenStruct.new(
         response_body: {message: "Workflow does not have 'workflow_dispatch' trigger"}.to_json
       )
     )
-    include_examples "with known error", Installations::Github::Error.new(
+
+    it_behaves_like "with known error", Installations::Github::Error.new(
       OpenStruct.new(
         response_body: {message: "Required input 'parameter_X' not provided"}.to_json
       )
@@ -50,7 +57,7 @@ RSpec.describe WorkflowRuns::TriggerJob do
     context "when error is unknown" do
       before do
         err = Installations::Error.new("Some Error", reason: :unknown_failure)
-        allow(workflow_run).to receive(:trigger!).and_raise(err)
+        allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!).and_raise(err)
       end
 
       it "does not change state of workflow_run to trigger_failed" do
@@ -60,6 +67,7 @@ RSpec.describe WorkflowRuns::TriggerJob do
           nil
         end
 
+        expect(workflow_run.reload.status).to eq("triggering")
         expect(workflow_run.reload.status).not_to eq("trigger_failed")
       end
     end

--- a/spec/libs/installations/bitrise/api_spec.rb
+++ b/spec/libs/installations/bitrise/api_spec.rb
@@ -103,7 +103,8 @@ describe Installations::Bitrise::Api, type: :integration do
       expected = {
         ci_ref: "d40e1f6c-e3a0-4c37-bbb0-1fa22ecdc8c5",
         ci_link: "https://app.bitrise.io/build/d40e1f6c-e3a0-4c37-bbb0-1fa22ecdc8c5",
-        number: 102
+        number: 102,
+        unique_number: 102 # same as number
       }
       expect(result).to match(expected)
     end

--- a/spec/libs/installations/github/api_spec.rb
+++ b/spec/libs/installations/github/api_spec.rb
@@ -66,7 +66,8 @@ describe Installations::Github::Api, type: :integration do
       expected = {
         ci_ref: 30433642,
         ci_link: "https://github.com/octo-org/octo-repo/actions/runs/30433642",
-        number: 562
+        number: 562,
+        unique_number: 30433642 # same as ci_ref
       }
       expect(result).to match(expected)
     end

--- a/spec/models/workflow_run_spec.rb
+++ b/spec/models/workflow_run_spec.rb
@@ -13,6 +13,7 @@ describe WorkflowRun do
     let(:number) { Faker::Number.number(digits: 3).to_s }
     let(:api_double) { instance_double(Installations::Google::PlayDeveloper::Api) }
     let(:workflow_run) { create(:workflow_run, :triggering) }
+    let(:unique_number) { (workflow_run.app.build_number + 1).to_s }
 
     before do
       allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!)
@@ -42,7 +43,7 @@ describe WorkflowRun do
 
     context "when workflow found (github)" do
       before do
-        allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!).and_return({ci_ref:, ci_link:, number:})
+        allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!).and_return({ci_ref:, ci_link:, number:, unique_number:})
       end
 
       it "transitions state to started" do
@@ -75,35 +76,19 @@ describe WorkflowRun do
 
         it "updates build number" do
           expect(workflow_run.build.build_number).to be_nil
+
           workflow_run.trigger!
-          expect(workflow_run.build.build_number).to eq(ci_ref)
-          expect(workflow_run.app.build_number.to_s).to eq(ci_ref)
-        end
-      end
-    end
 
-    context "when workflow found (bitrise)" do
-      let(:ci_ref) { Faker::Internet.uuid }
-
-      before do
-        # TODO: Use BitriseIntegration here for actual better testing
-        allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!).and_return({ci_ref:, ci_link:, number:})
-      end
-
-      context "when use build number from workflow is enabled" do
-        # New build number from workflow must be always higher than currently known build number
-        # generated in app
-        let(:number) { (workflow_run.app.build_number + 1).to_s }
-
-        before do
-          workflow_run.app.update(build_number_managed_internally: false)
+          expect(workflow_run.build.build_number).to eq(unique_number)
+          expect(workflow_run.app.build_number.to_s).to eq(unique_number)
         end
 
-        it "updates build number" do
-          expect(workflow_run.build.build_number).to be_nil
-          workflow_run.trigger!
-          expect(workflow_run.build.build_number).to eq(number)
-          expect(workflow_run.app.build_number.to_s).to eq(number)
+        it "fails the workflow run if external unique number is not available" do
+          allow_any_instance_of(GithubIntegration).to receive(:trigger_workflow_run!).and_return({ci_ref:, ci_link:, number:, unique_number: nil})
+
+          expect {
+            workflow_run.trigger!
+          }.to raise_error(WorkflowRun::ExternalUniqueNumberNotFound)
         end
       end
     end


### PR DESCRIPTION
Case:

Bitrise - external_id = UUID, external_number = number but unique per run irrespective of workflow

Github - external_id = increasing number irrespective of workflow, external_number = number but grouped by workflow (starts at #1 for each workflow)