### PR TITLE
Allow multiple channels along with release-specific channels

### DIFF
--- a/app/components/notification_settings_component.html.erb
+++ b/app/components/notification_settings_component.html.erb
@@ -1,5 +1,5 @@
 <% if enabled? %>
-  <%= render TableComponent.new(columns: ["kind", "channels", "status", ""]) do |table| %>
+  <%= render TableComponent.new(columns: ["kind", "channels", "status", "status (release-specific)"]) do |table| %>
     <% display_settings.each do |setting| %>
       <% setting = notification_setting_component(setting) %>
       <% table.with_row do |row| %>
@@ -13,18 +13,11 @@
         <% row.with_cell do %>
           <% if setting.active? %>
             <div class="flex overflow-x-hidden hover:overflow-x-auto gap-x-3">
-              <% if setting.release_specific_channel_allowed? %>
+              <% setting.notification_channels(include_release_specific: false)&.each do |channel| %>
                 <div class="inline-flex items-center">
                   <%= render IconComponent.new("integrations/logo_#{setting.notification_provider}.png", size: :md, classes: "mr-1") %>
-                  <%= helpers.release_specific_channel_pattern(app) %>
+                  <%= channel["name"] %>
                 </div>
-              <% else %>
-                <% setting.notification_channels&.each do |channel| %>
-                  <div class="inline-flex items-center">
-                    <%= render IconComponent.new("integrations/logo_#{setting.notification_provider}.png", size: :md, classes: "mr-1") %>
-                    <%= channel["name"] %>
-                  </div>
-                <% end %>
               <% end %>
             </div>
           <% end %>
@@ -32,6 +25,10 @@
 
         <% row.with_cell do %>
           <%= render setting.status_pill %>
+        <% end %>
+
+        <% row.with_cell do %>
+          <%= render setting.release_specific_status_pill %>
         <% end %>
 
         <% row.with_cell(wrap: true) do %>

--- a/app/components/notification_settings_component.html.erb
+++ b/app/components/notification_settings_component.html.erb
@@ -13,7 +13,7 @@
         <% row.with_cell do %>
           <% if setting.active? %>
             <div class="flex overflow-x-hidden hover:overflow-x-auto gap-x-3">
-              <% setting.notification_channels(include_release_specific: false)&.each do |channel| %>
+              <% setting.notification_channels&.each do |channel| %>
                 <div class="inline-flex items-center">
                   <%= render IconComponent.new("integrations/logo_#{setting.notification_provider}.png", size: :md, classes: "mr-1") %>
                   <%= channel["name"] %>

--- a/app/components/notification_settings_component.html.erb
+++ b/app/components/notification_settings_component.html.erb
@@ -1,5 +1,5 @@
 <% if enabled? %>
-  <%= render TableComponent.new(columns: ["kind", "channels", "status", "status (release-specific)"]) do |table| %>
+  <%= render TableComponent.new(columns: header_columns) do |table| %>
     <% display_settings.each do |setting| %>
       <% setting = notification_setting_component(setting) %>
       <% table.with_row do |row| %>
@@ -23,12 +23,14 @@
           <% end %>
         <% end %>
 
-        <% row.with_cell do %>
-          <%= render setting.status_pill %>
+        <% if @train.notifications_release_specific_channel_enabled? %>
+          <% row.with_cell do %>
+            <%= render setting.release_specific_status_pill %>
+          <% end %>
         <% end %>
 
         <% row.with_cell do %>
-          <%= render setting.release_specific_status_pill %>
+          <%= render setting.status_pill %>
         <% end %>
 
         <% row.with_cell(wrap: true) do %>

--- a/app/components/notification_settings_component.rb
+++ b/app/components/notification_settings_component.rb
@@ -57,7 +57,7 @@ class NotificationSettingsComponent < ViewComponent::Base
 
   def header_columns
     if @train.notifications_release_specific_channel_enabled?
-      ["kind", "default channels", "release specific channel", "status"]
+      ["kind", "core channels", "release specific channel", "status"]
     else
       %w[kind channels status]
     end

--- a/app/components/notification_settings_component.rb
+++ b/app/components/notification_settings_component.rb
@@ -84,7 +84,7 @@ class NotificationSettingsComponent < ViewComponent::Base
     end
 
     attr_reader :setting, :app
-    delegate :id, :active?, :notification_channels, :notification_provider, :release_specific_channel_allowed?, to: :setting
+    delegate :id, :active?, :notification_channels, :notification_provider, :release_specific_channel_allowed?, :channels, to: :setting
 
     def edit_path
       edit_app_train_notification_setting_path(@app, @train, setting)

--- a/app/components/notification_settings_component.rb
+++ b/app/components/notification_settings_component.rb
@@ -99,7 +99,7 @@ class NotificationSettingsComponent < ViewComponent::Base
     end
 
     def needs_invite?
-      setting.kind == NotificationSetting.kinds[:build_available]
+      setting.kind == NotificationSetting.kinds[:build_available_v2]
     end
 
     def edit_frame_id

--- a/app/components/notification_settings_component.rb
+++ b/app/components/notification_settings_component.rb
@@ -55,6 +55,14 @@ class NotificationSettingsComponent < ViewComponent::Base
     NotificationSettingComponent.new(app, train, setting)
   end
 
