### PR TITLE
feat: Store workspace name for both Linear/Jira integrations

### DIFF
--- a/app/controllers/integration_listeners/linear_controller.rb
+++ b/app/controllers/integration_listeners/linear_controller.rb
@@ -36,7 +36,7 @@ class IntegrationListeners::LinearController < IntegrationListenerController
   def providable_params
     super.merge(
       code: code,
-      organization_id: params[:organization_id]
+      workspace_id: params[:organization_id]
     )
   end
 

--- a/app/libs/installations/linear/api.rb
+++ b/app/libs/installations/linear/api.rb
@@ -60,7 +60,7 @@ module Installations
 
       def get_organizations(access_token)
         query = {
-          query: "query { organization { id name } }"
+          query: "query { organization { id name urlKey } }"
         }
 
         response = HTTP

--- a/app/models/linear_integration.rb
+++ b/app/models/linear_integration.rb
@@ -6,6 +6,7 @@
 #  oauth_access_token  :string
 #  oauth_refresh_token :string
 #  workspace_name      :string
+#  workspace_url_key   :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  workspace_id        :string           indexed
@@ -83,6 +84,7 @@ class LinearIntegration < ApplicationRecord
     if organizations.length >= 1
       self.workspace_id = organizations.first["id"]
       self.workspace_name = organizations.first["name"]
+      self.workspace_url_key = organizations.first["urlKey"]
       true
     else
       false

--- a/db/migrate/20250716115322_add_workspace_name_to_linear_integrations.rb
+++ b/db/migrate/20250716115322_add_workspace_name_to_linear_integrations.rb
@@ -1,0 +1,5 @@
+class AddWorkspaceNameToLinearIntegrations < ActiveRecord::Migration[7.2]
+  def change
+    add_column :linear_integrations, :workspace_name, :string
+  end
+end

--- a/db/migrate/20250716121502_rename_organization_id_to_workspace_id_in_linear_integrations.rb
+++ b/db/migrate/20250716121502_rename_organization_id_to_workspace_id_in_linear_integrations.rb
@@ -1,0 +1,7 @@
+class RenameOrganizationIdToWorkspaceIdInLinearIntegrations < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      rename_column :linear_integrations, :organization_id, :workspace_id
+    end
+  end
+end

--- a/db/migrate/20250716124930_add_organization_name_to_jira_integrations.rb
+++ b/db/migrate/20250716124930_add_organization_name_to_jira_integrations.rb
@@ -1,0 +1,5 @@
+class AddOrganizationNameToJiraIntegrations < ActiveRecord::Migration[7.2]
+  def change
+    add_column :jira_integrations, :organization_name, :string
+  end
+end

--- a/db/migrate/20250717080947_add_workspace_url_slug_to_project_management_integrations.rb
+++ b/db/migrate/20250717080947_add_workspace_url_slug_to_project_management_integrations.rb
@@ -1,0 +1,6 @@
+class AddWorkspaceUrlSlugToProjectManagementIntegrations < ActiveRecord::Migration[7.2]
+  def change
+    add_column :jira_integrations, :organization_url, :string
+    add_column :linear_integrations, :workspace_url_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_09_165953) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_16_124930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -412,16 +412,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_09_165953) do
     t.string "cloud_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "organization_name"
     t.index ["cloud_id"], name: "index_jira_integrations_on_cloud_id"
   end
 
   create_table "linear_integrations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "oauth_access_token"
     t.string "oauth_refresh_token"
-    t.string "organization_id"
+    t.string "workspace_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["organization_id"], name: "index_linear_integrations_on_organization_id"
+    t.string "workspace_name"
+    t.index ["workspace_id"], name: "index_linear_integrations_on_workspace_id"
   end
 
   create_table "memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_16_124930) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_17_080947) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -413,6 +413,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_16_124930) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "organization_name"
+    t.string "organization_url"
     t.index ["cloud_id"], name: "index_jira_integrations_on_cloud_id"
   end
 
@@ -423,6 +424,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_16_124930) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "workspace_name"
+    t.string "workspace_url_key"
     t.index ["workspace_id"], name: "index_linear_integrations_on_workspace_id"
   end
 

--- a/lib/tasks/anonymize.rake
+++ b/lib/tasks/anonymize.rake
@@ -394,6 +394,9 @@ namespace :anonymize do
         whitelist_timestamps
         anonymize("oauth_access_token") { |_| "anonymized_token" }
         anonymize("oauth_refresh_token") { |_| "anonymized_refresh_token" }
