### PR TITLE
Simplify multiple changelogs in RC finished notifications

### DIFF
--- a/app/libs/notifiers/slack/renderers/changelog.rb
+++ b/app/libs/notifiers/slack/renderers/changelog.rb
@@ -15,9 +15,9 @@ module Notifiers
 
       def changelog_header
         if @continuation
-          "…_#{@header}_"
+          "…_#{@header_affix}_"
         else
-          ":book: *#{@header}*"
+          ":book: *#{@header_affix}*"
         end
       end
     end

--- a/app/libs/notifiers/slack/renderers/changelog.rb
+++ b/app/libs/notifiers/slack/renderers/changelog.rb
@@ -12,6 +12,14 @@ module Notifiers
       def render_footer
         {blocks: []}.to_json
       end
+
+      def changelog_header
+        if @continuation
+          "…_#{@header}_"
+        else
+          ":book: *#{@header}*"
+        end
+      end
     end
   end
 end

--- a/app/libs/notifiers/slack/renderers/internal_release_finished.rb
+++ b/app/libs/notifiers/slack/renderers/internal_release_finished.rb
@@ -5,8 +5,12 @@ module Notifiers
 
       def main_text
         text = ":sparkles: The internal build step finished for *#{@release_version} (#{@build_number})* for commit <#{@commit_url}|#{@commit_sha}>."
-        text += " The build has been sent to #{@submission_channels}." if @submission_channels.present?
+        text += " The build has been sent to #{submission_channels}." if submission_channels.present?
         text
+      end
+
+      def submission_channels
+        @submissions.map { |s| "#{s.provider.display} - #{s.submission_channel.name}" }.join(", ")
       end
     end
   end

--- a/app/libs/notifiers/slack/renderers/production_rollout_started.rb
+++ b/app/libs/notifiers/slack/renderers/production_rollout_started.rb
@@ -14,6 +14,10 @@ module Notifiers
       def initial_rollout_percentage_text
         "🎢 Initial rollout percentage is *#{@rollout_percentage}%*."
       end
+
+      def changelog_header
+        ":memo: *#{@changelog[:header]}*"
+      end
     end
   end
 end

--- a/app/libs/notifiers/slack/renderers/production_rollout_started.rb
+++ b/app/libs/notifiers/slack/renderers/production_rollout_started.rb
@@ -16,7 +16,7 @@ module Notifiers
       end
 
       def changelog_header
-        ":memo: *#{@changelog[:header]}*"
+        ":memo: *#{@changelog[:header_affix]}*"
       end
     end
   end

--- a/app/libs/notifiers/slack/renderers/rc_finished.rb
+++ b/app/libs/notifiers/slack/renderers/rc_finished.rb
@@ -5,16 +5,16 @@ module Notifiers
     class Renderers::RcFinished < Renderers::Base
       TEMPLATE_FILE = "rc_finished.json.erb"
 
-      def submission_text(submission)
-        if submission.deep_link.present?
-          ":white_check_mark: Submitted to <#{submission.deep_link}|*#{submission.display}*>"
+      def submission_text(sub)
+        if sub.deep_link.present?
+          ":white_check_mark: Submitted to <#{sub.deep_link}|*#{sub.display}* (#{sub.submission_channel.name})>"
         else
-          ":white_check_mark: Submitted to *#{submission.display}*"
+          ":white_check_mark: Submitted to *#{sub.display}* (#{sub.submission_channel.name})"
         end
       end
 
       def changelog_header
-        ":memo: *#{@changelog[:header]}*"
+        ":memo: *#{@changelog[:header_affix]}*"
       end
     end
   end

--- a/app/libs/notifiers/slack/renderers/rc_finished.rb
+++ b/app/libs/notifiers/slack/renderers/rc_finished.rb
@@ -12,6 +12,10 @@ module Notifiers
           ":white_check_mark: Submitted to *#{submission.display}*"
         end
       end
