### PR TITLE
Misc submission form issues

### DIFF
--- a/app/controllers/config/release_platforms_controller.rb
+++ b/app/controllers/config/release_platforms_controller.rb
@@ -1,6 +1,7 @@
 class Config::ReleasePlatformsController < SignedInApplicationController
   include Tabbable
   using RefinedString
+  ConfigUpdater = WebHandlers::UpdateReleasePlatformConfig
 
   before_action :require_write_access!, only: %i[update]
   before_action :set_train, only: %i[edit update refresh_workflows]
@@ -18,10 +19,13 @@ class Config::ReleasePlatformsController < SignedInApplicationController
   end
 
   def update
-    if @config.update(update_config_params)
+    updater = ConfigUpdater.new(@config, config_params, @submission_types, @ci_actions, @release_platform)
+
+    if updater.call
       redirect_to update_redirect_path, notice: t(".success")
     else
-      redirect_to update_redirect_path, flash: {error: @config.errors.full_messages.to_sentence}
+      error_message = updater.errors.full_messages.to_sentence
+      redirect_to update_redirect_path, flash: {error: error_message.presence || "Failed to update configuration."}
     end
   end
 
@@ -90,90 +94,6 @@ class Config::ReleasePlatformsController < SignedInApplicationController
         parameters_attributes: [:id, :name, :value, :_destroy]
       ]
     )
-  end
-
-  # Parse form params and delete parents as necessary
-  def update_config_params
-    permitted_params = config_params
-    internal_enabled = permitted_params[:internal_release_enabled] == "true"
-    beta_enabled = permitted_params[:beta_release_submissions_enabled] == "true"
-    prod_enabled = permitted_params[:production_release_enabled] == "true"
-
-    if !internal_enabled && permitted_params[:internal_release_attributes].present?
-      set_destroy!(permitted_params[:internal_release_attributes])
-      set_destroy!(permitted_params[:internal_workflow_attributes])
-    end
-
-    if !beta_enabled && permitted_params[:beta_release_attributes].present?
-      permitted_params[:beta_release_attributes][:submissions_attributes]&.each do |_, submission|
-        set_destroy!(submission)
-        set_destroy!(submission[:submission_external_attributes])
-      end
-    end
-
-    if !prod_enabled && permitted_params[:production_release_attributes].present?
-      set_destroy!(permitted_params[:production_release_attributes])
-    end
-
-    parse_config_params(permitted_params)
-  end
-
-  def parse_config_params(permitted_params)
-    update_workflow_name(permitted_params[:internal_workflow_attributes])
-    update_workflow_name(permitted_params[:release_candidate_workflow_attributes])
-    update_submission_params(permitted_params[:internal_release_attributes])
-    update_submission_params(permitted_params[:beta_release_attributes])
-    update_production_release_rollout_stages(permitted_params[:production_release_attributes]) if @release_platform.android? && permitted_params[:production_release_attributes].present?
-
-    permitted_params
-  end
-
-  def update_workflow_name(workflow_attributes)
-    if workflow_attributes&.dig(:identifier).present?
-      workflow_attributes[:name] = find_workflow_name(workflow_attributes[:identifier])
-    end
-  end
-
-  def update_submission_params(release_attributes)
-    if release_attributes.present?
-      release_attributes[:submissions_attributes]&.each do |_, submission|
-        variant = @submission_types[:variants].find { |v| v[:id] == submission[:integrable_id] }
-        submission[:integrable_type] = variant[:type]
-
-        ext_sub = find_submission(submission, variant)
-        if ext_sub.present?
-          submission[:submission_external_attributes][:name] = ext_sub[:name]
-          submission[:submission_external_attributes][:internal] = ext_sub[:is_internal]
-        end
-      end
-    end
-  end
-
-  def update_production_release_rollout_stages(production_release_attributes)
-    submission_attributes = production_release_attributes[:submissions_attributes]["0"]
-    if production_release_attributes.present? && submission_attributes[:rollout_enabled] == "true"
-      submission_attributes[:rollout_stages] = submission_attributes[:rollout_stages].safe_csv_parse(coerce_float: true)
-    else
-      submission_attributes[:finish_rollout_in_next_release] = false
-    end
-  end
-
-  def find_workflow_name(identifier)
-    @ci_actions.find { |action| action[:id] == identifier }&.dig(:name)
-  end
-
-  def find_submission(submission, variant)
-    return if variant.blank?
-    identifier = submission.dig(:submission_external_attributes, :identifier)
-    return unless identifier
-
-    variant[:submissions].find { |type| type[:type].to_s == submission[:submission_type].to_s }
-      &.then { |sub| sub.dig(:channels) }
-      &.then { |channels| channels.find { |channel| channel[:id].to_s == identifier } }
-  end
-
-  def set_destroy!(param)
-    param[:_destroy] = "1"
   end
 
   def update_redirect_path

