### PR TITLE
Notifications: Add new flag for core notification, use active as a global flag

### DIFF
--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -40,7 +40,7 @@ class ButtonComponent < BaseComponent
   renders_one :icon, IconComponent
   renders_one :tooltip, ->(text, **args) { TooltipComponent.new(text, **args.merge(cursor: false)) }
 
-  def initialize(label: nil, scheme: :switcher, type: :button, size: :xxs, options: nil, html_options: nil, arrow: :none, authz: true, turbo: true, disabled: false, auto_label_case: true)
+  def initialize(label: nil, scheme: :switcher, type: :button, size: :xxs, options: nil, html_options: nil, arrow: :none, authz: true, turbo: true, disabled: false, auto_label_case: true, name: nil, value: nil)
     arrow = (scheme == :switcher) ? :double : arrow
     raise ArgumentError, "Invalid scheme" unless SCHEMES.include?(scheme)
     raise ArgumentError, "Invalid button type" unless TYPES.include?(type)
@@ -58,6 +58,8 @@ class ButtonComponent < BaseComponent
     @disabled = disabled
     @turbo = turbo
     @auto_label_case = auto_label_case
+    @button_name = name
+    @button_value = value
   end
 
   def before_render
@@ -109,12 +111,12 @@ class ButtonComponent < BaseComponent
   end
 
   def button_component
-    return button_tag(@options, @html_options) { render(icon) } if icon_only?
+    return button_tag(@html_options) { render(icon) } if icon_only?
 
     classname = icon? ? "ml-1.5" : ""
     classname += " group-disabled:hidden" unless disabled?
 
-    button_tag(@options, @html_options) do
+    button_tag(@html_options) do
       concat(icon) if icon?
 
       if title_text?
@@ -141,6 +143,8 @@ class ButtonComponent < BaseComponent
     options[:class] << " #{DISABLED_STYLE}" if disabled?
     options[:class] = options[:class].squish
     options[:disabled] = true if disabled?
+    options[:name] = @button_name unless @button_name.nil?
+    options[:value] = @button_value unless @button_value.nil?
 
     options[:data] ||= {}
     options[:data][:turbo] = @turbo

--- a/app/components/form_component.html.erb
+++ b/app/components/form_component.html.erb
@@ -35,7 +35,8 @@
           <% end %>
         </div>
       <% elsif actions.size > 1 %>
-        <div class="grid grid-flow-col auto-cols-2 place-items-center xl:space-x-20 p-2">
+        <div class="grid grid-flow-col place-items-center xl:space-x-20 p-2">
+          <div class="col-span-1 mr-2"></div>
           <% actions.each_with_index do |action, index| %>
             <div class="place-self-<%= index.even? ? "end" : "start" %> mt-2">
               <%= action %>

--- a/app/components/form_component.html.erb
+++ b/app/components/form_component.html.erb
@@ -27,23 +27,16 @@
         </div>
       <% end %>
 
-      <% if actions.size == 1 %>
+      <% if actions.present? %>
         <div class="grid grid-cols-3 items-start xl:space-x-20 p-2">
           <div class="col-span-1"></div>
-          <% actions.each do |action| %>
-            <div class="col-span-2 justify-start mt-2"><%= action %></div>
-          <% end %>
-        </div>
-      <% elsif actions.size > 1 %>
-        <div class="grid grid-flow-col place-items-center xl:space-x-20 p-2">
-          <div class="col-span-1 mr-2"></div>
-          <% actions.each_with_index do |action, index| %>
-            <div class="place-self-<%= index.even? ? "end" : "start" %> mt-2">
+          <div class="col-span-2 justify-start mt-2">
+            <% actions.each do |action| %>
               <%= action %>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
-    <% end %>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/form_component.html.erb
+++ b/app/components/form_component.html.erb
@@ -2,9 +2,11 @@
   <% set_form(form) %>
   <% if free_form? %>
     <%= content %>
-    <% if action? %>
+    <% if actions.present? %>
       <div class="flex justify-end mt-6">
-        <%= action %>
+        <% actions.each do |action| %>
+          <%= action %>
+        <% end %>
       </div>
     <% end %>
   <% else %>