+
+      def changelog_header
+        ":memo: *#{@changelog[:header]}*"
+      end
     end
   end
 end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -160,9 +160,9 @@ class NotificationSetting < ApplicationRecord
     notifiable_channels.each do |channel|
       thread_id =
         notification_provider.notify_with_threaded_changelog!(channel, message, kind, params,
-                                                              changelog_key: :diff_changelog,
-                                                              changelog_partitions: CHANGELOG_PER_MESSAGE_LIMIT,
-                                                              header_affix: "Changes in this build")
+          changelog_key: :diff_changelog,
+          changelog_partitions: CHANGELOG_PER_MESSAGE_LIMIT,
+          header_affix: "Changes in this build")
 
       # show full changelog when necessary
       # todo: we can probably also encapsulate this nicely like we do for notify_with_threaded_changelog!
@@ -175,15 +175,15 @@ class NotificationSetting < ApplicationRecord
         # first send the initial part of the changelog
         header_affix = "Full release changelog"
         notification_provider.notify_changelog!(channel["id"], message, thread_id, full_parts[0],
-                                                header_affix: header_affix,
-                                                continuation: false)
+          header_affix: header_affix,
+          continuation: false)
 
         # send the rest of the parts as "continuations"
         full_parts[1..].each.with_index(2) do |change_group, index|
           continuation_header_affix = "#{header_affix} (#{index}/#{full_parts.size})"
           notification_provider.notify_changelog!(channel["id"], message, thread_id, change_group,
-                                                  header_affix: continuation_header_affix,
-                                                  continuation: true)
+            header_affix: continuation_header_affix,
+            continuation: true)
         end
       end
     end
@@ -192,9 +192,9 @@ class NotificationSetting < ApplicationRecord
   def notify_production_rollout_started!(message, params)
     notifiable_channels.each do |channel|
       notification_provider.notify_with_threaded_changelog!(channel, message, kind, params,
-                                                            changelog_key: :diff_changelog,
-                                                            changelog_partitions: CHANGELOG_PER_MESSAGE_LIMIT,
-                                                            header_affix: "Changes in release")
+        changelog_key: :diff_changelog,
+        changelog_partitions: CHANGELOG_PER_MESSAGE_LIMIT,
+        header_affix: "Changes in release")
     end
   end
 end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -59,7 +59,7 @@ class NotificationSetting < ApplicationRecord
   ]
   RELEASE_SPECIFIC_CHANNEL_ALLOWED_KINDS = NotificationSetting.kinds.keys.map(&:to_sym) - RELEASE_SPECIFIC_CHANNEL_NOT_ALLOWED_KINDS
   THREADED_CHANGELOG_NOTIFICATION_KINDS = [:rc_finished, :production_rollout_started]
-  CHANGELOG_PER_MESSAGE_LIMIT = 2
+  CHANGELOG_PER_MESSAGE_LIMIT = 20
 
   scope :active, -> { where(active: true) }
   scope :release_specific_channel_allowed, -> { where(kind: RELEASE_SPECIFIC_CHANNEL_ALLOWED_KINDS) }

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -167,8 +167,8 @@ class NotificationSetting < ApplicationRecord
       # show full changelog when necessary
       # todo: we can probably also encapsulate this nicely like we do for notify_with_threaded_changelog!
       # todo: but in the interest of time, this is sort of manually hand-constructed
-      single_changelog_set = params[:first_pre_prod_release] || false
-      unless single_changelog_set
+      show_full_changelog = !params[:first_pre_prod_release] || false
+      if show_full_changelog
         full = params[:full_changelog]
         full_parts = full.in_groups_of(CHANGELOG_PER_MESSAGE_LIMIT, false)
 

--- a/app/models/slack_integration.rb
+++ b/app/models/slack_integration.rb
@@ -123,14 +123,7 @@ class SlackIntegration < ApplicationRecord
     return if response.blank?
     response.dig("message", "ts")
   rescue => e
-    elog(e, level: :debug)
-  end
-
-  def notify_changelog_in_thread!(channel, message, thread_id, changelog, header: nil)
-    return if changelog.blank?
-    payload = notifier(:changelog, {changes: changelog, header: header})
-    installation.message(channel, message, block: payload, thread_id:)
-  rescue => e
+    Rails.logger.error("Error sending message to Slack: #{e.message}")
     elog(e, level: :debug)
   end
 