--- a/app/libs/web_handlers/update_release_platform_config.rb
+++ b/app/libs/web_handlers/update_release_platform_config.rb
@@ -1,0 +1,178 @@
+class WebHandlers::UpdateReleasePlatformConfig
+  using RefinedString
+
+  def initialize(config, params, submission_types, ci_actions, release_platform)
+    @config = config
+    @original_params = params.deep_dup
+    @submission_types = submission_types
+    @ci_actions = ci_actions
+    @release_platform = release_platform
+    @processed_params = nil
+    @internal_submission_order_map = {}
+    @beta_submission_order_map = {}
+    @internal_submissions_relation = config.internal_release&.submissions
+    @beta_submissions_relation = config.beta_release&.submissions
+    @errors = ActiveModel::Errors.new(self)
+  end
+
+  attr_reader :config, :errors
+
+  def call
+    self.processed_params = original_params
+
+    ActiveRecord::Base.transaction do
+      handle_conditional_destruction
+      enrich_workflow_data
+      enrich_submission_data
+      reorder_submission_data
+      enrich_production_data
+
+      # @config.errors.merge!(service.errors) # Uncomment if form re-renders and needs errors
+      config.update!(processed_params)
+    end
+
+    errors.empty?
+  rescue ActiveRecord::RecordInvalid => e
+    copy_errors_from(e.record)
+    false
+  rescue => e
+    Rails.logger.error("UpdateReleasePlatformConfigService failed: #{e.message}\n#{e.backtrace.join("\n")}")
+    errors.add(:base, "An unexpected error occurred: #{e.message}")
+    false
+  end
+
+  private
+
+  attr_reader :original_params, :submission_types, :ci_actions, :release_platform
+  attr_accessor :processed_params, :internal_submission_order_map, :beta_submission_order_map
+
+  def handle_conditional_destruction
+    internal_enabled = original_params[:internal_release_enabled] == "true"
+    beta_enabled = original_params[:beta_release_submissions_enabled] == "true"
+    prod_enabled = original_params[:production_release_enabled] == "true"
+
+    if !internal_enabled && processed_params[:internal_release_attributes].present?
+      set_destroy!(processed_params[:internal_release_attributes])
+      set_destroy!(processed_params[:internal_workflow_attributes]) if processed_params[:internal_workflow_attributes]
+    end
+
+    if !beta_enabled && processed_params[:beta_release_attributes].present?
+      processed_params[:beta_release_attributes][:submissions_attributes]&.each do |_, submission|
+        set_destroy!(submission)
+        set_destroy!(submission[:submission_external_attributes]) if submission[:submission_external_attributes]
+      end
+    end
+
+    if !prod_enabled && processed_params[:production_release_attributes].present?
+      set_destroy!(processed_params[:production_release_attributes])
+    end
+  end
+
+  def enrich_workflow_data
+    update_workflow_name(processed_params[:internal_workflow_attributes])
+    update_workflow_name(processed_params[:release_candidate_workflow_attributes])
+  end
+
+  def enrich_submission_data
+    update_submissions(processed_params[:internal_release_attributes])
+    update_submissions(processed_params[:beta_release_attributes])
+  end
+
+  def reorder_submission_data
+    reorder_submissions(
+      @internal_submissions_relation&.reload,
+      processed_params&.dig(:internal_release_attributes, :submissions_attributes)
+    )
+
+    reorder_submissions(
+      @beta_submissions_relation&.reload,
+      processed_params&.dig(:beta_release_attributes, :submissions_attributes)
+    )
+  end
+
+  def enrich_production_data
+    prod_attrs = processed_params[:production_release_attributes]
+
+    if release_platform.android? && prod_attrs.present?
+      submission_attrs = prod_attrs[:submissions_attributes]["0"]
+
+      if submission_attrs.present? && submission_attrs[:rollout_enabled] == "true"
+        submission_attrs[:rollout_stages] = submission_attrs[:rollout_stages].safe_csv_parse(coerce_float: true)
+      else
+        submission_attrs[:rollout_stages] = []
+        submission_attrs[:finish_rollout_in_next_release] = false
+      end
+    end
+  end
+
+  def update_submissions(release_attributes)
+    if release_attributes.present?
+      release_attributes[:submissions_attributes]&.each do |_, submission|
+        variant = submission_types[:variants].find { |v| v[:id] == submission[:integrable_id] }
+        submission[:integrable_type] = variant[:type]
+
+        ext_sub = find_submission(submission, variant)
+        if ext_sub.present? && submission[:submission_external_attributes].present?
+          submission[:submission_external_attributes][:name] = ext_sub[:name]
+          submission[:submission_external_attributes][:internal] = ext_sub[:is_internal]
+        end
+      end
+    end
+  end
+
+  def update_workflow_name(workflow_attributes)
+    if workflow_attributes&.dig(:identifier).present?
+      workflow_attributes[:name] = find_workflow_name(workflow_attributes[:identifier])
+    end
+  end
+
+  def find_workflow_name(identifier)
+    ci_actions.find { |action| action[:id] == identifier }&.dig(:name)
+  end
+
+  def find_submission(submission, variant)
+    return nil if variant.blank?
+    identifier = submission.dig(:submission_external_attributes, :identifier)
+    return nil unless identifier
+
+    variant[:submissions].find { |type| type[:type].to_s == submission[:submission_type].to_s }
+      &.then { |sub| sub.dig(:channels) }
+      &.then { |channels| channels.find { |channel| channel[:id].to_s == identifier } }
+  end
+
+  def set_destroy!(param)
+    param[:_destroy] = "1" if param.present?
+  end
+
+  def reorder_submissions(existing_submissions_relation, submissions_attributes)
+    return if existing_submissions_relation.blank? || submissions_attributes.blank?
+    existing_submissions = existing_submissions_relation.index_by(&:id)
+
+    sorted_submissions =
+      submissions_attributes
+        .to_h
+        .reject { |_, attrs| attrs["_destroy"] == "1" }
+        .sort_by { |_, attrs| attrs["number"].to_i }
+
+    # set all existing submissions to temporary negative numbers to avoid conflicts
+    existing_submissions.each do |_, submission|
+      submission.update(number: -submission.number)
+    end
+
+    # update both params and DB with new sequential numbers
+    sorted_submissions.each_with_index do |(_, submission_attrs), index|
+      new_number = index + 1
+      submission_attrs["number"] = new_number.to_s
+
+      if submission_attrs["id"].present? && (existing_submission = existing_submissions[submission_attrs["id"].to_i])
+        existing_submission.update(:number, new_number)
+      end
+    end
+  end
+
+  def copy_errors_from(record)
+    record.errors.full_messages.each do |msg|
+      errors.add(:base, msg) unless errors.messages_for(:base).include?(msg)
+    end
+  end
+end