@@ -25,10 +27,22 @@
         </div>
       <% end %>
 
-      <div class="grid grid-cols-3 items-start xl:space-x-20 p-2">
-        <div class="col-span-1"></div>
-        <div class="col-span-2 justify-start mt-2"><%= action %></div>
-      </div>
+      <% if actions.size == 1 %>
+        <div class="grid grid-cols-3 items-start xl:space-x-20 p-2">
+          <div class="col-span-1"></div>
+          <% actions.each do |action| %>
+            <div class="col-span-2 justify-start mt-2"><%= action %></div>
+          <% end %>
+        </div>
+      <% elsif actions.size > 1 %>
+        <div class="grid grid-flow-col auto-cols-2 place-items-center xl:space-x-20 p-2">
+          <% actions.each_with_index do |action, index| %>
+            <div class="place-self-<%= index.even? ? "end" : "start" %> mt-2">
+              <%= action %>
+            </div>
+          <% end %>
+        </div>
+    <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/form_component.rb
+++ b/app/components/form_component.rb
@@ -1,5 +1,5 @@
 class FormComponent < BaseComponent
-  renders_one :action
+  renders_many :actions
   renders_many :sections, ->(**args) { Form::SectionComponent.new(form: @form, **args) }
   renders_many :advanced_sections, ->(**args) { Form::SectionComponent.new(form: @form, **args) }
 

--- a/app/components/notification_settings_component.rb
+++ b/app/components/notification_settings_component.rb
@@ -133,12 +133,12 @@ class NotificationSettingsComponent < ViewComponent::Base
     end
 
     def status_pill
-      BadgeComponent.new(text: status_text(setting.active?), status: status_type(setting.active?))
+      BadgeComponent.new(text: status_text(setting.active? && setting.core_enabled?), status: status_type(setting.active? && setting.core_enabled?))
     end
 
     def release_specific_status_pill
       if setting.release_specific_channel_allowed?
-        BadgeComponent.new(text: status_text(setting.release_specific_enabled?), status: status_type(setting.release_specific_enabled?))
+        BadgeComponent.new(text: status_text(setting.active? && setting.release_specific_enabled?), status: status_type(setting.active? && setting.release_specific_enabled?))
       else
         BadgeComponent.new(text: "Not Applicable", status: :neutral)
       end

--- a/app/controllers/notification_settings_controller.rb
+++ b/app/controllers/notification_settings_controller.rb
@@ -45,6 +45,7 @@ class NotificationSettingsController < SignedInApplicationController
   def notif_setting_params
     params.require(:notification_setting).permit(
       :active,
+      :core_enabled,
       :release_specific_enabled,
       notification_channels: []
     )

--- a/app/helpers/enhanced_form_helper.rb
+++ b/app/helpers/enhanced_form_helper.rb
@@ -26,9 +26,9 @@ module EnhancedFormHelper
     FILE_INPUT_CLASSES = "w-full text-sm text-main border border-gray-300 rounded-lg cursor-pointer bg-gray-50 dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400"
     OPTION_CLASSES = "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
 
-    def authz_submit(label, icon, scheme: :default, size: :sm, disabled: false, html_options: {}, authz: true)
+    def authz_submit(label, icon, scheme: :default, size: :sm, disabled: false, html_options: {}, authz: true, name: nil, value: nil)
       button_component =
-        ButtonComponent.new(scheme:, type: :action, size:, label:, html_options:, turbo: false, disabled:, authz:)
+        ButtonComponent.new(scheme:, type: :action, size:, label:, options:, html_options:, turbo: false, disabled:, authz:, name:, value:)
       button_component.with_icon(icon)
       @template.render(button_component)
     end

--- a/app/helpers/enhanced_form_helper.rb
+++ b/app/helpers/enhanced_form_helper.rb
@@ -28,7 +28,7 @@ module EnhancedFormHelper
 
     def authz_submit(label, icon, scheme: :default, size: :sm, disabled: false, html_options: {}, authz: true, name: nil, value: nil)
       button_component =