+  def header_columns
+    if @train.notifications_release_specific_channel_enabled?
+      ["kind", "default channels", "release specific channel", "status"]
+    else
+      %w[kind channels status]
+    end
+  end
+
   def display_settings
     settings.sort_by { |setting| NOTIFICATIONS[setting.kind][:number] }
   end

--- a/app/components/notification_settings_component.rb
+++ b/app/components/notification_settings_component.rb
@@ -75,7 +75,7 @@ class NotificationSettingsComponent < ViewComponent::Base
       @setting = setting
     end
 
-    attr_reader :setting
+    attr_reader :setting, :app
     delegate :id, :active?, :notification_channels, :notification_provider, :release_specific_channel_allowed?, to: :setting
 
     def edit_path
@@ -114,18 +114,26 @@ class NotificationSettingsComponent < ViewComponent::Base
       NOTIFICATIONS[setting.kind][:icon] || "aerial_lift.svg"
     end
 
-    def status_text
-      return "Enabled" if setting.active?
+    def status_text(flag)
+      return "Enabled" if flag
       "Disabled"
     end
 
-    def status_type
-      return :success if setting.active?
+    def status_type(flag)
+      return :success if flag
       :neutral
     end
 
     def status_pill
-      BadgeComponent.new(text: status_text, status: status_type)
+      BadgeComponent.new(text: status_text(setting.active?), status: status_type(setting.active?))
+    end
+
+    def release_specific_status_pill
+      if setting.release_specific_channel_allowed?
+        BadgeComponent.new(text: status_text(setting.release_specific_enabled?), status: status_type(setting.active?))
+      else
+        BadgeComponent.new(text: "Not Applicable", status: :neutral)
+      end
     end
 
     def default_channels

--- a/app/components/notification_settings_component.rb
+++ b/app/components/notification_settings_component.rb
@@ -121,7 +121,7 @@ class NotificationSettingsComponent < ViewComponent::Base
 
     def status_type(flag)
       return :success if flag
-      :neutral
+      :failure
     end
 
     def status_pill
@@ -130,7 +130,7 @@ class NotificationSettingsComponent < ViewComponent::Base
 
     def release_specific_status_pill
       if setting.release_specific_channel_allowed?
-        BadgeComponent.new(text: status_text(setting.release_specific_enabled?), status: status_type(setting.active?))
+        BadgeComponent.new(text: status_text(setting.release_specific_enabled?), status: status_type(setting.release_specific_enabled?))
       else
         BadgeComponent.new(text: "Not Applicable", status: :neutral)
       end

--- a/app/controllers/notification_settings_controller.rb
+++ b/app/controllers/notification_settings_controller.rb
@@ -45,6 +45,7 @@ class NotificationSettingsController < SignedInApplicationController
   def notif_setting_params
     params.require(:notification_setting).permit(
       :active,
+      :release_specific_enabled,
       notification_channels: []
     )
   end

--- a/app/libs/coordinators/setup_release_specific_channel.rb
+++ b/app/libs/coordinators/setup_release_specific_channel.rb
@@ -18,7 +18,7 @@ class Coordinators::SetupReleaseSpecificChannel
     # Use the default notification channel if we did not receive a new channel
     notification_channel = notification_provider.create_channel!(channel_name) || train.notification_channel
     release.set_notification_channel!(notification_channel)
-    notification_settings.release_specific_channel_allowed.update(notification_channels: [notification_channel])
+    notification_settings.release_specific_channel_allowed.update(release_specific_channel: notification_channel)
   end
 
   def channel_name

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -7,7 +7,7 @@
 #  author_login            :string
 #  author_name             :string           not null
 #  backmerge_failure       :boolean          default(FALSE)
-#  commit_hash             :string           not null, indexed => [release_id]
+#  commit_hash             :string           not null, indexed => [release_id, release_changelog_id]
 #  message                 :string           indexed
 #  parents                 :jsonb
 #  search_vector           :tsvector         indexed
@@ -16,8 +16,8 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  build_queue_id          :uuid             indexed
-#  release_changelog_id    :uuid             indexed
-#  release_id              :uuid             indexed => [commit_hash], indexed => [timestamp]
+#  release_changelog_id    :uuid             indexed => [commit_hash, release_id], indexed
+#  release_id              :uuid             indexed => [commit_hash, release_changelog_id], indexed => [timestamp]
 #  release_platform_id     :uuid             indexed
 #  release_platform_run_id :uuid             indexed
 #

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -88,19 +88,19 @@ class NotificationSetting < ApplicationRecord
       channels.concat(notification_channels)
     end
 
-    if release_specific_enabled? && release_specific_channel.present?
+    if release_specific_notifiable? && release_specific_channel.present?
       channels.append(release_specific_channel)
     end
 
     channels.compact.uniq { |c| c["id"] }
   end
 
-  def release_specific_enabled?
-    train.notifications_release_specific_channel_enabled? && super
+  def release_specific_notifiable?
+    train.notifications_release_specific_channel_enabled? && release_specific_enabled?
   end
 
   def release_specific_channel_allowed?
