### PR TITLE
Notification Setting: Check core_enabled for validating notification_channels

### DIFF
--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -125,7 +125,7 @@ class NotificationSetting < ApplicationRecord
   end
 
   def notification_channels_settings
-    if active? && notification_channels.blank?
+    if core_enabled? && notification_channels.blank?
       errors.add(:notification_channels, :at_least_one)
     end
 


### PR DESCRIPTION
Related to #822 and #805.

Was checking the wrong flag for validating notification_channels.