### PR TITLE
Slack notification fixes improvements

### DIFF
--- a/app/components/live_release/overview_component.html.erb
+++ b/app/components/live_release/overview_component.html.erb
@@ -45,8 +45,16 @@
         <% if continuous_backmerge? %>
           <% component.with_data_set(title: "Backmerges").with_content(backmerge_summary) %>
         <% end %>
-        <% if release.release_specific_channel_name.present? %>
-          <% component.with_data_set(title: "Notification channel").with_content(release.release_specific_channel_name) %>
+      <% end %>
+
+      <% if release.release_specific_channel_name.present? %>
+        <% component.with_data_set(title: "Notification channel") do %>
+          <div class="inline-flex items-center">
+            <a href="<%= release.release_specific_channel_deep_link %>">
+              <%= render IconComponent.new("integrations/logo_#{release.notification_provider}.png", size: :md, classes: "mr-1") %>
+              <%= release.release_specific_channel_name %>
+            </a>
+          </div>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/live_release/overview_component.html.erb
+++ b/app/components/live_release/overview_component.html.erb
@@ -50,10 +50,7 @@
       <% if release.release_specific_channel_name.present? %>
         <% component.with_data_set(title: "Notification channel") do %>
           <div class="inline-flex items-center">
-            <a href="<%= release.release_specific_channel_deep_link %>">
-              <%= render IconComponent.new("integrations/logo_#{release.notification_provider}.png", size: :md, classes: "mr-1") %>
-              <%= release.release_specific_channel_name %>
-            </a>
+            <%= render partial: "shared/release_specific_notification_channel", locals: {release:} %>
           </div>
         <% end %>
       <% end %>

--- a/app/components/notification_settings_component.html.erb
+++ b/app/components/notification_settings_component.html.erb
@@ -13,7 +13,7 @@
         <% row.with_cell do %>
           <% if setting.active? %>
             <div class="flex overflow-x-hidden hover:overflow-x-auto gap-x-3">
-              <% if @train.notifications_release_specific_channel_enabled? && setting.release_specific_channel_allowed? %>
+              <% if setting.release_specific_channel_allowed? %>
                 <div class="inline-flex items-center">
                   <%= render IconComponent.new("integrations/logo_#{setting.notification_provider}.png", size: :md, classes: "mr-1") %>
                   <%= helpers.release_specific_channel_pattern(app) %>

--- a/app/components/notification_settings_component.html.erb
+++ b/app/components/notification_settings_component.html.erb
@@ -13,16 +13,18 @@
         <% row.with_cell do %>
           <% if setting.active? %>
             <div class="flex overflow-x-hidden hover:overflow-x-auto gap-x-3">
-              <% setting.notification_channels&.each do |channel| %>
+              <% if @train.notifications_release_specific_channel_enabled? && setting.release_specific_channel_allowed? %>
                 <div class="inline-flex items-center">
                   <%= render IconComponent.new("integrations/logo_#{setting.notification_provider}.png", size: :md, classes: "mr-1") %>
-
-                  <% if @train.notifications_release_specific_channel_enabled? && setting.release_specific_channel_allowed? %>
-                    <%= helpers.release_specific_channel_pattern(app) %>
-                  <% else %>
-                    <%= channel["name"] %>
-                  <% end %>
+                  <%= helpers.release_specific_channel_pattern(app) %>
                 </div>
+              <% else %>
+                <% setting.notification_channels&.each do |channel| %>
+                  <div class="inline-flex items-center">
+                    <%= render IconComponent.new("integrations/logo_#{setting.notification_provider}.png", size: :md, classes: "mr-1") %>
+                    <%= channel["name"] %>
+                  </div>
+                <% end %>
               <% end %>
             </div>
           <% end %>

--- a/app/components/release_overview_component.html.erb
+++ b/app/components/release_overview_component.html.erb
@@ -58,6 +58,16 @@
                 <%= render Reldex::StatusComponent.new(release:, reldex_score: reldex) %>
               <% end %>
             <% end %>
+            <% if release.release_specific_channel_name.present? %>
+              <% component.with_data_set(title: "Notification channel") do %>
+                <div class="inline-flex items-center">
+                  <a href="<%= release.release_specific_channel_deep_link %>">
+                    <%= render IconComponent.new("integrations/logo_#{release.notification_provider}.png", size: :md, classes: "mr-1") %>
+                    <%= release.release_specific_channel_name %>
+                  </a>
+                </div>
+              <% end %>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/app/components/release_overview_component.html.erb
+++ b/app/components/release_overview_component.html.erb
@@ -61,10 +61,7 @@
             <% if release.release_specific_channel_name.present? %>
               <% component.with_data_set(title: "Notification channel") do %>
                 <div class="inline-flex items-center">
