### PR TITLE
Search improvements

### DIFF
--- a/app/components/pull_request_component.rb
+++ b/app/components/pull_request_component.rb
@@ -35,6 +35,6 @@ class PullRequestComponent < ViewComponent::Base
 
   def truncated_title
     title = enable_truncate ? pr.title.truncate(DEFAULT_TRUNCATE) : pr.title
-    render_html ? sanitize(title, tags: %w[span]) : title
+    render_html ? sanitize(title, tags: %w[mark span]) : title
   end
 end

--- a/app/components/vertical_tab_component.html.erb
+++ b/app/components/vertical_tab_component.html.erb
@@ -15,7 +15,7 @@
             data-activation-active-value="<%= SELECTED_TAB_STYLE %>"
             data-activation-inactive-value="<%= TAB_STYLE %>">
 
-          <% sorted_configs.each do |(_position, name, path, icon)| %>
+          <% sorted_configs.each do |(_position, name, path, count, icon)| %>
             <li class="flex items-center justify-center w-full gap-2">
               <div data-turbo-prefetch="false" class="w-full mr-2">
                 <a href="<%= path %>"
@@ -26,7 +26,14 @@
                    class="<%= style(path) %>">
 
                   <div class="flex gap-2 items-center">
-                    <span class="text-sm font-normal py-1.5 dark:bg-gray-200"><%= name %></span>
+                    <span class="text-sm font-normal py-1.5 dark:bg-gray-200">
+                      <%= name %>
+                    </span>
+                    <% if count.present? %>
+                      <span class="inline-flex items-center justify-center px-2 py-0.5 ml-1 text-xs font-bold leading-none text-white bg-gray-500 rounded-full min-w-[1.5em] h-[1.5em]">
+                        <%= count %>
+                      </span>
+                    <% end %>
                   </div>
 
                   <%= render IconComponent.new(icon, size: :md) %>

--- a/app/components/vertical_tab_component.html.erb
+++ b/app/components/vertical_tab_component.html.erb
@@ -30,9 +30,7 @@
                       <%= name %>
                     </span>
                     <% if count.present? %>
-                      <span class="inline-flex items-center justify-center px-2 py-0.5 ml-1 text-xs font-bold leading-none text-white bg-gray-500 rounded-full min-w-[1.5em] h-[1.5em]">
-                        <%= count %>
-                      </span>
+                      <%= render BadgeComponent.new(text: count, kind: :badge) %>
                     <% end %>
                   </div>
 

--- a/app/components/vertical_tab_component.rb
+++ b/app/components/vertical_tab_component.rb
@@ -8,7 +8,7 @@ class VerticalTabComponent < BaseComponent
 
   def initialize(turbo_frame:, sidebar_header:, tab_config: [], error_resource: nil)
     raise ArgumentError, "tab_config must be an array" unless tab_config.is_a?(Array)
-    raise ArgumentError, "tab_config must be an array of arrays" unless tab_config.all? { _1.length == 4 }
+    raise ArgumentError, "tab_config must be an array of arrays" unless tab_config.all? { _1.length == 5 }
 
     @tab_config = tab_config
     @turbo_frame = turbo_frame

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -74,10 +74,9 @@ class AppsController < SignedInApplicationController
     gen_query_filters(:release_status, Release.statuses[:finished])
     set_query_helpers
     @query_params.add_search_query(params[:search_pattern]) if params[:search_pattern].present?
-    set_query_pagination(Queries::Releases.count(app: @app, params: @query_params))
-    @releases = Queries::Releases.all(app: @app, params: @query_params)
-    @builds = Queries::Builds.all(app: @app, params: @query_params)
     set_search_result_counts
+    set_query_pagination(@releases_count.presence || 0)
+    @releases = Queries::Releases.all(app: @app, params: @query_params)
     set_search_tab_config
   end
 
@@ -87,10 +86,9 @@ class AppsController < SignedInApplicationController
     gen_query_filters(:release_status, ReleasePlatformRun.statuses[:finished])
     set_query_helpers
     @query_params.add_search_query(params[:search_pattern]) if params[:search_pattern].present?
-    set_query_pagination(Queries::Builds.count(app: @app, params: @query_params))
-    @releases = Queries::Releases.all(app: @app, params: @query_params)
-    @builds = Queries::Builds.all(app: @app, params: @query_params)
     set_search_result_counts
+    set_query_pagination(@builds_count.presence || 0)
+    @builds = Queries::Builds.all(app: @app, params: @query_params)
     set_search_tab_config
   end
 