--- a/app/views/config/release_platforms/_pre_prod_release_form.html.erb
+++ b/app/views/config/release_platforms/_pre_prod_release_form.html.erb
@@ -20,13 +20,15 @@
             end %>
       </div>
 
+      <% current_submissions = rr.object.submissions %>
+
       <ul data-controller="sortable-list-ext list-position"
           data-sortable-list-ext-handle-value=".handle"
           data-sortable-list-ext-list-position-outlet="#<%= release_type %>_submissions"
-          data-list-position-initial-value=1
+          data-list-position-initial-value="<%= current_submissions[0]&.number || 1 %>"
           class="flex flex-col item-gap-default"
           id="<%= release_type %>_submissions">
-        <% rr.object.submissions.each_with_index do |submission, _index| %>
+        <% current_submissions.each_with_index do |submission, _index| %>
           <li class="nested-form-wrapper" data-new-record="false">
             <% rr.fields_for :submissions, submission do |submission_form| %>
               <%= render "submissions_form", form: submission_form, submission_types: submission_types %>


### PR DESCRIPTION
### Problems

The form to configure workflows/submissions is quite complicated and has a few subtle bugs:

1. Reordering issues when positional indexes get reused
2. Disabling step sometimes don't correctly destroy the underlying submissions

### This addresses

- Move the logic to a service object (web_handlers) so that it can be easily tested
- Correctly reorder submissions and update the entire tree in a transaction