### PR TITLE
feat: allow manually skipping scheduled releases

### DIFF
--- a/app/assets/images/circle_arrow_right.svg
+++ b/app/assets/images/circle_arrow_right.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+     stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M8 12h8"/>
+  <path d="m12 16 4-4-4-4"/>
+</svg>

--- a/app/components/scheduled_train_component.html.erb
+++ b/app/components/scheduled_train_component.html.erb
@@ -80,6 +80,7 @@
     <!-- future -->
     <% if future_release.present? %>
       <%= render partial: "scheduled_release/show", locals: {
+            skip_or_resume_button: skip_or_resume_button(future_release),
             header: time_text(future_release),
             title: next_version,
             empty_icon: "calendar.svg",
@@ -88,10 +89,11 @@
             footer: time_format(future_release.scheduled_at, only_day: true)
           } %>
       <%= render partial: "scheduled_release/show", locals: {
+            skip_or_resume_button: nil,
             header: time_text(future_release),
             title: next_next_version,
             empty_icon: "calendar.svg",
-            status: scheduled_release_status(future_release),
+            status: future_release_status,
             box_classes: "opacity-50",
             footer: time_format(next_to_next_run_at, only_day: true)
           } %>

--- a/app/components/scheduled_train_component.rb
+++ b/app/components/scheduled_train_component.rb
@@ -59,8 +59,7 @@ class ScheduledTrainComponent < BaseComponent
       type: :button,
       html_options: {
         method: :patch,
-        data: {turbo_method: :patch,
-               turbo_confirm: confirmation_message}
+        data: {turbo_method: :patch, turbo_confirm: confirmation_message}
       }
     )
 

--- a/app/controllers/scheduled_releases_controller.rb
+++ b/app/controllers/scheduled_releases_controller.rb
@@ -1,0 +1,37 @@
+class ScheduledReleasesController < SignedInApplicationController
+  include Loggable
+
+  before_action :require_write_access!, only: %i[skip resume]
+  before_action :set_train, only: %i[skip resume]
+  before_action :set_scheduled_release, only: %i[skip resume]
+
+  def skip
+    if @scheduled_release.manually_skip
+      redirect_to train_path, notice: t(".success")
+    else
+      train_redirect_back("Could not skip the scheduled release. #{@scheduled_release.errors.full_messages.to_sentence}.")
+    end
+  end
+
+  def resume
+    if @scheduled_release.manually_resume
+      redirect_to train_path, notice: t(".success")
+    else
+      train_redirect_back("Could not resume the skipped scheduled release. #{@scheduled_release.errors.full_messages.to_sentence}.")
+    end
+  end
+
+  private
+
+  def set_train
+    @train = @app.trains.friendly.find(params[:train_id])
+  end
+
+  def set_scheduled_release
+    @scheduled_release = @train.scheduled_releases.find(params[:id])
+  end
+
+  def train_path
+    app_train_releases_path(@app, @train)
+  end
+end

--- a/app/controllers/scheduled_releases_controller.rb
+++ b/app/controllers/scheduled_releases_controller.rb
@@ -9,7 +9,7 @@ class ScheduledReleasesController < SignedInApplicationController
     if @scheduled_release.manually_skip
       redirect_to train_path, notice: t(".success")
     else
-      train_redirect_back("Could not skip the scheduled release. #{@scheduled_release.errors.full_messages.to_sentence}.")
+      train_redirect_back(t(".fail"))
     end
   end
 
@@ -17,7 +17,7 @@ class ScheduledReleasesController < SignedInApplicationController
     if @scheduled_release.manually_resume
       redirect_to train_path, notice: t(".success")
     else
-      train_redirect_back("Could not resume the skipped scheduled release. #{@scheduled_release.errors.full_messages.to_sentence}.")
+      train_redirect_back(t(".fail"))
     end
   end
 
@@ -33,5 +33,9 @@ class ScheduledReleasesController < SignedInApplicationController
 
   def train_path
     app_train_releases_path(@app, @train)
+  end
+
+  def train_redirect_back(message)
+    redirect_back fallback_location: train_path, flash: {error: message}
   end
 end

--- a/app/jobs/release_kickoff_job.rb
+++ b/app/jobs/release_kickoff_job.rb
@@ -4,6 +4,7 @@ class ReleaseKickoffJob < ApplicationJob
   def perform(scheduled_release_id)
     scheduled_release = ScheduledRelease.find_by(id: scheduled_release_id)
     return if scheduled_release.blank?