@@ -146,6 +139,38 @@ class SlackIntegration < ApplicationRecord
     end
   rescue => e
     elog(e, level: :warn)
+  end
+
+  # renders the changelog exclusively in a thread
+  def notify_changelog!(channel, message, thread_id, changelog, header_affix: nil, continuation: false)
+    return if changelog.blank?
+    payload = notifier(:changelog, {changes: changelog, header: header_affix, continuation:})
+    installation.message(channel, message, block: payload, thread_id:)
+  rescue => e
+    elog(e, level: :debug)
+  end
+
+  # renders the primary notification and then threads a changelog as necessary
+  def notify_with_threaded_changelog!(channel, message, type, params, changelog_key:, changelog_partitions:, header_affix:)
+    changelog = params[changelog_key]
+    return if changelog.blank?
+
+    changelog_parts = changelog.in_groups_of(changelog_partitions, false)
+    params[:changelog] = {first_part: changelog_parts[0], total_parts: changelog_parts.size, header: header_affix}
+
+    # send the initial part of the notification
+    thread_id = notify!(channel["id"], message, type, params)
+    return unless thread_id
+
+    # thread the changelog if necessary
+    if changelog_parts.size > 1
+      changelog_parts[1..].each.with_index(2) do |change_group, index|
+        header_affix = "#{header_affix} (#{index}/#{changelog_parts.size})"
+        notify_changelog!(channel["id"], message, thread_id, change_group, header_affix:, continuation: true)
+      end
+    end
+
+    thread_id
   end
 
   def upload_file!(file, file_name)

--- a/app/views/notifiers/slack/changelog.json.erb
+++ b/app/views/notifiers/slack/changelog.json.erb
@@ -1,14 +1,12 @@
 {
   "blocks": [
-    <% if @header.present? %>
     {
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": ":pushpin: *<%= @header %>*"
+        "text": "<%= changelog_header %>"
       }
     },
-    <% end %>
     {
       "type": "rich_text",
       "elements": [

--- a/app/views/notifiers/slack/production_rollout_started.json.erb
+++ b/app/views/notifiers/slack/production_rollout_started.json.erb
@@ -26,14 +26,13 @@
           "emoji": false
         }
       ]
-    }
+    },
     <% end %>
-    <% if changelog[:last_run].present? %>,
     {
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "*:book: Changes in release*"
+        "text": "<%= changelog_header %>"
       }
     },
     {
@@ -43,7 +42,7 @@
           "type": "rich_text_list",
           "style": "bullet",
           "elements": [
-            <% changelog[:last_run].each_with_index do |change, i| %>
+            <% changelog[:first_part].each_with_index do |change, i| %>
             <%= i.zero? ? "" : "," %>
             {
               "type": "rich_text_section",
@@ -59,17 +58,16 @@
         }
       ]
     }
-    <% if changelog[:last_run_part_count] > 1 %>,
+    <% if changelog[:total_parts] > 1 %>,
     {
       "type": "context",
       "elements": [
         {
           "type": "mrkdwn",
-          "text": "Changes in release – part 1/<%= changelog[:last_run_part_count] %>, continued in thread :thread:"
+          "text": "Changes in release, continued in thread :thread:"
         }
       ]
     }
-    <% end %>
     <% end %>
   ]
 }

--- a/app/views/notifiers/slack/production_rollout_started.json.erb
+++ b/app/views/notifiers/slack/production_rollout_started.json.erb
@@ -42,7 +42,7 @@
           "type": "rich_text_list",
           "style": "bullet",
           "elements": [
-            <% changelog[:first_part].each_with_index do |change, i| %>
+            <% @changelog[:first_part].each_with_index do |change, i| %>
             <%= i.zero? ? "" : "," %>
             {
               "type": "rich_text_section",
@@ -58,7 +58,7 @@
         }
       ]
     }