@@ -103,8 +101,8 @@ class AppsController < SignedInApplicationController
 
   def set_search_result_counts
     if @query_params.search_query.present?
-      @releases_count = @releases.count
-      @builds_count = @builds.count
+      @releases_count = Queries::Releases.count(app: @app, params: @query_params)
+      @builds_count = Queries::Builds.count(app: @app, params: @query_params)
     end
   end
 

--- a/app/libs/queries/builds.rb
+++ b/app/libs/queries/builds.rb
@@ -24,8 +24,8 @@ class Queries::Builds
 
   def initialize(app:, params:)
     @app = app
-    @params = params
-    params.sort_column ||= DEFAULT_SORT_COLUMN
+    @params = params.dup
+    @params.sort_column ||= DEFAULT_SORT_COLUMN
   end
 
   attr_reader :app, :sort_column, :sort_direction, :params

--- a/app/libs/queries/releases.rb
+++ b/app/libs/queries/releases.rb
@@ -13,8 +13,8 @@ class Queries::Releases
 
   def initialize(app:, params:)
     @app = app
-    @params = params
-    params.sort_column ||= DEFAULT_SORT_COLUMN
+    @params = params.dup
+    @params.sort_column ||= DEFAULT_SORT_COLUMN
   end
 
   attr_reader :app, :sort_column, :sort_direction, :params

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -408,7 +408,7 @@ class Release < ApplicationRecord
   end
 
   def build_number
-    builds.order(created_at: :desc).select(:build_number).first&.build_number
+    builds.order(created_at: :desc).limit(1).pick(:build_number)
   end
 
   alias_method :version_current, :release_version

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -407,6 +407,10 @@ class Release < ApplicationRecord
     release_platform_runs.pluck(:release_version).map(&:to_semverish).max.to_s
   end
 
+  def build_number
+    builds.order(created_at: :desc).select(:build_number).first&.build_number
+  end
+
   alias_method :version_current, :release_version
 
   def release_branch

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -408,7 +408,7 @@ class Release < ApplicationRecord
   end
 
   def build_number
-    builds.order(created_at: :desc).limit(1).pick(:build_number)
+    builds.order(created_at: :desc).pick(:build_number)
   end
 
   alias_method :version_current, :release_version

--- a/app/presenters/release_presenter.rb
+++ b/app/presenters/release_presenter.rb
@@ -58,6 +58,14 @@ class ReleasePresenter < SimpleDelegator
     release_version
   end
 
+  def has_builds?
+    display_build_number.present?
+  end
+
+  memoize def display_build_number
+    build_number
+  end
+
   delegate :team_release_commits, :team_stability_commits, :reldex, to: :breakdown
 
   def hotfix_badge

--- a/app/presenters/release_presenter.rb
+++ b/app/presenters/release_presenter.rb
@@ -58,12 +58,9 @@ class ReleasePresenter < SimpleDelegator
     release_version
   end
 
-  def has_build_number?
-    display_build_number.present?
-  end
-
-  memoize def display_build_number
-    build_number
+  def display_build_number
+    build_number = self.build_number
+    build_number.present? ? "(#{build_number})" : nil
   end
 
   delegate :team_release_commits, :team_stability_commits, :reldex, to: :breakdown

--- a/app/presenters/release_presenter.rb
+++ b/app/presenters/release_presenter.rb
@@ -58,7 +58,7 @@ class ReleasePresenter < SimpleDelegator
     release_version
   end
 
-  def has_builds?
+  def has_build_number?
     display_build_number.present?
   end
 

--- a/app/views/apps/search/_all_releases_search_results.html.erb
+++ b/app/views/apps/search/_all_releases_search_results.html.erb
@@ -15,7 +15,12 @@
       <div class="flex flex-col gap-y-2">
         <div class="flex items-center justify-between border-default-b px-1 py-1 mb-3">
           <div class="flex justify-start item-gap-default">
-            <h2 class="heading-2 text-main dark:text-white font-normal">Release <%= release.display_release_version %></h2>
+            <h2 class="heading-2 text-main dark:text-white font-normal">
+              Release <%= release.display_release_version %>
+              <% if release.has_builds? %>
+                (<%= release.display_build_number %>)
+              <% end %>
+            </h2>
             <div class="flex items-center gap-1">
               <%= render BadgeComponent.new(**release.release_status) %>
               <%= render BadgeComponent.new(text: "Started on #{release.display_start_time}", kind: :badge) %>