-        ButtonComponent.new(scheme:, type: :action, size:, label:, options:, html_options:, turbo: false, disabled:, authz:, name:, value:)
+        ButtonComponent.new(scheme:, type: :action, size:, label:, html_options:, turbo: false, disabled:, authz:, name:, value:)
       button_component.with_icon(icon)
       @template.render(button_component)
     end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -4,6 +4,7 @@
 #
 #  id                       :uuid             not null, primary key
 #  active                   :boolean          default(TRUE), not null
+#  core_enabled             :boolean          default(FALSE), not null
 #  kind                     :string           not null, indexed => [train_id]
 #  notification_channels    :jsonb
 #  release_specific_channel :jsonb

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -69,23 +69,29 @@ class NotificationSetting < ApplicationRecord
   validate :notification_channels_settings
 
   def notify!(message, params, file_id = nil, file_title = nil)
+    return unless send_notifications?
+
     notifiable_channels.each do |channel|
       notification_provider.notify!(channel["id"], message, kind, params, file_id, file_title)
     end
   end
 
   def notify_with_snippet!(message, params, snippet_content, snippet_title)
+    return unless send_notifications?
+
     notifiable_channels.each do |channel|
       notification_provider.notify_with_snippet!(channel["id"], message, kind, params, snippet_content, snippet_title)
     end
   end
 
-  def notifiable_channels
-    return unless app.notifications_set_up?
+  def send_notifications?
+    app.notifications_set_up? && active?
+  end
 
+  def notifiable_channels
     channels = []
 
-    if active? && notification_channels.present?
+    if core_enabled? && notification_channels.present?
       channels.concat(notification_channels)
     end
 

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -278,6 +278,7 @@ class Train < ApplicationRecord
         train_id: id,
         kind:,
         active: true,
+        core_enabled: true,
         notification_channels: notification_channel.present? ? [notification_channel] : nil
       }
     }

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -13,8 +13,8 @@
 
       <% if @train.notifications_release_specific_channel_enabled? %>
         <%= render Form::SwitchComponent.new(form: section.F,
-                                             field_name: :active,
-                                             switch_id: "active-switch-#{@setting.id}",
+                                             field_name: :core_enabled,
+                                             switch_id: "core-switch-#{@setting.id}",
                                              on_label: "Core notifications enabled",
                                              off_label: "Core notifications disabled") do |switch| %>
           <% switch.with_child do %>
@@ -31,10 +31,24 @@
             </div>
           <% end %>
         <% end %>
+
+        <% if @setting.release_specific_channel_allowed? %>
+          <%= render Form::SwitchComponent.new(form: section.F,
+                                               field_name: :release_specific_enabled,
+                                               switch_id: "release-specific-enabled-#{@setting.id}",
+                                               on_label: "Release-specific channel enabled",
+                                               off_label: "Release-specific channel disabled") do |switch| %>
+            <% switch.with_info_icon do %>
+              <span class="text-secondary">
+              Channels like <strong><%= release_specific_channel_pattern(@setting.app) %></strong> will be automatically created for each release.
+            </span>
+            <% end %>
+          <% end %>
+        <% end %>
       <% else %>
         <%= render Form::SwitchComponent.new(form: section.F,
-                                             field_name: :active,
-                                             switch_id: "active-switch-#{@setting.id}",
+                                             field_name: :core_enabled,
+                                             switch_id: "core-switch-#{@setting.id}",
                                              on_label: "Notifications enabled",
                                              off_label: "Notifications disabled") do |switch| %>
           <% switch.with_child do %>
@@ -52,24 +66,16 @@
           <% end %>
         <% end %>
       <% end %>
-
-      <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? %>
-        <%= render Form::SwitchComponent.new(form: section.F,
-                                             field_name: :release_specific_enabled,
-                                             switch_id: "release-specific-enabled-#{@setting.id}",
-                                             on_label: "Release-specific channel enabled",
-                                             off_label: "Release-specific channel disabled") do |switch| %>
-          <% switch.with_info_icon do %>
-            <span class="text-secondary">
-              Channels like <strong><%= release_specific_channel_pattern(@setting.app) %></strong> will be automatically created for each release.
-            </span>
-          <% end %>
-        <% end %>
-      <% end %>
     <% end %>
 
     <% f.with_action do %>
