### PR TITLE
Add index release health metrics

### DIFF
--- a/app/models/release_health_metric.rb
+++ b/app/models/release_health_metric.rb
@@ -6,7 +6,7 @@
 #  daily_users                :bigint
 #  daily_users_with_errors    :bigint
 #  errors_count               :bigint
-#  fetched_at                 :datetime         not null, indexed
+#  fetched_at                 :datetime         not null, indexed => [production_release_id], indexed
 #  new_errors_count           :bigint
 #  sessions                   :bigint
 #  sessions_in_last_day       :bigint
@@ -15,7 +15,7 @@
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  external_release_id        :string
-#  production_release_id      :uuid             indexed
+#  production_release_id      :uuid             indexed => [fetched_at], indexed
 #
 class ReleaseHealthMetric < ApplicationRecord
   self.ignored_columns += ["deployment_run_id"]

--- a/app/models/release_platform_run.rb
+++ b/app/models/release_platform_run.rb
@@ -12,7 +12,6 @@
 #  scheduled_at          :datetime         not null
 #  status                :string           not null
 #  stopped_at            :datetime
-#  tag_name              :string
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  last_commit_id        :uuid             indexed

--- a/db/migrate/20250522160156_add_reverse_index_release_health_metrics.rb
+++ b/db/migrate/20250522160156_add_reverse_index_release_health_metrics.rb
@@ -1,0 +1,7 @@
+class AddReverseIndexReleaseHealthMetrics < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+  
+  def change
+    add_index :release_health_metrics, [:production_release_id, :fetched_at], order: {fetched_at: :desc}, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_12_121521) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_22_160156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -600,6 +600,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_12_121521) do
     t.uuid "production_release_id"
     t.index ["deployment_run_id"], name: "index_release_health_metrics_on_deployment_run_id"
     t.index ["fetched_at"], name: "index_release_health_metrics_on_fetched_at"
+    t.index ["production_release_id", "fetched_at"], name: "idx_on_production_release_id_fetched_at_0e35dbfce7", order: { fetched_at: :desc }
     t.index ["production_release_id"], name: "index_release_health_metrics_on_production_release_id"
   end
 


### PR DESCRIPTION
## Why

Performance problems when querying release health metrics on dashboard.

## This addresses

Adds an index on `production_release_id, fetched_at` ordered by fetched_at in DESC which is needed by the query.