--- a/app/views/apps/search/_all_releases_search_results.html.erb
+++ b/app/views/apps/search/_all_releases_search_results.html.erb
@@ -17,7 +17,7 @@
           <div class="flex justify-start item-gap-default">
             <h2 class="heading-2 text-main dark:text-white font-normal">
               Release <%= release.display_release_version %>
-              <% if release.has_builds? %>
+              <% if release.has_build_number? %>
                 (<%= release.display_build_number %>)
               <% end %>
             </h2>

--- a/app/views/apps/search/_all_releases_search_results.html.erb
+++ b/app/views/apps/search/_all_releases_search_results.html.erb
@@ -16,10 +16,7 @@
         <div class="flex items-center justify-between border-default-b px-1 py-1 mb-3">
           <div class="flex justify-start item-gap-default">
             <h2 class="heading-2 text-main dark:text-white font-normal">
-              Release <%= release.display_release_version %>
-              <% if release.has_build_number? %>
-                (<%= release.display_build_number %>)
-              <% end %>
+              Release <%= release.display_release_version %> <%= release.display_build_number %>
             </h2>
             <div class="flex items-center gap-1">
               <%= render BadgeComponent.new(**release.release_status) %>

--- a/app/views/apps/search_builds.html.erb
+++ b/app/views/apps/search_builds.html.erb
@@ -1,4 +1,5 @@
 <%= render ContainerComponent.new(title: "Search Tramline", subtitle: "Search through releases, commits, pull requests, and builds") do |container| %>
+  <% container.with_back_button %>
   <% container.with_body do %>
     <%= render SearchBarComponent.new(search_name: :search, search_value: params[:search_pattern], search_placeholder: "commits, PRs, versions") do |search| %>
       <% search.with_notice do %>

--- a/app/views/apps/search_releases.html.erb
+++ b/app/views/apps/search_releases.html.erb
@@ -1,4 +1,5 @@
 <%= render ContainerComponent.new(title: "Search Tramline", subtitle: "Search through releases, commits, pull requests, and builds") do |container| %>
+  <% container.with_back_button %>
   <% container.with_body do %>
     <%= render SearchBarComponent.new(search_name: :search, search_value: params[:search_pattern], search_placeholder: "commits, PRs, versions") do |search| %>
       <% search.with_notice do %>


### PR DESCRIPTION
**Closes:** https://github.com/tramlinehq/site/issues/807

## Why

The search screen currently has a few minor issues UX - these changes attempt to fix those.

## This addresses

- showing the final build number of a release in the search result
    - this renders the latest build's `build_number` besides the release version if it's present
- highlighting the search term when search results have pull requests
- show the total number of results on each tab, even if the user does not open the tab
    - the number of results for each search tab only show up if there's a search term entered by a user
- showing a back button on the search page

| Scenario | Screenshot |
| --- | --- |
| When no search term is entered | <img width="1439" alt="Screenshot 2025-06-16 at 11 48 59 PM" src="https://github.com/user-attachments/assets/5bbdc01a-cc67-4f2b-9784-f031ff8fcf82" /> |
| When a search term is entered | <img width="1439" alt="Screenshot 2025-06-17 at 11 38 44 PM" src="https://github.com/user-attachments/assets/0d710342-d185-45c4-abbf-e49b32d70460" /> |
| When no builds exist/relevant pull requests are present | <img width="1440" alt="Screenshot 2025-06-17 at 11 39 07 PM" src="https://github.com/user-attachments/assets/6b276ee6-83c7-4329-b74b-f5ad83fe104d" /> |
| When builds are present | <img width="1440" alt="Screenshot 2025-06-17 at 11 39 30 PM" src="https://github.com/user-attachments/assets/87b41a4b-ecb1-4280-b09a-7a02bbc545ee" /> |

## Scenarios tested

- [x] Show the final build number of a release in the search result
- [x] Don't show the build number of a release if the build does not exist
- [x] When search results have pull requests, highlight the search term
- [x] Show the total number of results on each tab, even if the user does not open the tab
- [x] Don't show any search result count if no search term was entered
- [x] Navigate back to the top of the history stack from the search releases page
- [x] Navigate back to the top of the history stack from the search builds page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added badges to vertical tabs to display counts for each tab.
  * Introduced back button in search results for builds and releases.
  * Release search results now display both the release version and its build number.

* **Enhancements**
  * Improved tab configuration to include dynamic result counts.
  * Search tab labels now support multiline display and visual badges.

* **Bug Fixes**
  * Prevented unintended changes to search parameters during builds and releases queries.

* **Other**
  * Expanded support for additional HTML tags in pull request titles for enhanced highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->