+    return if scheduled_release.manually_skipped?
     return unless scheduled_release.train.active?
 
     scheduled_release.train.stop_failed_ongoing_release!

--- a/app/jobs/scheduled_release_notification_job.rb
+++ b/app/jobs/scheduled_release_notification_job.rb
@@ -4,6 +4,7 @@ class ScheduledReleaseNotificationJob < ApplicationJob
   def perform(scheduled_release_id)
     scheduled_release = ScheduledRelease.find_by(id: scheduled_release_id)
     return if scheduled_release.blank?
+    return if scheduled_release.manually_skipped?
     return unless scheduled_release.train.active?
 
     scheduled_release.train.notify!("A release is scheduled", :release_scheduled, scheduled_release.notification_params)

--- a/app/models/scheduled_release.rb
+++ b/app/models/scheduled_release.rb
@@ -33,15 +33,21 @@ class ScheduledRelease < ApplicationRecord
   end
 
   def manually_skip
-    update(manually_skipped: true) if skip_or_resume?
+    return if manually_skipped == true
+    return unless skip_or_resume?
+
+    update(manually_skipped: true)
   end
 
   def manually_resume
-    update(manually_skipped: false) if skip_or_resume?
+    return if manually_skipped == false
+    return unless skip_or_resume?
+
+    update(manually_skipped: false)
   end
 
   def skip_or_resume?
-    !is_success? && train.active? && to_be_scheduled?
+    train.active? && to_be_scheduled?
   end
 
   def notification_params

--- a/app/models/scheduled_release.rb
+++ b/app/models/scheduled_release.rb
@@ -2,14 +2,15 @@
 #
 # Table name: scheduled_releases
 #
-#  id             :uuid             not null, primary key
-#  failure_reason :string
-#  is_success     :boolean          default(FALSE)
-#  scheduled_at   :datetime         not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  release_id     :uuid
-#  train_id       :uuid             not null, indexed
+#  id               :uuid             not null, primary key
+#  failure_reason   :string
+#  is_success       :boolean          default(FALSE)
+#  manually_skipped :boolean          default(FALSE)
+#  scheduled_at     :datetime         not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  release_id       :uuid
+#  train_id         :uuid             not null, indexed
 #
 class ScheduledRelease < ApplicationRecord
   has_paper_trail
@@ -31,6 +32,18 @@ class ScheduledRelease < ApplicationRecord
     ScheduledReleaseNotificationJob.set(wait_until: scheduled_at - NOTIFICATION_WINDOW).perform_async(id)
   end
 
