### PR TITLE
fix: Preserve casing of App name in browser title

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,7 +140,7 @@ module ApplicationHelper
     middle_section = app&.name || current_organization&.name
     prefix = release&.release_version.presence || page_name || middle_section
 
-    [prefix&.titleize, middle_section&.titleize, suffix&.titleize].compact.join(" | ")
+    [prefix&.titleize, middle_section, suffix&.titleize].compact.join(" | ")
   end
 
   def list_to_csv(list)


### PR DESCRIPTION
**Closes:** https://github.com/tramlinehq/site/issues/813

## Why

We want to preserve the App's name's casing in the browser's title.

## This addresses

The app/org name's casing being titleized in the browser's title.

When the app is present:
<img width="1440" alt="Screenshot 2025-05-25 at 9 49 42 AM" src="https://github.com/user-attachments/assets/851fba1f-a5b9-40dd-bec7-4d23c74d0d68" />

When the app is blank:
<img width="1440" alt="Screenshot 2025-05-25 at 9 50 48 AM" src="https://github.com/user-attachments/assets/13d1bbfd-a495-4d72-aa0c-9395e305e3fc" />

## Scenarios tested

- [x] When the app is present, the middle section has the app name with its casing preserved.
- [x] When the app is blank, the middle section has the organization name with its casing preserved.