-                  <a href="<%= release.release_specific_channel_deep_link %>">
-                    <%= render IconComponent.new("integrations/logo_#{release.notification_provider}.png", size: :md, classes: "mr-1") %>
-                    <%= release.release_specific_channel_name %>
-                  </a>
+                  <%= render partial: "shared/release_specific_notification_channel", locals: {release:} %>
                 </div>
               <% end %>
             <% end %>

--- a/app/libs/coordinators/setup_release_specific_channel.rb
+++ b/app/libs/coordinators/setup_release_specific_channel.rb
@@ -16,19 +16,29 @@ class Coordinators::SetupReleaseSpecificChannel
   def call
     return unless train.notifications_release_specific_channel_enabled?
 
-    channel_name =
-      if app.cross_platform?
-        "release-#{app.name}-#{release.release_version}"
-      else
-        "release-#{app.name}-#{app.platform}-#{release.release_version}"
-      end
+    notification_channel = nil
+
+    5.times do |attempt|
+      notification_channel = notification_provider.create_channel!(channel_name(attempt))
+      break
+    rescue Installations::Error => e
+      # We will try in loop only if name_taken is the error, not in other cases
+      break unless e.reason == "name_taken"
+    end
+
+    # Use the default notification channel if we did not receive a new channel
+    release.set_notification_channel!(notification_channel.presence || train.notification_channel)
+    notification_settings.release_specific_channel_allowed.update(notification_channels: [notification_channel])
+  end
+
+  def channel_name(attempt)
+    name = "release-#{app.name}"
+    name << "-#{app.platform}" unless app.cross_platform?
+    name << "-#{release.release_version}"
+    name << "-#{attempt}" if attempt > 0
 
     # Slack validation accepts only
     # letters (lower case), numbers, hyphens and underscores
-    sanitized_channel_name = channel_name.downcase.gsub(/\W/, "-")
-    notification_channel = notification_provider.create_channel!(sanitized_channel_name)
-
-    release.set_notification_channel!(notification_channel)
-    notification_settings.release_specific_channel_allowed.update(notification_channels: [notification_channel])
+    name.downcase.gsub(/\W/, "-")
   end
 end

--- a/app/libs/coordinators/setup_release_specific_channel.rb
+++ b/app/libs/coordinators/setup_release_specific_channel.rb
@@ -15,28 +15,16 @@ class Coordinators::SetupReleaseSpecificChannel
 
   def call
     return unless train.notifications_release_specific_channel_enabled?
-
-    notification_channel = nil
-
-    5.times do |attempt|
-      notification_channel = notification_provider.create_channel!(channel_name(attempt))
-      break
-    rescue Installations::Error => e
-      # We will try in loop only if name_taken is the error, not in other cases
-      break unless e.reason == "name_taken"
-    end
-
     # Use the default notification channel if we did not receive a new channel
-    release.set_notification_channel!(notification_channel.presence || train.notification_channel)
+    notification_channel = notification_provider.create_channel!(channel_name) || train.notification_channel
+    release.set_notification_channel!(notification_channel)
     notification_settings.release_specific_channel_allowed.update(notification_channels: [notification_channel])
   end
 
-  def channel_name(attempt)
+  def channel_name
     name = "release-#{app.name}"
     name << "-#{app.platform}" unless app.cross_platform?
     name << "-#{release.release_version}"
-    name << "-#{attempt}" if attempt > 0
-
     # Slack validation accepts only
     # letters (lower case), numbers, hyphens and underscores
     name.downcase.gsub(/\W/, "-")

--- a/app/libs/installations/slack/api.rb
+++ b/app/libs/installations/slack/api.rb
@@ -107,8 +107,13 @@ module Installations
       }
 
       execute(:post, CREATE_CHANNEL_URL, params)
-        .then { |response| Installations::Response::Keys.transform([response["channel"]], transforms) }
-        .first
+        .then { |response|
+          if response["ok"]
+            Installations::Response::Keys.transform([response["channel"]], transforms)
+          else
+            raise Error.new("Slack API - Error creating channel", reason: response["error"])
+          end
+        }.first
     end
 
     def list_channels(transforms, cursor = nil)

--- a/app/libs/installations/slack/api.rb
+++ b/app/libs/installations/slack/api.rb
@@ -106,14 +106,13 @@ module Installations
         }
       }
 