+  def manually_skip
+    update(manually_skipped: true) if skip_or_resume?
+  end
+
+  def manually_resume
+    update(manually_skipped: false) if skip_or_resume?
+  end
+
+  def skip_or_resume?
+    !is_success? && train.active? && to_be_scheduled?
+  end
+
   def notification_params
     train.notification_params.merge(
       {
@@ -39,7 +52,11 @@ class ScheduledRelease < ApplicationRecord
     )
   end
 
-  def pending?
+  def to_be_scheduled?
     scheduled_at > Time.current
+  end
+
+  def pending?
+    to_be_scheduled? && !manually_skipped?
   end
 end

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -287,7 +287,6 @@ class Train < ApplicationRecord
 
   def restore_default_notification_settings
     return if notification_channel.blank? || notifications_release_specific_channel_enabled?
-
     notification_settings.release_specific_channel_allowed.update(notification_channels: [notification_channel])
   end
 

--- a/app/views/scheduled_release/_show.html.erb
+++ b/app/views/scheduled_release/_show.html.erb
@@ -1,11 +1,18 @@
-<div class="h-20 sm:h-28 lg:h-32 box-padding <%= box_classes %> text-main-600">
+<%# locals: (skip_or_resume_button: nil, header:, title: nil, status: nil, box_classes: nil, empty_icon:, footer: nil) %>
+
+<div class="h-24 sm:h-28 lg:h-40 box-padding <%= box_classes %> text-main-600">
   <div class="h-full flex flex-col justify-between">
-    <div class="grow flex flex-col gap-y-1 overflow-hidden">
+    <div class="grow flex flex-col gap-2 overflow-hidden">
       <div class="text-secondary font-normal text-sm"><%= header %></div>
+
       <% if title %>
         <div class="heading-2"><%= title %></div>
       <% else %>
         <%= render IconComponent.new(empty_icon, size: :lg, rounded: false, classes: "mt-1") %>
+      <% end %>
+
+      <% if skip_or_resume_button %>
+        <%= render skip_or_resume_button %>
       <% end %>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,10 +218,11 @@ en:
       success: "Approval item was successfully created."
   scheduled_releases:
     resume:
+      fail: "Could not resume the skipped scheduled release."
       success: "Done. The next scheduled release will continue as expected."
     skip:
+      fail: "Could not skip the scheduled release."
       success: "Done. The next scheduled release will be skipped."
-
   activerecord:
     models:
       slack_integration: "Slack"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
           show: "Submission Details"
           new: "Submission New"
           edit: "Submission Edit"
+
   config:
     release_platforms:
       success: "Platform configuration was successfully updated."
@@ -223,6 +224,7 @@ en:
     skip:
       fail: "Could not skip the scheduled release."
       success: "Done. The next scheduled release will be skipped."
+
   activerecord:
     models:
       slack_integration: "Slack"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,7 +78,6 @@ en:
           show: "Submission Details"
           new: "Submission New"
           edit: "Submission Edit"
-
   config:
     release_platforms:
       success: "Platform configuration was successfully updated."
@@ -217,6 +216,11 @@ en:
       failure: "Could not update approval item status. Please try again."
     create:
       success: "Approval item was successfully created."
+  scheduled_releases:
+    resume:
+      success: "Done. The next scheduled release will continue as expected."
+    skip:
+      success: "Done. The next scheduled release will be skipped."
 
   activerecord:
     models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,13 @@ Rails.application.routes.draw do
         patch :deactivate
       end
 
+      resources :scheduled_releases do
+        member do
+          patch :skip
+          patch :resume
+        end
+      end
+
       resource :release_index, only: %i[edit update]
       resources :notification_settings, only: %i[index update edit]
 

--- a/db/migrate/20250507091951_add_manually_skipped_to_scheduled_releases.rb
+++ b/db/migrate/20250507091951_add_manually_skipped_to_scheduled_releases.rb
@@ -1,0 +1,5 @@
+class AddManuallySkippedToScheduledReleases < ActiveRecord::Migration[7.2]
+  def change
+    add_column :scheduled_releases, :manually_skipped, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_30_150508) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_07_091951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -753,6 +753,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_30_150508) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "release_id"
+    t.boolean "manually_skipped", default: false
     t.index ["train_id"], name: "index_scheduled_releases_on_train_id"
   end
 

--- a/spec/factories/scheduled_releases.rb
+++ b/spec/factories/scheduled_releases.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :scheduled_release do
+    train
+    release
+    is_success { false }
+    manually_skipped { false }
+    scheduled_at { Time.current }
+  end
+end

--- a/spec/jobs/release_kickoff_job_spec.rb
+++ b/spec/jobs/release_kickoff_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ReleaseKickoffJob do
+  let(:train) { create(:train, :active) }
+  let(:release) { create(:release, train:) }
+
+  it "kicks off the release" do
+    allow(Coordinators::Actions).to receive(:start_release!).and_return(GitHub::Result.new)
+    scheduled_release = create(:scheduled_release, train:, release:)
+
+    described_class.new.perform(scheduled_release.id)
+
+    expect(Coordinators::Actions).to have_received(:start_release!).with(scheduled_release.train, automatic: true)
+  end
+
+  it "skips starting the release if it was manually skipped" do
+    allow(Coordinators::Actions).to receive(:start_release!).and_return(GitHub::Result.new)
+    scheduled_release = create(:scheduled_release, train: release.train, release:, manually_skipped: true)
+
+    described_class.new.perform(scheduled_release.id)
+
+    expect(Coordinators::Actions).not_to have_received(:start_release!)
+  end
+end

