### PR TITLE
Add link to Release Activity page on Rollout timeline panel

### DIFF
--- a/app/components/live_release/prod_release/previous_rollout_component.html.erb
+++ b/app/components/live_release/prod_release/previous_rollout_component.html.erb
@@ -40,7 +40,7 @@
       <% button.with_icon("activity.svg", size: :base) %>
       <% button.with_tooltip("See recent rollout activity", placement: "top") %>
       <% modal.with_body do %>
-        <div class="pl-3"><%= render TimelineComponent.new(events:) %></div>
+        <div class="pl-3"><%= render TimelineComponent.new(events:, view_all_link: timeline_release_path(release)) %></div>
       <% end %>
     <% end %>
   </div>

--- a/app/components/live_release/prod_release/rollout_component.html.erb
+++ b/app/components/live_release/prod_release/rollout_component.html.erb
@@ -19,7 +19,7 @@
           <% button.with_icon("activity.svg", size: :base) %>
           <% button.with_tooltip("See recent rollout activity", placement: "top") %>
           <% modal.with_body do %>
-            <div class="pl-3"><%= render TimelineComponent.new(events:) %></div>
+            <div class="pl-3"><%= render TimelineComponent.new(events:, view_all_link: timeline_release_path(release)) %></div>
           <% end %>
         <% end %>
       <% end %>

--- a/app/components/timeline_component.html.erb
+++ b/app/components/timeline_component.html.erb
@@ -13,7 +13,7 @@
       </li>
     <% end %>
 
-    <% if truncate %>
+    <% if view_all_link.present? %>
       <li class="mt-6 last:mb-0 ms-4 text-secondary text-xs">
         <%= render ButtonComponent.new(
               label: "View all events",


### PR DESCRIPTION
**Closes:** https://github.com/tramlinehq/site/issues/810

## Why

We want to allow users to view the whole Release Activity page for a store rollout from the Rollout timeline panel.

## This addresses

These changes should allow the users to navigate to the Release Activity page from the Rollout timeline panel.

One change in the `TimelineComponent` ViewComponent that is worth mentioning: since the `truncate` argument is only used to limit the number of `Passport` events rendered on the UI, we should render the "View all events" link if the `view_all_link` argument is present regardless of whether the events are being truncated or not.

## Scenarios tested

- [ ] should be able to view the View all events link, which when clicked takes the user to the Release Activity page, from the Store Rollouts screen for the previous rollout
- [ ] should be able to view the View all events link from the Store Rollouts screen for the inflight rollout(s) on both desktop and mobile
- [ ] should be able to view the View all events link from the Store Rollouts screen for the active rollout(s) on both desktop and mobile
- [ ] should be able to view the View all events link from the Store Rollouts screen for the finished rollout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "View all events" link to the timeline in release modals, allowing users to access the full list of timeline events for a release.

* **Refactor**
  * Updated the display logic for the "View all events" button to show it only when a relevant link is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->