### PR TITLE
Fix: generate GH release notes manually before creating a release

### DIFF
--- a/app/components/live_release/prod_release/rollout_component.html.erb
+++ b/app/components/live_release/prod_release/rollout_component.html.erb
@@ -33,14 +33,17 @@
       <div class="flex flex-col justify-between gap-1 h-full">
         <div class="grid grid-cols-12">
           <div class="col-span-5 flex flex-col gap-2">
-            <%= render LiveRelease::BuildComponent.new(
-                  build,
-                  show_metadata: false,
-                  show_ci: false,
-                  show_activity: false,
-                  show_commit: false,
-                  show_compact_metadata: true
-                ) %>
+            <div class="flex flex-row items-center">
+              <%= render LiveRelease::BuildComponent.new(
+                    build,
+                show_metadata: false,
+                show_ci: false,
+                show_activity: false,
+                show_commit: false,
+                show_compact_metadata: true
+                  ) %>
+              <%= render partial: "shared/tag_link", locals: {taggable: parent_release} %>
+            </div>
 
             <div class="flex items-baseline gap-2">
               <%= render IconComponent.new("integrations/logo_#{provider}.png", size: :xl) %>

--- a/app/components/live_release/prod_release/rollout_component.rb
+++ b/app/components/live_release/prod_release/rollout_component.rb
@@ -29,7 +29,9 @@ class LiveRelease::ProdRelease::RolloutComponent < BaseComponent
     :store_submission,
     :latest_events,
     :external_link,
-    :automatic_rollout?, :id, to: :store_rollout
+    :automatic_rollout?,
+    :id,
+    :parent_release, to: :store_rollout
   delegate :release, :platform, to: :release_platform_run
 
   def decorated_status

--- a/app/components/live_release/prod_release/submission_component.html.erb
+++ b/app/components/live_release/prod_release/submission_component.html.erb
@@ -188,18 +188,7 @@
                                                    show_activity: false,
                                                    show_commit: false,
                                                    show_compact_metadata: true) %>
-
-        <% if parent_release.tag_name.present? %>
-          <%= render ButtonComponent.new(label: parent_release.tag_name,
-                                         scheme: :link,
-                                         type: :link_external,
-                                         options: parent_release.tag_url,
-                                         authz: false,
-                                         size: :xxs,
-                                         arrow: :none) do |b|
-                b.with_icon(vcs_provider_logo, size: :sm)
-              end %>
-        <% end %>
+        <%= render partial: "shared/tag_link", locals: {taggable: parent_release} %>
       </div>
 
       <div class="flex flex-row gap-2 items-center">

--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -490,16 +490,18 @@ module Installations
 
         response = yield(new_client)
 
+        response_headers = response.headers.to_h.with_indifferent_access
         response_params = {
           status: response.status,
           body: response.body,
-          response_headers: response.headers.to_h.with_indifferent_access
+          response_headers: response_headers
         }
 
         if (error = Octokit::Error.from_response(response_params))
           raise error
         end
 
+        Rails.logger.info "GitHub API (execute_custom): #{response_headers}"
         response_params[:body]
       end
     end

--- a/app/models/bitbucket_integration.rb
+++ b/app/models/bitbucket_integration.rb
@@ -219,7 +219,7 @@ class BitbucketIntegration < ApplicationRecord
     false
   end
 
-  def create_release!(tag_name, branch_name, _) = create_tag!(tag_name, branch_name)
+  def create_release!(tag_name, branch_name, _, _) = create_tag!(tag_name, branch_name)
 
   def create_tag!(tag_name, sha)
     with_api_retries { installation.create_tag!(code_repository_name, tag_name, sha) }

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -15,7 +15,7 @@ module Taggable
   # it *can* get expensive in the worst-case scenario, so ideally invoke this in a bg job
   def create_vcs_release!(commitish, release_diff, input_tag_name = base_tag_name)
     return if tag_name.present?
-    train.create_vcs_release!(commitish, input_tag_name, release_diff)
+    train.create_vcs_release!(commitish, input_tag_name, previous_tag_name, release_diff)
     update!(tag_name: input_tag_name)
     event_stamp!(reason: :vcs_release_created, kind: :notice, data: {provider: train.vcs_provider.display, tag: input_tag_name})
   rescue Installations::Error => ex

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -147,11 +147,8 @@ class GithubIntegration < ApplicationRecord
     end
   end
 