--- a/spec/jobs/scheduled_release_notification_job_spec.rb
+++ b/spec/jobs/scheduled_release_notification_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ScheduledReleaseNotificationJob do
+  let(:train) { create(:train, :active) }
+  let(:release) { create(:release, train:) }
+
+  it "sends a notification" do
+    scheduled_release = create(:scheduled_release, train:, release:)
+    allow(ScheduledRelease).to receive(:find_by).with(id: scheduled_release.id).and_return(scheduled_release)
+    allow(scheduled_release.train).to receive(:notify!)
+
+    described_class.new.perform(scheduled_release.id)
+
+    expect(scheduled_release.train).to have_received(:notify!).with(
+      "A release is scheduled",
+      :release_scheduled,
+      scheduled_release.notification_params
+    )
+  end
+
+  it "does not send a notification when scheduled release was manually skipped" do
+    scheduled_release = create(:scheduled_release, train:, release:, manually_skipped: true)
+    allow(ScheduledRelease).to receive(:find_by).with(id: scheduled_release.id).and_return(scheduled_release)
+    allow(scheduled_release.train).to receive(:notify!)
+
+    described_class.new.perform(scheduled_release.id)
+
+    expect(scheduled_release.train).not_to have_received(:notify!)
+  end
+
+  it "does not send a notification when train is inactive" do
+    inactive_train = create(:train, :inactive)
+    scheduled_release = create(:scheduled_release, train: inactive_train, release:)
+    allow(ScheduledRelease).to receive(:find_by).with(id: scheduled_release.id).and_return(scheduled_release)
+    allow(inactive_train).to receive(:notify!)
+
+    described_class.new.perform(scheduled_release.id)
+
+    expect(inactive_train).not_to have_received(:notify!)
+  end
+end

--- a/spec/models/scheduled_release_spec.rb
+++ b/spec/models/scheduled_release_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ScheduledRelease do
+  let(:train) { create(:train, :active) }
+
+  describe "#manually_skip" do
+    it "marks the release as manually_skipped" do
+      scheduled_at = Time.current
+
+      travel_to scheduled_at - 1.hour do
+        scheduled_release = create(:scheduled_release, train:, scheduled_at:, manually_skipped: false)
+
+        scheduled_release.manually_skip
+
+        expect(scheduled_release.manually_skipped?).to be true
+      end
+    end
+
+    it "does not mark the release as manually_skipped if its schedule time is in the past" do
+      scheduled_at = Time.current
+
+      travel_to scheduled_at + 1.hour do
+        scheduled_release = create(:scheduled_release, train:, scheduled_at:, manually_skipped: false)
+
+        scheduled_release.manually_skip
+
+        expect(scheduled_release.manually_skipped?).to be false
+      end
+    end
+  end
+
+  describe "#manually_resume" do
+    it "marks manually_skipped to be false" do
+      scheduled_at = Time.current
+
+      travel_to scheduled_at - 1.hour do
+        scheduled_release = create(:scheduled_release, train:, scheduled_at:, manually_skipped: true)
+
+        scheduled_release.manually_resume
+
+        expect(scheduled_release.manually_skipped?).to be false
+      end
+    end
+
+    it "does not modify the manually_skipped setting if its schedule time is in the past" do
+      scheduled_at = Time.current
+
+      travel_to scheduled_at + 1.hour do
+        scheduled_release = create(:scheduled_release, scheduled_at:, manually_skipped: true)
+
+        scheduled_release.manually_resume
+
+        expect(scheduled_release.manually_skipped?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why

Allow manually skipping the next scheduled release. This is helpful for users to add new work before the cutoff time or change major version and release manually. This does not affect the scheduling for the future release. Only the one particular scheduled release (the upcoming one).

## This addresses

Adds a skip/resume button to the next / upcoming scheduled release.

**Skip**
<img width="1518" alt="Screenshot 2025-05-07 at 10 54 12 PM" src="https://github.com/user-attachments/assets/2dcb36d9-6b55-47df-9c39-cffe139e3f4b" />

**Resume**
<img width="1483" alt="Screenshot 2025-05-07 at 10 53 42 PM" src="https://github.com/user-attachments/assets/7e9ad0c7-6851-4555-bd8e-b0cc6d1c631a" />

**Skipped, previously**
<img width="1547" alt="Screenshot 2025-05-07 at 11 06 28 PM" src="https://github.com/user-attachments/assets/16d72195-118b-4f20-beda-b970ef94c116" />

## Scenarios tested

- [x] Skip/resume works and the release does not get scheduled
- [x] The actions fail when the release is stale and is already complete or when the train is inactive
- [x] Deactivating the train resets the manually skipped status