-    !kind.to_sym.in?(RELEASE_SPECIFIC_CHANNEL_NOT_ALLOWED_KINDS)
+    kind.to_sym.in?(RELEASE_SPECIFIC_CHANNEL_ALLOWED_KINDS)
   end
 
   def notification_channels_settings

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -2,14 +2,16 @@
 #
 # Table name: notification_settings
 #
-#  id                    :uuid             not null, primary key
-#  active                :boolean          default(TRUE), not null
-#  kind                  :string           not null, indexed => [train_id]
-#  notification_channels :jsonb
-#  user_groups           :jsonb
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  train_id              :uuid             not null, indexed, indexed => [kind]
+#  id                       :uuid             not null, primary key
+#  active                   :boolean          default(TRUE), not null
+#  kind                     :string           not null, indexed => [train_id]
+#  notification_channels    :jsonb
+#  release_specific_channel :jsonb
+#  release_specific_enabled :boolean          default(FALSE)
+#  user_groups              :jsonb
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  train_id                 :uuid             not null, indexed, indexed => [kind]
 #
 class NotificationSetting < ApplicationRecord
   has_paper_trail

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -96,7 +96,7 @@ class NotificationSetting < ApplicationRecord
   end
 
   def release_specific_enabled?
-    train.notifications_release_specific_channel_enabled && super
+    train.notifications_release_specific_channel_enabled? && super
   end
 
   def release_specific_channel_allowed?

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -95,6 +95,10 @@ class NotificationSetting < ApplicationRecord
     channels.compact.uniq { |c| c["id"] }
   end
 
+  def release_specific_enabled?
+    train.notifications_release_specific_channel_enabled && super
+  end
+
   def release_specific_channel_allowed?
     !kind.to_sym.in?(RELEASE_SPECIFIC_CHANNEL_NOT_ALLOWED_KINDS)
   end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -66,7 +66,7 @@ class NotificationSetting < ApplicationRecord
   validate :notification_channels_settings
 
   def send_notifications?
-    app.notifications_set_up? && active? && notification_channels.present?
+    app.notifications_set_up?
   end
 
   def notify!(message, params, file_id = nil, file_title = nil)
@@ -81,6 +81,13 @@ class NotificationSetting < ApplicationRecord
     notification_channels.each do |channel|
       notification_provider.notify_with_snippet!(channel["id"], message, kind, params, snippet_content, snippet_title)
     end
+  end
+
+  def notification_channels(include_release_specific: true)
+    channels = []
+    channels.concat(super()) if active?
+    channels.concat(release_specific_channel) if include_release_specific && release_specific_enabled?
+    channels.compact
   end
 
   def release_specific_channel_allowed?

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -84,13 +84,16 @@ class NotificationSetting < ApplicationRecord
   end
 
   def release_specific_channel_allowed?
-    train.notifications_release_specific_channel_enabled? &&
-      !kind.to_sym.in?(RELEASE_SPECIFIC_CHANNELS_NOT_ALLOWED_KINDS)
+    !kind.to_sym.in?(RELEASE_SPECIFIC_CHANNEL_NOT_ALLOWED_KINDS)
   end
 
   def notification_channels_settings
-    if active? && notification_channels.blank? && !release_specific_channel_allowed?
+    if active? && notification_channels.blank?
       errors.add(:notification_channels, :at_least_one)
+    end
+
+    if release_specific_enabled? && !release_specific_channel_allowed?
+      errors.add(:release_specific_enabled, :invalid_configuration_for_release_specific_channel)
     end
   end
 

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -104,8 +104,12 @@ class NotificationSetting < ApplicationRecord
       errors.add(:notification_channels, :at_least_one)
     end
 
-    if release_specific_enabled? && !release_specific_channel_allowed?
-      errors.add(:release_specific_enabled, :invalid_configuration_for_release_specific_channel)
+    if release_specific_enabled?
+      if !release_specific_channel_allowed?
+        errors.add(:release_specific_enabled, :release_specific_channel_not_allowed_for_this_kind)
+      elsif !train.notifications_release_specific_channel_enabled?
+        errors.add(:release_specific_enabled, :release_specific_not_enabled_in_train)
+      end
     end
   end
 

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -52,14 +52,14 @@ class NotificationSetting < ApplicationRecord
     workflow_trigger_failed: "workflow_trigger_failed"
   }
 
