### PR TITLE
Add a special unauthenticated route for demo on dev and staging

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -159,16 +159,20 @@
             </div>
           <% end %>
 
-          <% dropdown.with_item_group(list_style: "text-secondary dark:text-secondary-50") do |group| %>
-            <% group.with_item(link: {path: edit_accounts_user_path, "data-turbo": false}) do %>
-              Settings
+          <% unless current_user.demo? %>
+            <% dropdown.with_item_group(list_style: "text-secondary dark:text-secondary-50") do |group| %>
+              <% group.with_item(link: {path: edit_accounts_user_path, "data-turbo": false}) do %>
+                Settings
+              <% end %>
             <% end %>
           <% end %>
 
-          <% dropdown.with_item_group(list_style: "text-secondary dark:text-secondary-50") do |group| %>
-            <% if billing? %>
-              <% group.with_item(link: {path: billing_link, external: true}) do %>
-                Go to billing ↗
+          <% unless current_user.demo? %>
+            <% dropdown.with_item_group(list_style: "text-secondary dark:text-secondary-50") do |group| %>
+              <% if billing? %>
+                <% group.with_item(link: {path: billing_link, external: true}) do %>
+                  Go to billing ↗
+                <% end %>
               <% end %>
             <% end %>
 
@@ -177,9 +181,11 @@
             <% end %>
           <% end %>
 
-          <% dropdown.with_item_group(list_style: "text-secondary dark:text-secondary-50") do |group| %>
-            <% group.with_item(link: {path: logout_path, "data-turbo": false}) do %>
-              Sign out
+          <% unless current_user.demo? %>
+            <% dropdown.with_item_group(list_style: "text-secondary dark:text-secondary-50") do |group| %>
+              <% group.with_item(link: {path: logout_path, "data-turbo": false}) do %>
+                Sign out
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,17 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user
-    @current_user ||= current_email_authentication&.user || @current_sso_user
+    @current_user ||= current_email_authentication&.user || @current_sso_user || demo_user
+  end
+
+  def demo_user
+    return if session[:active_organization].blank?
+    org = Accounts::Organization.find_by(slug: session[:active_organization])
+    return unless org&.demo?
+
+    demo_user_slug = ENV.fetch("DEMO_USER_SLUG", nil)
+    return if demo_user_slug.blank?
+    Accounts::User.find_by(slug: demo_user_slug)
   end
 
   protected

--- a/app/controllers/demo_controller.rb
+++ b/app/controllers/demo_controller.rb
@@ -1,0 +1,15 @@
+class DemoController < ApplicationController
+  def index
+    demo_org_slug = ENV.fetch("DEMO_ORG_SLUG", nil)
+    if demo_org_slug.present?
+      demo_org = Accounts::Organization.friendly.find(demo_org_slug)
+
+      redirect_to root_path and return unless demo_org&.demo?
+
+      session[:active_organization] = demo_org_slug
+      redirect_to apps_path
+      return
+    end
+    redirect_to root_path
+  end
+end

--- a/app/controllers/signed_in_application_controller.rb
+++ b/app/controllers/signed_in_application_controller.rb
@@ -11,7 +11,7 @@ class SignedInApplicationController < ApplicationController
   before_action :turbo_frame_request_variant
   before_action :set_currents
   before_action :set_paper_trail_whodunnit
-  before_action :require_login, unless: :authentication_controllers?
+  before_action :require_login, unless: -> { authentication_controllers? || demo_org? }
   before_action :require_organization!
   before_action :track_behaviour
   before_action :set_app

--- a/app/models/accounts/user.rb
+++ b/app/models/accounts/user.rb
@@ -67,6 +67,10 @@ class Accounts::User < ApplicationRecord
 
   def email = unique_authn_id
 
+  def demo?
+    slug == ENV["DEMO_USER_SLUG"]
+  end
+
   class << self
     def find_via_email(email)
       joins(:email_authentications).find_by(email_authentications: {email: email})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   mount ActionCable.server => "/cable"
   mount Easymon::Engine => "/up"
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  get "demo", to: "demo#index" if Rails.env.development? || ENV["RAILS_PIPELINE_ENV"].eql?("staging")
   # get "up" => "rails/health#show", as: :rails_health_check
 
   root "authentication/sessions#root"


### PR DESCRIPTION
## Why

Have a public demo page for sales and marketing purposes where we don't have to create external viewer credentials

## This addresses

Allows one organization on staging environment to be selected as "demo organization" and all the data for the organization will be public (available without requiring login) on `<staging-url>/demo`.

The following setup is required beforehand:
```
org = Accounts::Organization.create!(status: "active", name: "Demo org name", created_by: "no-reply@tramline.app")
demo_email = "demo@tramline.app"
email_authentication = Accounts::EmailAuthentication.find_or_initialize_by(email: demo_email)
demo_user = Accounts::User.find_or_create_by!(full_name: "Demo User", preferred_name: "Demo User", admin: false, unique_authn_id: demo_email)
email_authentication.update!(password: <some password>, confirmed_at: DateTime.now, user: demo_user)
org.memberships << Accounts::Membership.new(user: demo_user, organization: org, role: "viewer")
```

Also, requires the following env variables:
```
DEMO_ORG_SLUG=<demo-org-slug>
DEMO_USER_SLUG=<demo-user-slug>
```