### PR TITLE
Hide previous releases paginator if releases < min count

### DIFF
--- a/app/components/pagination_component.html.erb
+++ b/app/components/pagination_component.html.erb
@@ -1,3 +1,4 @@
+<% if show_paginator? %>
 <div class="sm:flex sm:justify-between sm:items-center mt-2">
   <div class="text-sm justify-center">
     <%== pagy_nav(results, link_extra: "data-turbo-frame='#{turbo_frame}'") %>
@@ -7,3 +8,4 @@
     <%== pagy_info(results) if info? %>
   </div>
 </div>
+<% end %>

--- a/app/components/pagination_component.rb
+++ b/app/components/pagination_component.rb
@@ -10,4 +10,8 @@ class PaginationComponent < ViewComponent::Base
   end
 
   def info? = @info
+
+  def show_paginator?
+    results.count > Pagy::DEFAULT[:gearbox_items].first
+  end
 end

--- a/app/components/release_history_component.html.erb
+++ b/app/components/release_history_component.html.erb
@@ -53,6 +53,4 @@
   <% end %>
 <% end %>
 
-<% if show_previous_releases_paginator? %>
-  <%= render PaginationComponent.new(results: paginator, turbo_frame: "previous_releases", info: true) %>
-<% end %>
+<%= render PaginationComponent.new(results: paginator, turbo_frame: "previous_releases", info: true) %>

--- a/app/components/release_history_component.html.erb
+++ b/app/components/release_history_component.html.erb
@@ -52,4 +52,7 @@
     <% end %>
   <% end %>
 <% end %>
-<%= render PaginationComponent.new(results: paginator, turbo_frame: "previous_releases", info: true) %>
+
+<% if show_previous_releases_paginator? %>
+  <%= render PaginationComponent.new(results: paginator, turbo_frame: "previous_releases", info: true) %>
+<% end %>

--- a/app/components/release_history_component.rb
+++ b/app/components/release_history_component.rb
@@ -23,8 +23,4 @@ class ReleaseHistoryComponent < BaseComponent
   def reldex_defined?
     train.release_index.present?
   end
-
-  def show_previous_releases_paginator?
-    train.previous_releases.size > Pagy::DEFAULT[:gearbox_items].first
-  end
 end

--- a/app/components/release_history_component.rb
+++ b/app/components/release_history_component.rb
@@ -23,4 +23,8 @@ class ReleaseHistoryComponent < BaseComponent
   def reldex_defined?
     train.release_index.present?
   end
+
+  def show_previous_releases_paginator?
+    train.previous_releases.size > Pagy::DEFAULT[:gearbox_items].first
+  end
 end


### PR DESCRIPTION
**Closes:** https://github.com/orgs/tramlinehq/projects/5/views/1?pane=issue&itemId=107786988

## Why

Paginator is not required if number of items is <= what can be shown on a page.

## This addresses

![image](https://github.com/user-attachments/assets/dbedaa4b-4a41-4d64-9290-a59e69b02e3d)
![image](https://github.com/user-attachments/assets/353cdb0c-d7f0-4af3-8c91-62a98634cd8b)

## Scenarios tested

- [x] Paginator does not show up when number of items is <= 10
- [x] Paginator shows up when number of items is more than 10