-  RELEASE_SPECIFIC_CHANNELS_NOT_ALLOWED_KINDS = [
+  RELEASE_SPECIFIC_CHANNEL_NOT_ALLOWED_KINDS = [
     :release_started,
     :release_scheduled
   ]
 
   scope :active, -> { where(active: true) }
-  scope :release_specific_channel_allowed, -> { where.not(kind: RELEASE_SPECIFIC_CHANNELS_NOT_ALLOWED_KINDS) }
-  scope :release_specific_channel_not_allowed, -> { where(kind: RELEASE_SPECIFIC_CHANNELS_NOT_ALLOWED_KINDS) }
+  scope :release_specific_channel_allowed, -> { where.not(kind: RELEASE_SPECIFIC_CHANNEL_NOT_ALLOWED_KINDS) }
+  scope :release_specific_channel_not_allowed, -> { where(kind: RELEASE_SPECIFIC_CHANNEL_NOT_ALLOWED_KINDS) }
   delegate :app, to: :train
   delegate :notification_provider, to: :app
   delegate :channels, to: :notification_provider

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -272,22 +272,13 @@ class Train < ApplicationRecord
 
   # rubocop:disable Rails/SkipsModelValidations
   def create_default_notification_settings
-    notif_setting = ->(kind, release_specific_enabled) {
+    vals = NotificationSetting.kinds.keys.map { |kind|
       {
         train_id: id,
         kind:,
         active: true,
-        notification_channels: notification_channel.present? ? [notification_channel] : nil,
-        release_specific_enabled:
+        notification_channels: notification_channel.present? ? [notification_channel] : nil
       }
-    }
-
-    vals = NotificationSetting::RELEASE_SPECIFIC_CHANNEL_ALLOWED_KINDS.map { |kind|
-      notif_setting.call(kind, notifications_release_specific_channel_enabled)
-    }
-
-    vals += NotificationSetting::RELEASE_SPECIFIC_CHANNEL_NOT_ALLOWED_KINDS.map { |kind|
-      notif_setting.call(kind, false)
     }
 
     NotificationSetting.upsert_all(vals, unique_by: [:train_id, :kind])

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -408,7 +408,8 @@ class Train < ApplicationRecord
   end
 
   def send_notifications?
-    app.notifications_set_up? && notification_channel.present?
+    app.notifications_set_up? &&
+      (notification_channel.present? || notifications_release_specific_channel_enabled?)
   end
 
   def schedule_editable?

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -277,7 +277,6 @@ class Train < ApplicationRecord
         kind:,
         active: true,
         notification_channels: notification_channel.present? ? [notification_channel] : nil,
-        release_specific_channel: notification_channel.presence,
         release_specific_enabled:
       }
     }

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -408,8 +408,10 @@ class Train < ApplicationRecord
   end
 
   def send_notifications?
-    app.notifications_set_up? &&
-      (notification_channel.present? || notifications_release_specific_channel_enabled?)
+    # Release-specific notifications and general notifications are not exclusive.
+    # Some notifications are not supported (do not make sense) in release-specific mode.
+    # So, this does not check for the release-specific flag.
+    app.notifications_set_up? && notification_channel.present?
   end
 
   def schedule_editable?

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -31,15 +31,19 @@
           <div>Enable to receive notifications in release specific channels</div>
         <% end %>
 
-        <%= render Form::SwitchComponent.new(form: section.F,
-                                             field_name: :release_specific_enabled,
-                                             switch_id: "release-specific-enabled-#{@setting.id}",
-                                             on_label: "Notifications enabled",
-                                             off_label: "Notifications disabled") do |switch| %>
-          <% switch.with_child do %>
-            <%= section.F.label_only :release_specific_enabled,
-                                     "Channel like #{release_specific_channel_pattern(@setting.app)} will be created for each release" %>
+        <% if @train.notifications_release_specific_channel_enabled? %>
+          <%= render Form::SwitchComponent.new(form: section.F,
+                                               field_name: :release_specific_enabled,
+                                               switch_id: "release-specific-enabled-#{@setting.id}",
+                                               on_label: "Notifications enabled",
+                                               off_label: "Notifications disabled") do |switch| %>
+            <% switch.with_child do %>
+              <%= section.F.label_only :release_specific_enabled,
+                                       "Channel like #{release_specific_channel_pattern(@setting.app)} will be created for each release" %>
+            <% end %>
           <% end %>
+        <% else %>
+          <span class="text-secondary">Notifications to release specific channels must be enabled in train settings first to configure this.</span>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -11,21 +11,41 @@
         <% end %>
       <% end %>
 
-      <%= render Form::SwitchComponent.new(form: section.F,
-                                           field_name: :active,
-                                           switch_id: "active-switch-#{@setting.id}",
-                                           on_label: "Default notifications enabled",
-                                           off_label: "Default notifications disabled") do |switch| %>
-        <% switch.with_child do %>
-          <div class="flex flex-col gap-1">
-            <div>
-              <%= section.F.labeled_select :notification_channels,
-                                           "Channels",
-                                           @setting.channel_select_options,
-                                           {},
-                                           {multiple: true, data: {controller: "input-select"}} %>
+      <% if @train.notifications_release_specific_channel_enabled? %>
+        <%= render Form::SwitchComponent.new(form: section.F,
+                                             field_name: :active,
+                                             switch_id: "active-switch-#{@setting.id}",
+                                             on_label: "Core notifications enabled",
+                                             off_label: "Core notifications disabled") do |switch| %>
+          <% switch.with_child do %>
+            <div class="flex flex-col gap-1">
+              <div>
+                <%= section.F.labeled_select :notification_channels,
+                                             "Core Channels",
+                                             @setting.channel_select_options,
+                                             {},
+                                             {multiple: true, data: {controller: "input-select"}} %>
+              </div>
             </div>