-      execute(:post, CREATE_CHANNEL_URL, params)
-        .then { |response|
-          if response["ok"]
-            Installations::Response::Keys.transform([response["channel"]], transforms)
-          else
-            raise Error.new("Slack API - Error creating channel", reason: response["error"])
-          end
-        }.first
+      execute(:post, CREATE_CHANNEL_URL, params).then do |response|
+        if response["ok"]
+          Installations::Response::Keys.transform([response["channel"]], transforms)
+        else
+          raise Error.new("Slack API - Error creating channel", reason: response["error"])
+        end
+      end.first
     end
 
     def list_channels(transforms, cursor = nil)

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -81,12 +81,12 @@ class NotificationSetting < ApplicationRecord
   end
 
   def release_specific_channel_allowed?
-    !kind.to_sym.in?(RELEASE_SPECIFIC_CHANNELS_NOT_ALLOWED_KINDS)
+    train.notifications_release_specific_channel_enabled? &&
+      !kind.to_sym.in?(RELEASE_SPECIFIC_CHANNELS_NOT_ALLOWED_KINDS)
   end
 
   def notification_channels_settings
-    if active? && notification_channels.blank? &&
-        !(train.notifications_release_specific_channel_enabled? && release_specific_channel_allowed?)
+    if active? && notification_channels.blank? && !release_specific_channel_allowed?
       errors.add(:notification_channels, :at_least_one)
     end
   end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -85,7 +85,10 @@ class NotificationSetting < ApplicationRecord
   end
 
   def notification_channels_settings
-    errors.add(:notification_channels, :at_least_one) if active? && notification_channels.blank?
+    if active? && notification_channels.blank? &&
+        !(train.notifications_release_specific_channel_enabled? && release_specific_channel_allowed?)
+      errors.add(:notification_channels, :at_least_one)
+    end
   end
 
   # rubocop:disable Rails/SkipsModelValidations

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -189,6 +189,10 @@ class Release < ApplicationRecord
     save!
   end
 
+  def release_specific_channel_deep_link
+    notification_provider.channel_deep_link(release_specific_channel_id) if release_specific_channel_id.present?
+  end
+
   def release_specific_channel_name
     notification_channel&.fetch("name")
   end

--- a/app/models/slack_integration.rb
+++ b/app/models/slack_integration.rb
@@ -57,8 +57,8 @@ class SlackIntegration < ApplicationRecord
   DEPLOY_MESSAGE = "A wild new release has appeared!"
   CACHE_EXPIRY = 1.month
   CODE_SNIPPET_CHARACTER_LIMIT = 3500
-
-  HANDLED_SLACK_ERRORS = ["name_taken"]
+  MAX_RETRY_ATTEMPTS = 3
+  RETRYABLE_ERRORS = ["name_taken"]
 
   def controllable_rollout?
     false
@@ -146,15 +146,11 @@ class SlackIntegration < ApplicationRecord
   end
 
   def create_channel!(name)
-    installation.create_channel(CREATE_CHANNEL_TRANSFORMATIONS, name)
-  rescue Installations::Error => e
-    if e.reason.in?(HANDLED_SLACK_ERRORS)
-      raise
-    else
-      elog(e, level: :warn)
+    execute_with_retry do |attempt|
+      channel_name = name
+      channel_name = "#{name}-#{attempt}" if attempt > 0
+      installation.create_channel(CREATE_CHANNEL_TRANSFORMATIONS, channel_name)
     end
-  rescue => e
-    elog(e, level: :warn)
   end
 
   def notifier(type, params)
@@ -198,6 +194,20 @@ class SlackIntegration < ApplicationRecord
   end
 
   private
+
+  def execute_with_retry(attempt: 0, &)
+    yield(attempt)
+  rescue Installations::Error => ex
+    elog(ex, level: :warn)
+    return if attempt >= MAX_RETRY_ATTEMPTS
+    next_attempt = attempt + 1
+
+    if RETRYABLE_ERRORS.include?(ex.reason)
+      execute_with_retry(attempt: next_attempt, &)
+    end
+  rescue => ex
+    elog(ex, level: :warn)
+  end
 
   def get_all_channels(cursor = nil, channels = [])
     resp = installation.list_channels(CHANNELS_TRANSFORMATIONS, cursor)

--- a/app/models/slack_integration.rb
+++ b/app/models/slack_integration.rb
@@ -58,6 +58,8 @@ class SlackIntegration < ApplicationRecord
   CACHE_EXPIRY = 1.month
   CODE_SNIPPET_CHARACTER_LIMIT = 3500
 
+  HANDLED_SLACK_ERRORS = ["name_taken"]
+
   def controllable_rollout?
     false
   end
@@ -145,6 +147,12 @@ class SlackIntegration < ApplicationRecord
 
   def create_channel!(name)
     installation.create_channel(CREATE_CHANNEL_TRANSFORMATIONS, name)