-    <% if changelog[:total_parts] > 1 %>,
+    <% if @changelog[:total_parts] > 1 %>,
     {
       "type": "context",
       "elements": [

--- a/app/views/notifiers/slack/rc_finished.json.erb
+++ b/app/views/notifiers/slack/rc_finished.json.erb
@@ -6,22 +6,21 @@
         "type": "mrkdwn",
         "text": ":sparkles: *New RC deployed for <%= @release_version %> (<%= @build_number %>)*"
       }
-    }
-    <% @submissions.each do |submission| %>,
+    },
+    <% @submissions.each do |submission| %>
     {
       "type": "section",
       "text": {
         "type": "mrkdwn",
         "text": "<%= submission_text(submission) %>"
       }
-    }
+    },
     <% end %>
-    <% if changelog[:last_run].present? %>,
     {
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": ":pushpin: *Changelog*"
+        "text": "<%= changelog_header %>"
       }
     },
     {
@@ -31,7 +30,7 @@
           "type": "rich_text_list",
           "style": "bullet",
           "elements": [
-            <% changelog[:last_run].each_with_index do |change, i| %>
+            <% changelog[:first_part].each_with_index do |change, i| %>
             <%= i.zero? ? "" : "," %>
             {
               "type": "rich_text_section",
@@ -47,18 +46,18 @@
         }
       ]
     }
-    <% if changelog[:last_run_part_count] > 1 %>,
+    <% if changelog[:total_parts] > 1 %>,
     {
       "type": "context",
       "elements": [
         {
           "type": "mrkdwn",
-          "text": "Changelog part 1/<%= changelog[:last_run_part_count] %>, continued in thread :thread:"
+          "text": "Changes in this build, continued in thread :thread:"
         }
       ]
     }
     <% end %>
-    ,
+    <% unless @first_pre_prod_release %>,
     {
       "type": "context",
       "elements": [
@@ -68,48 +67,6 @@
         }
       ]
     }
-    <% elsif changelog[:last_release].present? %>,
-    {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": ":pushpin: *Changes since last release*"
-      }
-    },
-    {
-      "type": "rich_text",
-      "elements": [
-        {
-          "type": "rich_text_list",
-          "style": "bullet",
-          "elements": [
-            <% changelog[:last_release].each_with_index do |change, i| %>
-            <%= i.zero? ? "" : "," %>
-            {
-              "type": "rich_text_section",
-              "elements": [
-                {
-                  "type": "text",
-                  "text": "<%= safe_string(change) %>"
-                }
-              ]
-            }
-            <% end %>
-          ]
-        }
-      ]
-    }
-    <% if changelog[:last_release_part_count] > 1 %>,
-    {
-      "type": "context",
-      "elements": [
-        {
-          "type": "mrkdwn",
-          "text": "Changes since last release part 1/<%= changelog[:last_release_part_count] %>, continued in thread :thread:"
-        }
-      ]
-    }
-    <% end %>
     <% end %>
   ]
 }

--- a/app/views/notifiers/slack/rc_finished.json.erb
+++ b/app/views/notifiers/slack/rc_finished.json.erb
@@ -30,7 +30,7 @@
           "type": "rich_text_list",
           "style": "bullet",
           "elements": [
-            <% changelog[:first_part].each_with_index do |change, i| %>
+            <% @changelog[:first_part].each_with_index do |change, i| %>
             <%= i.zero? ? "" : "," %>
             {
               "type": "rich_text_section",
@@ -46,7 +46,7 @@
         }
       ]
     }