-          </div>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= render Form::SwitchComponent.new(form: section.F,
+                                             field_name: :active,
+                                             switch_id: "active-switch-#{@setting.id}",
+                                             on_label: "Notifications enabled",
+                                             off_label: "Notifications disabled") do |switch| %>
+          <% switch.with_child do %>
+            <div class="flex flex-col gap-1">
+              <div>
+                <%= section.F.labeled_select :notification_channels,
+                                             "Channels",
+                                             @setting.channel_select_options,
+                                             {},
+                                             {multiple: true, data: {controller: "input-select"}} %>
+              </div>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
 
@@ -37,7 +57,7 @@
                                              off_label: "Release-specific channel disabled") do |switch| %>
           <% switch.with_info_icon do %>
             <span class="text-secondary">
-              Channel like <%= release_specific_channel_pattern(@setting.app) %> will be created for each release
+              Channels like <strong><%= release_specific_channel_pattern(@setting.app) %></strong> will be automatically created for each release.
             </span>
           <% end %>
         <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -19,13 +19,16 @@
                                              off_label: "Core notifications disabled") do |switch| %>
           <% switch.with_child do %>
             <div class="flex flex-col gap-1">
-              <div>
-                <%= section.F.labeled_select :notification_channels,
-                                             "Core Channels",
-                                             @setting.channel_select_options,
-                                             {},
-                                             {multiple: true, data: {controller: "input-select"}} %>
-              </div>
+              <%= render partial: "shared/notifications_form",
+                         locals: {
+                           form: section.F,
+                           channels: @setting.channels,
+                           current: @setting.default_channels,
+                           multiple: true,
+                           field_name: :notification_channels,
+                           field_title: "Core Channels"
+                         }
+              %>
             </div>
           <% end %>
         <% end %>
@@ -37,13 +40,16 @@
                                              off_label: "Notifications disabled") do |switch| %>
           <% switch.with_child do %>
             <div class="flex flex-col gap-1">
-              <div>
-                <%= section.F.labeled_select :notification_channels,
-                                             "Channels",
-                                             @setting.channel_select_options,
-                                             {},
-                                             {multiple: true, data: {controller: "input-select"}} %>
-              </div>
+              <%= render partial: "shared/notifications_form",
+                         locals: {
+                           form: section.F,
+                           channels: @setting.channels,
+                           current: @setting.default_channels,
+                           multiple: true,
+                           field_name: :notification_channels,
+                           field_title: "Channels"
+                         }
+              %>
             </div>
           <% end %>
         <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -10,13 +10,6 @@
                                            switch_id: "active-switch-#{@setting.id}",
                                            on_label: "Notifications enabled",
                                            off_label: "Notifications disabled") do |switch| %>
-        <% if @setting.release_specific_channel_allowed? %>
-          <% switch.with_child do %>
-            <p class="text-slate-700 text-sm">
-              Turn off release-specific channels in train settings to customize channels per notification kind.
-            </p>
-          <% end %>
-        <% else %>
           <% switch.with_child do %>
             <%= section.F.labeled_select :notification_channels,
                                          "Channels",
@@ -29,6 +22,25 @@
             <span class="text-secondary">To allow file uploads in channels, invite <strong>@Tramline</strong> into your channels.</span>
           <% end %>
           <%= render partial: "shared/notifications_refresh", locals: {app: @app} %>
+      <% end %>
+    <% end %>
+
+    <% if @setting.release_specific_channel_allowed? %>
+      <% f.with_section(heading: "Release Specific") do |section| %>
+        <% section.with_description do %>
+          <div>Enable to receive notifications in release specific channels</div>
+        <% end %>
+
+        <%= render Form::SwitchComponent.new(form: section.F,
+                                             field_name: :release_specific_channel_enabled,
+                                             switch_id: "release-specific-channel-enabled-#{@setting.id}",
+                                             on_label: "Notifications enabled",
+                                             off_label: "Notifications disabled") do |switch| %>
+          <% switch.with_child do %>
+            <%= section.F.label_only :release_specific_channel_enabled,
+                                     "Channel like #{release_specific_channel_pattern(@setting.app)} will be created for each release"
+            %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -32,12 +32,12 @@
         <% end %>
 
         <%= render Form::SwitchComponent.new(form: section.F,
-                                             field_name: :release_specific_channel_enabled,
-                                             switch_id: "release-specific-channel-enabled-#{@setting.id}",
+                                             field_name: :release_specific_enabled,
+                                             switch_id: "release-specific-enabled-#{@setting.id}",
                                              on_label: "Notifications enabled",
                                              off_label: "Notifications disabled") do |switch| %>
           <% switch.with_child do %>
-            <%= section.F.label_only :release_specific_channel_enabled,
+            <%= section.F.label_only :release_specific_enabled,
                                      "Channel like #{release_specific_channel_pattern(@setting.app)} will be created for each release"
             %>
           <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -2,43 +2,43 @@
   <%= render FormComponent.new(@setting.edit_form_params) do |f| %>
     <% f.with_section(heading: "Select") do |section| %>
       <% section.with_description do %>