+  rescue Installations::Error => e
+    if e.reason.in?(HANDLED_SLACK_ERRORS)
+      raise
+    else
+      elog(e, level: :warn)
+    end
   rescue => e
     elog(e, level: :warn)
   end

--- a/app/models/slack_integration.rb
+++ b/app/models/slack_integration.rb
@@ -193,6 +193,10 @@ class SlackIntegration < ApplicationRecord
     nil
   end
 
+  def channel_deep_link(channel_id)
+    "slack://channel?team=#{integration.metadata["id"]}&id=#{channel_id}"
+  end
+
   private
 
   def get_all_channels(cursor = nil, channels = [])

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -10,7 +10,7 @@
                                            switch_id: "active-switch-#{@setting.id}",
                                            on_label: "Notifications enabled",
                                            off_label: "Notifications disabled") do |switch| %>
-        <% if @train.notifications_release_specific_channel_enabled? && @setting.release_specific_channel_allowed? %>
+        <% if @setting.release_specific_channel_allowed? %>
           <% switch.with_child do %>
             <p class="text-slate-700 text-sm">
               Turn off release-specific channels in train settings to customize channels per notification kind.

--- a/app/views/shared/_release_specific_notification_channel.html.erb
+++ b/app/views/shared/_release_specific_notification_channel.html.erb
@@ -1,0 +1,6 @@
+<%# locals: (release:) %>
+
+<%= link_to_external release.release_specific_channel_deep_link, class: "underline" do %>
+  <%= render IconComponent.new("integrations/logo_#{release.notification_provider}.png", size: :md, classes: "mr-1") %>
+  <%= release.release_specific_channel_name + " ↗" %>
+<% end %>

--- a/spec/libs/coordinators/setup_release_specific_channel_spec.rb
+++ b/spec/libs/coordinators/setup_release_specific_channel_spec.rb
@@ -28,22 +28,6 @@ RSpec.describe Coordinators::SetupReleaseSpecificChannel do
       expect(slack).to have_received(:create_channel!).with(release_channel_name)
     end
 
-    context "when slack integration raises name_taken error" do
-      before do
-        allow(slack).to receive(:create_channel!).and_raise(Installations::Error.new("Name taken error", reason: "name_taken"))
-      end
-
-      it "attempts to create channel again" do
-        described_class.call(release)
-        expect(slack).to have_received(:create_channel!).with(release_channel_name.concat("-1"))
-      end
-
-      it "updates notification channel to default channel" do
-        described_class.call(release)
-        expect(release.reload.release_specific_channel_name).to eq(default_notification_channel[:name])
-      end
-    end
-
     it "updates notification channel in release" do
       described_class.call(release)
       expect(release.reload.release_specific_channel_name).to eq(release_channel_name)
@@ -60,6 +44,12 @@ RSpec.describe Coordinators::SetupReleaseSpecificChannel do
       described_class.call(release)
       notification_channels = train.notification_settings.release_specific_channel_not_allowed.pluck(:notification_channels)
       expect(notification_channels).to all(contain_exactly(default_notification_channel.as_json))
+    end
+
+    it "updates notification channel to default channel if create channel fails" do
+      allow(slack).to receive(:create_channel!).and_return(nil)
+      described_class.call(release)
+      expect(release.reload.release_specific_channel_name).to eq(default_notification_channel[:name])
     end
   end
 

--- a/spec/libs/installations/slack/api_spec.rb
+++ b/spec/libs/installations/slack/api_spec.rb
@@ -44,22 +44,42 @@ describe Installations::Slack::Api, type: :integration do
   describe "#create_channel" do
     let(:channel_name) { Faker::Alphanumeric.alphanumeric(number: 10) }
 
