### PR TITLE
Close the right-side pane when the user clicks outside the pane

### DIFF
--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -57,7 +57,7 @@
         <%= body %>
       </div>
 
-      <div class="bg-main-800/50 dark:bg-main-800/80 fixed inset-0 z-40"></div>
+      <div class="bg-main-800/50 dark:bg-main-800/80 fixed inset-0 z-40" data-action="click->reveal#hide"></div>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
**Closes:** https://github.com/tramlinehq/site/issues/809

## Why

A small QOL improvement for the drawers (right-side panes) used throughout the app.

## This addresses

Changes introduced as part of this add a Stimulus action to the drawer's back-drop to allow clicking outside the pane to close the drawer.

https://github.com/user-attachments/assets/f8131f9f-0ff7-46dd-94cc-b9779463bdc9

## Scenarios tested

- [ ] Reldex
- [x] Build Insights in the Internal builds and Release candidate panes of a release page
- [ ] Timeline in the Rollout pane of a release page