-        <div>One or more channel names for this type of notification.</div>
+        <p>One or more channel names for this type of notification.</p>
+        <%= render partial: "shared/notifications_refresh", locals: {app: @app} %>
+        <% if @setting.needs_invite? %>
+          <div class="text-secondary mt-1">
+            To allow file uploads in channels, invite <strong>@Tramline</strong> into your channels.
+          </div>
+        <% end %>
       <% end %>
 
       <%= render Form::SwitchComponent.new(form: section.F,
                                            field_name: :active,
                                            switch_id: "active-switch-#{@setting.id}",
-                                           on_label: "Notifications enabled",
-                                           off_label: "Notifications disabled") do |switch| %>
-          <% switch.with_child do %>
-            <%= section.F.labeled_select :notification_channels,
-                                         "Channels",
-                                         @setting.channel_select_options,
-                                         {},
-                                         {multiple: true, data: {controller: "input-select"}} %>
-          <% end %>
-
-          <% if @setting.needs_invite? %>
-            <span class="text-secondary">To allow file uploads in channels, invite <strong>@Tramline</strong> into your channels.</span>
-          <% end %>
-          <%= render partial: "shared/notifications_refresh", locals: {app: @app} %>
-      <% end %>
-    <% end %>
-
-    <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? %>
-      <% f.with_section(heading: "Release Specific") do |section| %>
-        <% section.with_description do %>
-          <div>Enable to receive notifications in release specific channels</div>
+                                           on_label: "Default notifications enabled",
+                                           off_label: "Default notifications disabled") do |switch| %>
+        <% switch.with_child do %>
+          <div class="flex flex-col gap-1">
+            <div>
+              <%= section.F.labeled_select :notification_channels,
+                                           "Channels",
+                                           @setting.channel_select_options,
+                                           {},
+                                           {multiple: true, data: {controller: "input-select"}} %>
+            </div>
+          </div>
         <% end %>
+      <% end %>
 
+      <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? %>
         <%= render Form::SwitchComponent.new(form: section.F,
                                              field_name: :release_specific_enabled,
                                              switch_id: "release-specific-enabled-#{@setting.id}",
-                                             on_label: "Notifications enabled",
-                                             off_label: "Notifications disabled") do |switch| %>
-          <% switch.with_child do %>
-            <%= section.F.label_only :release_specific_enabled,
-                                     "Channel like #{release_specific_channel_pattern(@setting.app)} will be created for each release" %>
+                                             on_label: "Release-specific channel enabled",
+                                             off_label: "Release-specific channel disabled") do |switch| %>
+          <% switch.with_info_icon do %>
+            <span class="text-secondary">
+              Channel like <%= release_specific_channel_pattern(@setting.app) %> will be created for each release
+            </span>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -38,8 +38,7 @@
                                              off_label: "Notifications disabled") do |switch| %>
           <% switch.with_child do %>
             <%= section.F.label_only :release_specific_enabled,
-                                     "Channel like #{release_specific_channel_pattern(@setting.app)} will be created for each release"
-            %>
+                                     "Channel like #{release_specific_channel_pattern(@setting.app)} will be created for each release" %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -25,25 +25,21 @@
       <% end %>
     <% end %>
 
-    <% if @setting.release_specific_channel_allowed? %>
+    <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? %>
       <% f.with_section(heading: "Release Specific") do |section| %>
         <% section.with_description do %>
           <div>Enable to receive notifications in release specific channels</div>
         <% end %>
 
-        <% if @train.notifications_release_specific_channel_enabled? %>
-          <%= render Form::SwitchComponent.new(form: section.F,
-                                               field_name: :release_specific_enabled,
-                                               switch_id: "release-specific-enabled-#{@setting.id}",
-                                               on_label: "Notifications enabled",
-                                               off_label: "Notifications disabled") do |switch| %>
-            <% switch.with_child do %>
-              <%= section.F.label_only :release_specific_enabled,
-                                       "Channel like #{release_specific_channel_pattern(@setting.app)} will be created for each release" %>
-            <% end %>
+        <%= render Form::SwitchComponent.new(form: section.F,
+                                             field_name: :release_specific_enabled,
+                                             switch_id: "release-specific-enabled-#{@setting.id}",
+                                             on_label: "Notifications enabled",
+                                             off_label: "Notifications disabled") do |switch| %>
+          <% switch.with_child do %>
+            <%= section.F.label_only :release_specific_enabled,
+                                     "Channel like #{release_specific_channel_pattern(@setting.app)} will be created for each release" %>
           <% end %>
-        <% else %>
-          <span class="text-secondary">Notifications to release specific channels must be enabled in train settings first to configure this.</span>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -27,8 +27,7 @@
                            multiple: true,
                            field_name: :notification_channels,
                            field_title: "Core Channels"
-                         }
-              %>
+                         } %>
             </div>
           <% end %>
         <% end %>
@@ -48,8 +47,7 @@
                            multiple: true,
                            field_name: :notification_channels,
                            field_title: "Channels"
-                         }
-              %>
+                         } %>
             </div>
           <% end %>
         <% end %>

--- a/app/views/shared/_notifications_form.html.erb
+++ b/app/views/shared/_notifications_form.html.erb
@@ -1,11 +1,9 @@
 <div>
