### PR TITLE
Set cookie when user switches org

### DIFF
--- a/app/controllers/accounts/organizations_controller.rb
+++ b/app/controllers/accounts/organizations_controller.rb
@@ -28,6 +28,7 @@ class Accounts::OrganizationsController < SignedInApplicationController
   end
 
   def switch
+    cookies["current_organization"] = {value: params[:id], expires: 30.days}
     session[:active_organization] = params[:id]
     redirect_to :root
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,8 +31,9 @@ class ApplicationController < ActionController::Base
         rescue ActiveRecord::RecordNotFound
           current_user&.organizations&.first
         end
-      else
-        current_user&.organizations&.first
+      elsif current_user.present?
+        current_user.organizations.find_by(name: cookies["current_organization"]) ||
+          current_user.organizations.first
       end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
           current_user&.organizations&.first
         end
       elsif current_user.present?
-        current_user.organizations.find_by(name: cookies["current_organization"]) ||
+        current_user.organizations.find_by(slug: cookies["current_organization"]) ||
           current_user.organizations.first
       end
   end


### PR DESCRIPTION
**Closes:** https://github.com/tramlinehq/site/issues/246

## Why

If user belongs to org 'A' and 'B' and he switches to 'B' and logs out, it's not definite that the next time he logs in, he will login to 'B'

## This addresses
Set a cookie when the user switches organizations. If the cookie is present, current_organization will use it; otherwise, it will default to the first organization the user belongs to..

## Scenarios tested

- Created 2 orgs 'fixtional' and 'suitcase' for user 'K'
- Logged in as 'fixtional'
- Switched to 'suitcase'
- Logged out
- Logged in again. Logged into 'suitcase' org :heavy_check_mark: 
- Switched to 'fixtional'.
- Logged out
- Logged in again. Logged into 'fixtional' org :heavy_check_mark: 