-    <% if changelog[:total_parts] > 1 %>,
+    <% if @changelog[:total_parts] > 1 %>,
     {
       "type": "context",
       "elements": [

--- a/db/data/20250605073404_add_rc_finished_notification.rb
+++ b/db/data/20250605073404_add_rc_finished_notification.rb
@@ -2,7 +2,7 @@
 
 class AddRcFinishedNotification < ActiveRecord::Migration[7.2]
   def up
-    Train.active.find_each do |train|
+    Train.find_each do |train|
       next unless train.send_notifications?
 
       train.notification_settings.create!(

--- a/spec/models/pre_prod_release_spec.rb
+++ b/spec/models/pre_prod_release_spec.rb
@@ -84,7 +84,9 @@ describe PreProdRelease do
     it "returns the release changelog when its the first pre-prod release" do
       release_changelog = create(:release_changelog, release:)
       first_release = create(:beta_release, release_platform_run:)
+
       result = first_release.changes_since_previous
+
       expect(result.size).to be > 0
       expect(result).to eq(release_changelog.commit_messages(true))
     end
@@ -98,6 +100,7 @@ describe PreProdRelease do
 
       result = second_release.changes_since_previous
       expected_messages = (release_changelog.commits.pluck(:message) + [first_commit.message, second_commit.message]).uniq
+
       expect(result.size).to be > 0
       expect(result).to match_array(expected_messages)
     end
@@ -110,6 +113,7 @@ describe PreProdRelease do
 
       result = release.changes_since_previous
       expected_messages = (release_changelog.commits.pluck(:message) + [first_commit.message, second_commit.message]).uniq
+
       expect(result.size).to be > 0
       expect(result).to match_array(expected_messages)
     end
@@ -120,7 +124,9 @@ describe PreProdRelease do
       first_release = create(:beta_release, :finished, release_platform_run:, commit: first_commit)
       second_commit = create(:commit, release:)
       second_release = create(:beta_release, release_platform_run:, commit: second_commit, previous: first_release)
+
       result = second_release.changes_since_previous
+
       expect(result.size).to be > 0
       expect(result).to contain_exactly(second_commit.message)
     end
@@ -133,34 +139,26 @@ describe PreProdRelease do
       _second_release = create(:beta_release, :stale, release_platform_run:, commit: second_commit, previous: first_release)
       third_commit = create(:commit, release:)
       third_release = create(:beta_release, release_platform_run:, commit: third_commit, previous: first_release)
+
       result = third_release.changes_since_previous
+
       expect(result.size).to be > 0
       expect(result).to contain_exactly(second_commit.message, third_commit.message)
     end
-  end
 
-  describe "#changes_since_last_release" do
-    let(:release) { create(:release, :with_no_platform_runs) }
-    let(:release_platform_run) { create(:release_platform_run, release:) }
+    context "when skip delta is true" do
+      it "returns the release changelog + all the new fixes so far" do
+        release_changelog = create(:release_changelog, release:)
+        first_commit = create(:commit, release:)
+        second_commit = create(:commit, release:)
+        release = create(:beta_release, release_platform_run:, commit: second_commit)
 
-    it "returns the release changelog when its the first pre-prod release" do
-      release_changelog = create(:release_changelog, release:)
-      first_release = create(:beta_release, release_platform_run:)
-      result = first_release.changes_since_last_release
-      expect(result.size).to be > 0
-      expect(result).to eq(release_changelog.commit_messages(true))
-    end
+        result = release.changes_since_previous(skip_delta: true)
+        expected_messages = (release_changelog.commits.pluck(:message) + [first_commit.message, second_commit.message]).uniq
 
-    it "returns the release changelog" do
-      release_changelog = create(:release_changelog, release:)
-      first_commit = create(:commit, release:)
-      _first_release = create(:beta_release, :stale, release_platform_run:, commit: first_commit)
-      second_commit = create(:commit, release:)
-      second_release = create(:beta_release, release_platform_run:, commit: second_commit)
-
-      result = second_release.changes_since_last_release
-      expect(result.size).to be > 0
-      expect(result).to eq(release_changelog.commit_messages(true))
+        expect(result.size).to be > 0
+        expect(result).to match_array(expected_messages)
+      end
     end
   end
 end


### PR DESCRIPTION
## Why

The logic in the previous cut to render two parts of the changelog in the RC notification was showing incorrect changelogs and also very complicated.

## This addresses

This is a simpler way that reduces branching, simplifies the ERB template and also corrects the changelog in terms of the data shown to the user.

## Scenarios tested

- [x] Diff between 2 RC changelogs with full changelog [ref](https://tramlinehq.slack.com/archives/C04E2PYS5HT/p1750031012605469)
- [x] First RC [ref](https://tramlinehq.slack.com/archives/C04E2PYS5HT/p1750030501394859)
- [x] Summarizing submissions correctly [ref](https://tramlinehq.slack.com/archives/C04E2PYS5HT/p1750024808316059)
- [x] Threading with titles, and footers [ref](https://tramlinehq.slack.com/archives/C04E2PYS5HT/p1750024808316059)
- [x] Proper emojis and text bolding and italicization
