### PR TITLE
Notification Settings: active flag supersedes all sub-flags

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,30 +15,30 @@ spec file="":
   fi
 
 lint:
-  docker exec -it tramline-web-1 bin/rubocop --autocorrect
-  docker exec -it tramline-web-1 bin/erb_lint --format compact --lint-all --autocorrect
+  docker compose exec web bin/rubocop --autocorrect
+  docker compose exec web bin/erb_lint --format compact --lint-all --autocorrect
 
 pre-setup:
   docker compose run --rm pre-setup
 
 rails +command="console":
-  docker exec -it tramline-web-1 bundle exec rails {{ command }}
+  docker compose exec web bundle exec rails {{ command }}
 
 rake +command:
-  docker exec -it tramline-web-1 bundle exec rake {{ command }}
+  docker compose exec web bundle exec rake {{ command }}
 
 bundle +command:
-  docker exec -it tramline-web-1 bundle {{ command }}
+  docker compose exec web bundle {{ command }}
 
 devlog log_lines="1000":
   tail -f -n {{ log_lines }} log/development.log
 
 bglog log_lines="20":
   @ echo "=====\nNOTE:\n=====\nWorker logs are STDOUT only.\nThis command tails and pull logs from the worker container.\nThis is in-line with how daemons should log: https://github.com/sidekiq/sidekiq/wiki/Logging#logger.\n↓"
-  docker-compose logs -f --no-log-prefix --tail={{ log_lines }} worker
+  docker compose logs -f --no-log-prefix --tail={{ log_lines }} worker
 
-attach container="web":
-  docker attach --detach-keys "ctrl-d" tramline-{{ container }}-1
+attach service="web":
+  docker compose attach --detach-keys "ctrl-d" {{ service }}
 
-shell container="web":
-  docker exec -it tramline-{{ container }}-1 /bin/bash
+shell service="web":
+  docker compose exec {{ service }} /bin/bash

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -122,6 +122,10 @@ class NotificationSetting < ApplicationRecord
         errors.add(:release_specific_enabled, :release_specific_not_enabled_in_train)
       end
     end
+
+    if active? && ![core_enabled, release_specific_enabled].any?
+      errors.add(:active, :at_least_one)
+    end
   end
 
   # rubocop:disable Rails/SkipsModelValidations

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -66,7 +66,21 @@ class NotificationSetting < ApplicationRecord
   delegate :app, to: :train
   delegate :notification_provider, to: :app
   delegate :channels, to: :notification_provider
+  before_validation :handle_active_flag
   validate :notification_channels_settings
+
+  def handle_active_flag
+    if release_specific_notifiable?
+      unless active?
+        self.core_enabled = false
+        self.release_specific_enabled = false
+      end
+    else
+      unless core_enabled?
+        self.active = false
+      end
+    end
+  end
 
   def notify!(message, params, file_id = nil, file_title = nil)
     return unless send_notifications?

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -95,7 +95,7 @@ class NotificationSetting < ApplicationRecord
       channels.concat(notification_channels)
     end
 
-    if release_specific_notifiable? && release_specific_channel.present?
+    if release_specific_notifiable? && release_specific_enabled? && release_specific_channel.present?
       channels.append(release_specific_channel)
     end
 
@@ -103,7 +103,7 @@ class NotificationSetting < ApplicationRecord
   end
 
   def release_specific_notifiable?
-    train.notifications_release_specific_channel_enabled? && release_specific_enabled?
+    train.notifications_release_specific_channel_enabled? && release_specific_channel_allowed?
   end
 
   def release_specific_channel_allowed?

--- a/app/views/notification_settings/edit.html+turbo_frame.erb
+++ b/app/views/notification_settings/edit.html+turbo_frame.erb
@@ -68,13 +68,22 @@
       <% end %>
     <% end %>
 
-    <% f.with_action do %>
-      <% f.F.authz_submit @setting.active? ? "Save" : "Enable", "archive.svg", size: :xs, name: f.F.field_name(:active), value: true %>
-    <% end %>
-
-    <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? && @setting.active? %>
-      <% f.with_action do %>
+    <% if @setting.release_specific_channel_allowed? && @train.notifications_release_specific_channel_enabled? %>
+      <% if @setting.active? %>
+        <% f.with_action do %>
+          <% f.F.authz_submit "Save", "archive.svg", size: :xs, name: f.F.field_name(:active), value: true %>
+        <% end %>
+        <% f.with_action do %>
           <% f.F.authz_submit "Disable", "archive_x.svg", size: :xs, scheme: :danger, name: f.F.field_name(:active), value: false %>
+        <% end %>
+      <% else %>
+        <% f.with_action do %>
+          <% f.F.authz_submit "Enable", "archive.svg", size: :xs, name: f.F.field_name(:active), value: true %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <% f.with_action do %>
+        <% f.F.authz_submit "Save", "archive.svg", size: :xs, name: f.F.field_name(:active), value: true %>
       <% end %>
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -505,6 +505,8 @@ en:
             release_specific_enabled:
               release_specific_channel_not_allowed_for_this_kind: "Release specific channel is not allowed for this kind of notification"
               release_specific_not_enabled_in_train: "Release specific channels are not enabled in train settings"
+            active:
+              at_least_one: "at least one type of notification delivery must be enabled"
         release_metadata:
           attributes:
             release_notes:

--- a/db/migrate/20250529022631_add_notification_setting_check.rb
+++ b/db/migrate/20250529022631_add_notification_setting_check.rb
@@ -1,0 +1,5 @@
+class AddNotificationSettingCheck < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint :notification_settings, "( (active is true and true = any(ARRAY[core_enabled, release_specific_enabled])) or (active is false and false = all(ARRAY[core_enabled, release_specific_enabled])) )", validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_22_160156) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_29_022631) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -443,6 +443,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_22_160156) do
     t.boolean "core_enabled", default: false, null: false
     t.index ["train_id", "kind"], name: "index_notification_settings_on_train_id_and_kind", unique: true
     t.index ["train_id"], name: "index_notification_settings_on_train_id"
+    t.check_constraint "active IS TRUE AND (true = ANY (ARRAY[core_enabled, release_specific_enabled])) OR active IS FALSE AND (false = ALL (ARRAY[core_enabled, release_specific_enabled]))", validate: false
   end
 
   create_table "organizations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Why

Improvements over #805 

## This addresses

1. Dev improvements - Uses docker compose commands so that multiple instances can be run for development.
2. Adds check constraint to validate the flags.
3. Core enabled & release specific flags are reset to false if active is false.
4. Active is set to false if core enabled is false (non-release specific case).
5. Improves form UI for clarity in Enable/Save button.
6. Adds validation so that invalid state cannot be saved.

## Scenarios tested

- [x] Check constraint works - does not allow to set active to true and both flags to false, or vice-versa.
- [x] Enable button appears when the flag is disabled, and Save button appears at other times.
- [x] Flag validation works correctly and shows error when active is true and neither of core_enabled & release_specific_enabled is true.
- [x] Train creation - both with and without release specific notification works