-      <% f.F.authz_submit "Save", "archive.svg", size: :xs %>
+      <% f.F.authz_submit "Save", "archive.svg", size: :xs, name: f.F.field_name(:active), value: true %>
+    <% end %>
+
+    <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? %>
+      <% f.with_action do %>
+          <% f.F.authz_submit "Disable", "archive.svg", size: :xs, scheme: :danger, name: f.F.field_name(:active), value: false %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -69,10 +69,10 @@
     <% end %>
 
     <% f.with_action do %>
-      <% f.F.authz_submit "Save", "archive.svg", size: :xs, name: f.F.field_name(:active), value: true %>
+      <% f.F.authz_submit @setting.active? ? "Save" : "Enable", "archive.svg", size: :xs, name: f.F.field_name(:active), value: true %>
     <% end %>
 
-    <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? %>
+    <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? && @setting.active? %>
       <% f.with_action do %>
           <% f.F.authz_submit "Disable", "archive_x.svg", size: :xs, scheme: :danger, name: f.F.field_name(:active), value: false %>
       <% end %>

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -74,7 +74,7 @@
 
     <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? %>
       <% f.with_action do %>
-          <% f.F.authz_submit "Disable", "archive.svg", size: :xs, scheme: :danger, name: f.F.field_name(:active), value: false %>
+          <% f.F.authz_submit "Disable", "archive_x.svg", size: :xs, scheme: :danger, name: f.F.field_name(:active), value: false %>
       <% end %>
     <% end %>
   <% end %>

--- a/db/data/20250527062528_notifications_copy_active_flag_to_core_enabled.rb
+++ b/db/data/20250527062528_notifications_copy_active_flag_to_core_enabled.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class NotificationsCopyActiveFlagToCoreEnabled < ActiveRecord::Migration[7.2]
+  def up
+    # Update core_enabled flag for notifications which are currently active
+    NotificationSetting.where(active: true).update_all(core_enabled: true)
+
+    # Turn on the global-active flag for notifications where release specific is enabled but the core notification is disabled
+    # core_enabled is false by default, no need to update it.
+    NotificationSetting.where(active: false, release_specific_enabled: true).update_all(active: true)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20250519092146_add_core_enabled_flag.rb
+++ b/db/migrate/20250519092146_add_core_enabled_flag.rb
@@ -1,0 +1,5 @@
+class AddCoreEnabledFlag < ActiveRecord::Migration[7.2]
+  def change
+    add_column :notification_settings, :core_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_12_121521) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_19_092146) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -440,6 +440,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_12_121521) do
     t.datetime "updated_at", null: false
     t.jsonb "release_specific_channel"
     t.boolean "release_specific_enabled", default: false
+    t.boolean "core_enabled", default: false, null: false
     t.index ["train_id", "kind"], name: "index_notification_settings_on_train_id_and_kind", unique: true
     t.index ["train_id"], name: "index_notification_settings_on_train_id"
   end


### PR DESCRIPTION
**Closes:** https://github.com/orgs/tramlinehq/projects/5/views/1?pane=issue&itemId=111258995

## Why

Active flag on notification setting is currently used for the core notification setting.
As we introduce more types of notifications and channels, we need a global enable/disable flag (which the active flag will now do).

## This addresses

Individually each notification can be controlled separately using their own flags. But if the main flag is off, the notification gets disabled across all channels.

Adds a disable button on notification setting modal

![image](https://github.com/user-attachments/assets/63198711-0d42-4d14-9e05-d8f686ce8f9f)

![image](https://github.com/user-attachments/assets/705c2c90-a08d-4de2-bdea-00bd828539a4)

## Scenarios tested

- [x] Updates active flag correctly depending on which button is clicked

- [x] Shows notifications as disabled if the main flag is off, irrespective of individual flags
![image](https://github.com/user-attachments/assets/0292a521-67f0-4811-8293-ea7533f66a59)

- [x] Notifications are not sent even if the individual flag is on but main flag is off