+        anonymize("workspace_id") { |_| "anonymized_workspace_id" }
+        anonymize("workspace_name") { |_| "anonymized_workspace_name" }
+        anonymize("workspace_url_key") { |_| "anonymized_workspace_url_key" }
       end
     end
 

--- a/spec/controllers/integration_listeners/linear_controller_spec.rb
+++ b/spec/controllers/integration_listeners/linear_controller_spec.rb
@@ -55,7 +55,7 @@ describe IntegrationListeners::LinearController do
 
     it "includes code and organization_id" do
       result = controller_instance.send(:providable_params)
-      expect(result).to eq({code: "test_code", integration: nil, organization_id: "test_org"})
+      expect(result).to eq({code: "test_code", integration: nil, workspace_id: "test_org"})
     end
   end
 end

--- a/spec/controllers/integration_listeners/linear_controller_spec.rb
+++ b/spec/controllers/integration_listeners/linear_controller_spec.rb
@@ -53,7 +53,7 @@ describe IntegrationListeners::LinearController do
       )
     end
 
-    it "includes code and organization_id" do
+    it "includes code and workspace_id" do
       result = controller_instance.send(:providable_params)
       expect(result).to eq({code: "test_code", integration: nil, workspace_id: "test_org"})
     end

--- a/spec/factories/jira_integrations.rb
+++ b/spec/factories/jira_integrations.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     oauth_access_token { "test_access_token" }
     oauth_refresh_token { "test_refresh_token" }
     cloud_id { "cloud_123" }
+    organization_name { "test_org" }
+    organization_url { "https://testorg.atlassian.net" }
     integration
 
     trait :with_app_config do

--- a/spec/factories/linear_integrations.rb
+++ b/spec/factories/linear_integrations.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :linear_integration do
     oauth_access_token { "test_access_token" }
     oauth_refresh_token { "test_refresh_token" }
-    organization_id { "test_org_id" }
+    workspace_id { "test_org_id" }
+    workspace_name { "test_org" }
+    workspace_url_key { "test" }
   end
 end

--- a/spec/models/jira_integration_spec.rb
+++ b/spec/models/jira_integration_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe JiraIntegration do
   subject(:integration) { build(:jira_integration) }
+
   let(:sample_release_label) { "release-1.0" }
   let(:sample_version) { "v1.0.0" }
 

--- a/spec/models/jira_integration_spec.rb
+++ b/spec/models/jira_integration_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 describe JiraIntegration do
   subject(:integration) { build(:jira_integration) }
-
   let(:sample_release_label) { "release-1.0" }
   let(:sample_version) { "v1.0.0" }
 

--- a/spec/models/linear_integration_spec.rb
+++ b/spec/models/linear_integration_spec.rb
@@ -4,10 +4,10 @@ describe LinearIntegration do
   let(:linear_integration) { build(:linear_integration) }
 
   describe "validations" do
-    it "validates presence of organization_id" do
-      linear_integration.organization_id = nil
+    it "validates presence of workspace_id" do
+      linear_integration.workspace_id = nil
       expect(linear_integration).not_to be_valid
-      expect(linear_integration.errors[:organization_id]).to include("can't be blank")
+      expect(linear_integration.errors[:workspace_id]).to include("can't be blank")
     end
   end
 
@@ -52,10 +52,10 @@ describe LinearIntegration do
       end
     end
 
-    context "when organization_id is already set" do
+    context "when workspace_id is already set" do
       it "returns true" do
         linear_integration.code = "test_code"
-        linear_integration.organization_id = "existing_org_id"
+        linear_integration.workspace_id = "existing_org_id"
 
         allow(Installations::Linear::Api).to receive(:get_access_token).and_return(
           double(access_token: "token", refresh_token: "refresh") # rubocop:disable RSpec/VerifiedDoubles


### PR DESCRIPTION
This is so that we can link changelogs properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jira integrations now display organization name and URL, enriching integration metadata.
  * Linear integrations now show workspace name and URL key, providing clearer workspace identification.

* **Improvements**
  * Linear integration terminology updated from "organization" to "workspace" for greater clarity.
  * Enhanced connection details for both Jira and Linear integrations to include new organization/workspace information.

* **Bug Fixes**
  * Updated tests and factories to support new organization and workspace attributes.

* **Chores**
  * Database schema updated to add new fields and rename columns for consistency.
  * Anonymization scripts extended to cover new workspace fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->