-  def create_release!(tag_name, branch, release_notes)
-    installation.create_release!(code_repository_name, tag_name, branch)
-  rescue Installations::Error => ex
-    raise ex unless ex.reason == :release_notes_too_long
-    installation.create_release!(code_repository_name, tag_name, branch, release_notes)
+  def create_release!(tag_name, branch, previous_tag_name, release_notes)
+    installation.create_release!(code_repository_name, tag_name, branch, previous_tag_name, release_notes)
   end
 
   def create_tag!(tag_name, sha)

--- a/app/models/gitlab_integration.rb
+++ b/app/models/gitlab_integration.rb
@@ -163,7 +163,7 @@ class GitlabIntegration < ApplicationRecord
     with_api_retries { installation.create_project_webhook!(code_repository_name, events_url(url_params), WEBHOOK_TRANSFORMATIONS) }
   end
 
-  def create_release!(tag_name, branch, _)
+  def create_release!(tag_name, branch, _, _)
     with_api_retries { installation.create_tag!(code_repository_name, tag_name, branch) }
   end
 

--- a/app/models/production_release.rb
+++ b/app/models/production_release.rb
@@ -217,6 +217,8 @@ class ProductionRelease < ApplicationRecord
     tag
   end
 
+  # either the previous production release tag, or
+  # it's the release's previous tag
   def previous_tag_name
     previous&.tag_name.presence || release.previous_tag_name
   end

--- a/app/models/production_release.rb
+++ b/app/models/production_release.rb
@@ -37,7 +37,7 @@ class ProductionRelease < ApplicationRecord
   delegate :commit, :version_name, :build_number, to: :build
   delegate :release_health_rules, to: :release_platform
 
-  STAMPABLE_REASONS = %w[created active finished tag_created]
+  STAMPABLE_REASONS = %w[created active finished tag_created vcs_release_created]
 
   STATES = {
     inflight: "inflight",
@@ -215,5 +215,9 @@ class ProductionRelease < ApplicationRecord
     tag << "-hotfix" if hotfix?
     tag << (train.tag_store_releases_with_platform_names ? "-#{platform}" : "")
     tag
+  end
+
+  def previous_tag_name
+    previous&.tag_name.presence || release.previous_tag_name
   end
 end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -590,6 +590,13 @@ class Release < ApplicationRecord
     train.previously_finished_release.present? && !hotfix?
   end
 
+  def previous_tag_name
+    prev = previous_release
+    return if prev.blank?
+
+    prev.tag_name.presence || prev.production_releases.last&.tag_name
+  end
+
   private
 
   def base_tag_name

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -590,6 +590,8 @@ class Release < ApplicationRecord
     train.previously_finished_release.present? && !hotfix?
   end
 
+  # either the previous release's end-of-release tag, or
+  # it's the previous release's rollout tag
   def previous_tag_name
     prev = previous_release
     return if prev.blank?

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -23,12 +23,11 @@ class ReleasePlatformRun < ApplicationRecord
   has_paper_trail
   include AASM
   include Passportable
-  include Taggable
   include ActionView::Helpers::DateHelper
   include Displayable
   using RefinedString
 
-  self.ignored_columns += %w[branch_name commit_sha original_release_version]
+  self.ignored_columns += %w[branch_name commit_sha original_release_version tag_name]
   self.implicit_order_column = :scheduled_at
 
   belongs_to :release_platform

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -362,9 +362,9 @@ class Train < ApplicationRecord
     !almost_trunk?
   end
 
-  def create_vcs_release!(branch_name, tag_name, release_diff = nil)
+  def create_vcs_release!(branch_name, tag_name, previous_tag_name, release_diff = nil)
     return false unless active?
-    vcs_provider.create_release!(tag_name, branch_name, release_diff)
+    vcs_provider.create_release!(tag_name, branch_name, previous_tag_name, release_diff)
   end
 
   delegate :create_tag!, to: :vcs_provider

--- a/app/views/shared/_tag_link.html.erb
+++ b/app/views/shared/_tag_link.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (taggable: nil) %>
+
+<% if taggable.tag_name.present? %>
+  <%= render ButtonComponent.new(label: taggable.tag_name,
+                                 scheme: :link,
+                                 type: :link_external,
+                                 options: taggable.tag_url,
+                                 authz: false,
+                                 size: :xxs,
+                                 arrow: :none) do |b|
+    b.with_icon(vcs_provider_logo, size: :sm)
+  end %>
+<% end %>

--- a/app/views/shared/_tag_link.html.erb
+++ b/app/views/shared/_tag_link.html.erb
@@ -8,6 +8,6 @@
                                  authz: false,
                                  size: :xxs,
                                  arrow: :none) do |b|
