### PR TITLE
Add play store deep link to rc finished notification

### DIFF
--- a/app/libs/notifiers/slack/renderers/rc_finished.rb
+++ b/app/libs/notifiers/slack/renderers/rc_finished.rb
@@ -9,7 +9,7 @@ module Notifiers
         if submission.deep_link.present?
           ":white_check_mark: Submitted to <#{submission.deep_link}|*#{submission.display}*>"
         else
-          ":white_check_mark: Submitted to *<#{submission.display}>"
+          ":white_check_mark: Submitted to *<#{submission.display}>*"
         end
       end
     end

--- a/app/libs/notifiers/slack/renderers/rc_finished.rb
+++ b/app/libs/notifiers/slack/renderers/rc_finished.rb
@@ -9,7 +9,7 @@ module Notifiers
         if submission.deep_link.present?
           ":white_check_mark: Submitted to <#{submission.deep_link}|*#{submission.display}*>"
         else
-          ":white_check_mark: Submitted to *<#{submission.display}>*"
+          ":white_check_mark: Submitted to *#{submission.display}*"
         end
       end
     end

--- a/app/models/play_store_submission.rb
+++ b/app/models/play_store_submission.rb
@@ -55,6 +55,7 @@ class PlayStoreSubmission < StoreSubmission
   PRE_PREPARE_STATES = %w[created preprocessing review_failed failed]
   CHANGEABLE_STATES = %w[created preprocessing failed prepared]
   MAX_NOTES_LENGTH = 500
+  DEEP_LINK_BASE = "https://play.google.com/store/apps/details?id="
 
   enum :failure_reason, {
     unknown_failure: "unknown_failure"
@@ -266,6 +267,10 @@ class PlayStoreSubmission < StoreSubmission
     previous_rollout = previous_run.finished_production_release.store_rollout
     previous_rollout.release_fully! if previous_rollout.rollout_in_progress?
     previous_rollout
+  end
+
+  def deep_link
+    DEEP_LINK_BASE + app.bundle_identifier
   end
 
   private


### PR DESCRIPTION
## Why

Deep link for play store was absent in RC Finished notification.

## This addresses

Adds the deep link.

![image](https://github.com/user-attachments/assets/024ad587-9d27-4f0f-9e30-e0d0f7102068)

Also fixes the submission text without deep link.

![image](https://github.com/user-attachments/assets/0be76a23-9dc4-4253-b7f7-100db747cd1a)

## Scenarios tested

- [x] Valid play store link is generated
- [x] Opens app in play store when link is clicked on phone