-  <%= form.labeled_select :notification_channel, field_title,
+  <%= form.labeled_select field_name, field_title,
         options_for_select(
           display_channels(channels) { |chan| "#" + chan[:name] },
-          current.to_json
+          current
         ),
         {},
-        {data: {controller: "input-select"}} %>
-
-  <%= render partial: "shared/notifications_refresh", locals: {app: app} %>
+        {multiple:, data: {controller: "input-select"}} %>
 </div>

--- a/app/views/shared/_notifications_form.html.erb
+++ b/app/views/shared/_notifications_form.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= form.labeled_select :notification_channel, "Notification Channel",
+  <%= form.labeled_select :notification_channel, field_title,
         options_for_select(
           display_channels(channels) { |chan| "#" + chan[:name] },
           current.to_json

--- a/app/views/trains/_notifications_config_form.html.erb
+++ b/app/views/trains/_notifications_config_form.html.erb
@@ -6,16 +6,17 @@
     <div class="mb-2">
       <%= render Form::SwitchComponent.new(form:, field_name: :notifications_release_specific_channel_enabled,
                                            hide_child: false,
-                                           on_label: "Send notifications to release specific channel as well",
-                                           off_label: "Send notifications only to default and/or custom channels") do |component1| %>
+                                           on_label: "Send notifications to core and release specific channel(s)",
+                                           off_label: "Send notifications core channel(s)") do |component1| %>
 
         <% component1.with_info_icon do %>
-          When enabled, notifications will be sent to channels like <%= release_specific_channel_pattern(@app) %> in addition to custom/default channels as configured in advanced notification settings.
+         <p>Core channel(s) consist of the default notification channel and any overrides configured in advanced settings.</p>
+         <p>When release-specific channels are enabled, notifications can be sent to core channel(s) in addition to automatically created channels like <strong><%= release_specific_channel_pattern(@app) %></strong> for each release.</p>
         <% end %>
     <% end %>
     </div>
 
     <%= render partial: "shared/notifications_form",
-               locals: {form:, app: @app, channels: @notification_channels, current: @current_notification_channel} %>
+               locals: {form:, app: @app, channels: @notification_channels, current: @current_notification_channel, field_title: "Default Notification Channel"} %>
   <% end %>
 <% end %>

--- a/app/views/trains/_notifications_config_form.html.erb
+++ b/app/views/trains/_notifications_config_form.html.erb
@@ -17,6 +17,16 @@
     </div>
 
     <%= render partial: "shared/notifications_form",
-               locals: {form:, app: @app, channels: @notification_channels, current: @current_notification_channel, field_title: "Default Notification Channel"} %>
+               locals: {
+                 form:,
+                 channels: @notification_channels,
+                 current: @current_notification_channel.to_json,
+                 multiple: false,
+                 field_name: :notification_channel,
+                 field_title: "Default Notification Channel",
+               }
+    %>
+
+    <%= render partial: "shared/notifications_refresh", locals: {app: @app} %>
   <% end %>
 <% end %>

--- a/app/views/trains/_notifications_config_form.html.erb
+++ b/app/views/trains/_notifications_config_form.html.erb
@@ -23,9 +23,8 @@
                  current: @current_notification_channel.to_json,
                  multiple: false,
                  field_name: :notification_channel,
-                 field_title: "Default Notification Channel",
-               }
-    %>
+                 field_title: "Default Notification Channel"
+               } %>
 
     <%= render partial: "shared/notifications_refresh", locals: {app: @app} %>
   <% end %>

--- a/app/views/trains/_notifications_config_form.html.erb
+++ b/app/views/trains/_notifications_config_form.html.erb
@@ -6,11 +6,11 @@
     <div class="mb-2">
       <%= render Form::SwitchComponent.new(form:, field_name: :notifications_release_specific_channel_enabled,
                                            hide_child: false,
-                                           on_label: "Send notifications to release specific channel",
-                                           off_label: "Send notifications to default and/or custom channels") do |component1| %>
+                                           on_label: "Send notifications to release specific channel as well",
+                                           off_label: "Send notifications only to default and/or custom channels") do |component1| %>
 
         <% component1.with_info_icon do %>
-          When enabled, notifications will be sent to channels like <%= release_specific_channel_pattern(@app) %>
+          When enabled, notifications will be sent to channels like <%= release_specific_channel_pattern(@app) %> in addition to custom/default channels as configured in advanced notification settings.
         <% end %>
     <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,6 +502,9 @@ en:
           attributes:
             notification_channels:
               at_least_one: "there should be at least one channel selected for an enabled notification"
+            release_specific_enabled:
+              release_specific_channel_not_allowed_for_this_kind: "Release specific channel is not allowed for this kind of notification"
+              release_specific_not_enabled_in_train: "Release specific channels are not enabled in train settings"
         release_metadata:
           attributes:
             release_notes:

--- a/db/data/20250514142607_update_notification_settings_to_add_release_specific_channels.rb
+++ b/db/data/20250514142607_update_notification_settings_to_add_release_specific_channels.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class UpdateNotificationSettingsToAddReleaseSpecificChannels < ActiveRecord::Migration[7.2]
+  def up
+    # find all trains with release-specific channels enabled
+    Train.where(notifications_release_specific_channel_enabled: true).find_each do |train|
+      notification_settings = train.notification_settings.release_specific_channel_allowed
+
+      # update all the notification settings (release-specific allowed) to have release-specific enabled
+      notification_settings.find_each do |notification_setting|
+        notification_setting.update!(
+          release_specific_enabled: true,
+          # also update the new 'release_specific_channel' to be
+          # the last release-specific chan that used to be stored in 'notification_channels'
+          release_specific_channel: notification_setting.notification_channels.first,
+          notification_channels: [train.notification_channel]
+        )
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20250509122543)
+DataMigrate::Data.define(version: 20250514142607)

--- a/db/migrate/20250512121521_add_release_specific_channel_to_notification_setting.rb
+++ b/db/migrate/20250512121521_add_release_specific_channel_to_notification_setting.rb
@@ -1,0 +1,6 @@
+class AddReleaseSpecificChannelToNotificationSetting < ActiveRecord::Migration[7.2]
+  def change
+    add_column :notification_settings, :release_specific_channel, :jsonb
+    add_column :notification_settings, :release_specific_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_07_091951) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_12_121521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -438,6 +438,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_07_091951) do
     t.jsonb "user_groups"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "release_specific_channel"
+    t.boolean "release_specific_enabled", default: false
     t.index ["train_id", "kind"], name: "index_notification_settings_on_train_id_and_kind", unique: true
     t.index ["train_id"], name: "index_notification_settings_on_train_id"
   end

--- a/spec/libs/coordinators/setup_release_specific_channel_spec.rb
+++ b/spec/libs/coordinators/setup_release_specific_channel_spec.rb
@@ -34,16 +34,10 @@ RSpec.describe Coordinators::SetupReleaseSpecificChannel do
       expect(release.release_specific_channel_id).to eq(slack_response[:id])
     end
 
-    it "updates notification channel in notifications settings in allowed kinds" do
+    it "updates release specific channel in notifications settings in allowed kinds" do
       described_class.call(release)
-      notification_channels = train.notification_settings.release_specific_channel_allowed.pluck(:notification_channels)
-      expect(notification_channels).to all(contain_exactly(slack_response.as_json))
-    end
-
-    it "does not update notification channel notification settings for non-allowed kinds" do
-      described_class.call(release)
-      notification_channels = train.notification_settings.release_specific_channel_not_allowed.pluck(:notification_channels)
-      expect(notification_channels).to all(contain_exactly(default_notification_channel.as_json))
+      notification_channels = train.notification_settings.release_specific_channel_allowed.pluck(:release_specific_channel)
+      expect(notification_channels).to all(eq(slack_response.as_json))
     end
 
     it "updates notification channel to default channel if create channel fails" do
@@ -67,8 +61,8 @@ RSpec.describe Coordinators::SetupReleaseSpecificChannel do
 
     it "does not update notification channel settings" do
       described_class.call(release)
-      notification_channels = train.notification_settings.pluck(:notification_channels)
-      expect(notification_channels).to all(contain_exactly(default_notification_channel.as_json))
+      notification_channels = train.notification_settings.pluck(:release_specific_channel)
+      expect(notification_channels).to all(eq(default_notification_channel.as_json))
     end
   end
 end

--- a/spec/libs/coordinators/setup_release_specific_channel_spec.rb
+++ b/spec/libs/coordinators/setup_release_specific_channel_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Coordinators::SetupReleaseSpecificChannel do
     it "does not update notification channel settings" do
       described_class.call(release)
       notification_channels = train.notification_settings.pluck(:release_specific_channel)
-      expect(notification_channels).to all(eq(default_notification_channel.as_json))
+      expect(notification_channels).to all(be_nil)
     end
   end
 end


### PR DESCRIPTION
**Closes:** https://github.com/orgs/tramlinehq/projects/5/views/1?pane=issue&itemId=110221559

## Why

To be able to send notifications to multiple channels when release specific channels are enabled

## This addresses

1. Release specific channel is now separated from the notification channels configuration.
2. Notifications can be sent to both default/custom channels and release-specific channels.
3. Both notifications can be toggled - some notifications can be sent to default/custom only and some to release-specific only.

![image](https://github.com/user-attachments/assets/daa19e3e-57dc-489b-95ca-1d86a6d4883b)
![image](https://github.com/user-attachments/assets/98df1614-8fae-4186-a3fa-77644c59db04)
![image](https://github.com/user-attachments/assets/85b2330a-32bc-4c0a-a8fb-d5568ce6934c)

## Scenarios tested

- [x] Setting up notifications for the first time without release-specific is configured correctly.
- [x] Disallows editing release-specific flag for individual notification without train setting being enabled first.
- [x] Turning on/off release-specific flag after initial setup turns on/off the flag for all release-specific notifs.
- [x] Preserves past customization of release-specific flags when main train flag is flipped.

| Release specific train flag | Notification level release specific flag | Result |
|--------|--------|--------|
| Disabled | Irrelevant | Sent only to default channel :heavy_check_mark:  |
| Enabled | Enabled | Sent to both :heavy_check_mark: |
| Enabled | Disabled | Sent only to default channel :heavy_check_mark: |