-    b.with_icon(vcs_provider_logo, size: :sm)
-  end %>
+        b.with_icon(vcs_provider_logo, size: :sm)
+      end %>
 <% end %>

--- a/spec/models/production_release_spec.rb
+++ b/spec/models/production_release_spec.rb
@@ -177,7 +177,17 @@ describe ProductionRelease do
 
       production_release.create_vcs_release!(commit.commit_hash, anything)
 
-      expect(train).to have_received(:create_vcs_release!).with(commit.commit_hash, "v1.2.3", anything)
+      expect(train).to have_received(:create_vcs_release!).with(commit.commit_hash, "v1.2.3", anything, anything)
+    end
+
+    it "uses a previous tag name" do
+      previous_prod_release = create(:production_release, :finished, build:, release_platform_run:, tag_name: "v1.2.0")
+      production_release = create(:production_release, :inflight, build:, release_platform_run:, previous: previous_prod_release)
+      allow(train).to receive(:create_vcs_release!)
+
+      production_release.create_vcs_release!(commit.commit_hash, anything)
+
+      expect(train).to have_received(:create_vcs_release!).with(commit.commit_hash, "v1.2.3", "v1.2.0", anything)
     end
   end
 

--- a/spec/models/production_release_spec.rb
+++ b/spec/models/production_release_spec.rb
@@ -180,7 +180,7 @@ describe ProductionRelease do
       expect(train).to have_received(:create_vcs_release!).with(commit.commit_hash, "v1.2.3", anything, anything)
     end
 
-    it "uses a previous tag name" do
+    it "uses a tag name from previous prod release" do
       previous_prod_release = create(:production_release, :finished, build:, release_platform_run:, tag_name: "v1.2.0")
       production_release = create(:production_release, :inflight, build:, release_platform_run:, previous: previous_prod_release)
       allow(train).to receive(:create_vcs_release!)
@@ -188,6 +188,18 @@ describe ProductionRelease do
       production_release.create_vcs_release!(commit.commit_hash, anything)
 
       expect(train).to have_received(:create_vcs_release!).with(commit.commit_hash, "v1.2.3", "v1.2.0", anything)
+    end
+
+    it "uses a tag name from the previous end-of-release tag" do
+      previous_release = create(:release, :finished, train:, tag_name: "v1.2.2")
+      previous_rpr = create(:release_platform_run, release_platform:, release: previous_release)
+      previous_prod_release = create(:production_release, :finished, build:, release_platform_run: previous_rpr, tag_name: nil)
+      production_release = create(:production_release, :inflight, build:, release_platform_run:, previous: previous_prod_release)
+      allow(train).to receive(:create_vcs_release!)
+
+      production_release.create_vcs_release!(commit.commit_hash, anything)
+
+      expect(train).to have_received(:create_vcs_release!).with(commit.commit_hash, "v1.2.3", "v1.2.2", anything)
     end
   end
 


### PR DESCRIPTION
## Why

The GitHub [releases API](https://docs.github.com/en/rest/releases/releases#create-a-release) is broken. It allows passing a boolean `generate_release_notes` which auto-generates the changelog / release notes and uses its own internal algorithm to decide the starting tag from which to scan for commits. 

This has a few problems:

- The tag from which it generates the diff, is often arbitrary and not correct (from a release-lens anyway)
- This sometimes leads to picking up a tag from a long time ago (sometimes 30 tags prior)
- Which can cause the release notes length to blow up (but the blow-up isn't communicated back to the client)

Now this API doesn't expose any of this as configuration, it selects a source tag itself and then ends up crashing internally. But it just returns a 502 back to the client. We don't get to see why it blew up.

But that's not all, it seems like:

- It isn't transactional, even after returning a 5xx to the client, it ends up cutting a tag anyway
- And worse of all, it actually does end up creating a VCS release **sometimes** with some truncated changelog

It's the worse version of _eventual consistency_... _eventually wrong_.

** all the conditions above are reproducibly failing
** the maximum release notes / body length for a release is 121kb (which is a lot!)

## This addresses

This PR now makes use of a [new API](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release) that allows one to generate just the notes separately and _pass_ in the previous tag for reference. We use this, and then manually carry over the generated notes when creating the GH release in the body. And we now explicitly disable `generate_release_notes` always.

If this new API fails for whatever reason, we default to our own copy of the release notes.