-    before do
-      allow_any_instance_of(described_class).to receive(:execute).and_return(
-        {
-          "ok" => true,
-          "channel" => {
-            "id" => "C08PWJT7YJ2",
-            "name" => channel_name,
-            "is_private" => false
+    context "when channel does not exist" do
+      before do
+        allow_any_instance_of(described_class).to receive(:execute).and_return(
+          {
+            "ok" => true,
+            "channel" => {
+              "id" => "C08PWJT7YJ2",
+              "name" => channel_name,
+              "is_private" => false
+            }
           }
-        }
-      )
+        )
+      end
+
+      it "returns transformed response" do
+        response = described_class.new(access_token).create_channel(SlackIntegration::CREATE_CHANNEL_TRANSFORMATIONS, channel_name)
+        expect(response).to include({id: "C08PWJT7YJ2", name: channel_name, is_private: false})
+      end
     end
 
-    it "returns transformed response" do
-      response = described_class.new(access_token).create_channel(SlackIntegration::CHANNELS_TRANSFORMATIONS, channel_name)
-      expect(response).to include({id: "C08PWJT7YJ2", name: channel_name, is_private: false})
+    context "when channel already exists" do
+      before do
+        allow_any_instance_of(described_class).to receive(:execute).and_return(
+          {
+            "ok" => false,
+            "error" => "name_taken"
+          }
+        )
+      end
+
+      it "raises error" do
+        expect { described_class.new(access_token).create_channel(SlackIntegration::CREATE_CHANNEL_TRANSFORMATIONS, channel_name) }
+          .to raise_error (Installations::Error) { |error|
+            expect(error.reason).to eq("name_taken")
+          }
+      end
     end
   end
 end

--- a/spec/libs/installations/slack/api_spec.rb
+++ b/spec/libs/installations/slack/api_spec.rb
@@ -76,7 +76,7 @@ describe Installations::Slack::Api, type: :integration do
 
       it "raises error" do
         expect { described_class.new(access_token).create_channel(SlackIntegration::CREATE_CHANNEL_TRANSFORMATIONS, channel_name) }
-          .to raise_error (Installations::Error) { |error|
+          .to raise_error(Installations::Error) { |error|
             expect(error.reason).to eq("name_taken")
           }
       end

--- a/spec/models/google_firebase_submission_spec.rb
+++ b/spec/models/google_firebase_submission_spec.rb
@@ -109,7 +109,7 @@ describe GoogleFirebaseSubmission do
             create_time: "2024-07-05T23:51:56.539088Z",
             display_version: "10.31.0",
             firebase_console_uri: Faker::Internet.url,
-            name: Faker::String.random(length: 10),
+            name: Faker::Lorem.word,
             release_notes: {text: "NOTES"}
           },
           GoogleFirebaseIntegration::BUILD_TRANSFORMATIONS

--- a/spec/models/slack_integration_spec.rb
+++ b/spec/models/slack_integration_spec.rb
@@ -42,4 +42,38 @@ describe SlackIntegration do
       expect(Rails.cache.read(slack_integration.channels_cache_key)).to contain_exactly("channel-1", "channel-2", "channel-3")
     end
   end
+
+  describe "#create_channel" do
+    let(:integration) { create(:integration, :with_slack) }
+    let(:slack_integration) { integration.providable }
+    let(:api_double) { instance_double(Installations::Slack::Api) }
+    let(:channel_name) { Faker::Lorem.word }
+
+    before do
+      allow(slack_integration).to receive(:installation).and_return(api_double)
+      allow(api_double).to receive(:create_channel)
+    end
+
+    it "creates the channel with the name" do
+      slack_integration.create_channel!(channel_name)
+      expect(api_double).to have_received(:create_channel).with(SlackIntegration::CREATE_CHANNEL_TRANSFORMATIONS, channel_name)
+    end
+
+    context "when slack api raises name_taken error" do
+      before do
+        allow(api_double).to receive(:create_channel).and_raise(Installations::Error.new("Name taken error", reason: "name_taken"))
+      end
+
+      it "attempts to create channel again with an appended name" do
+        slack_integration.create_channel!(channel_name)
+        expect(api_double).to have_received(:create_channel).with(SlackIntegration::CREATE_CHANNEL_TRANSFORMATIONS, channel_name).once
+        expect(api_double).to have_received(:create_channel).with(SlackIntegration::CREATE_CHANNEL_TRANSFORMATIONS, "#{channel_name}-1").once
+        expect(api_double).to have_received(:create_channel).with(SlackIntegration::CREATE_CHANNEL_TRANSFORMATIONS, "#{channel_name}-2").once
+      end
+
+      it "returns nil when no channel is created" do
+        expect(slack_integration.create_channel!(channel_name)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Closes:** https://github.com/orgs/tramlinehq/projects/5?pane=issue&itemId=107732119

## Why

1. Fixes re-enabling notification after disabling it when release-specific-channel is enabled
2. Handles slack channel already exists error
3. Introduces deep link to channel on release overview on main page as well as in live release overview

## This addresses

When channel already exists, it appends a number to it to create a fresh channel. Such attempts will be made 5 times total and if it still fails goes to default notification channel.

![image](https://github.com/user-attachments/assets/5c52624f-5a93-4add-a411-58cbb82a5583)

Deep links

![image](https://github.com/user-attachments/assets/e7242ec4-9023-447f-bb59-76d30e1507db)
![image](https://github.com/user-attachments/assets/2d7084be-3d6b-4cc3-9447-7eda10fb42d5)

