### PR TITLE
Only support Deploy-Action for GitHub

### DIFF
--- a/app/libs/installations/github/api.rb
+++ b/app/libs/installations/github/api.rb
@@ -82,8 +82,8 @@ module Installations
       end
     end
 
-    def run_workflow!(repo, id, ref, inputs, commit_hash, json_inputs_enabled = false)
-      inputs = if json_inputs_enabled
+    def run_workflow!(repo, id, ref, inputs, commit_hash)
+      inputs =
         inputs
           .slice(:version_code, :build_notes)
           .merge(version_name: inputs[:build_version], commit_ref: commit_hash)
@@ -91,17 +91,10 @@ module Installations
           .to_json
           .then { {"tramline-input" => _1} }
           .merge(inputs[:parameters])
-      else
-        {
-          versionCode: inputs[:version_code],
-          versionName: inputs[:build_version],
-          buildNotes: inputs[:build_notes]
-        }.merge(inputs[:parameters]).compact
-      end
 
       execute do
         @client
-          .workflow_dispatch(repo, id, ref, inputs: inputs)
+          .workflow_dispatch(repo, id, ref, inputs:)
           .then { |ok| ok.presence || raise(Installations::Error.new("Could not trigger the workflow", reason: :workflow_trigger_failed)) }
       end
     end

--- a/app/models/accounts/organization.rb
+++ b/app/models/accounts/organization.rb
@@ -67,10 +67,6 @@ class Accounts::Organization < ApplicationRecord
     Flipper.enabled?(:merge_only_build_notes, self)
   end
 
-  def deploy_action_enabled?
-    Flipper.enabled?(:deploy_action_enabled, self)
-  end
-
   def tester_notes_in_beta_releases?
     Flipper.enabled?(:tester_notes_in_beta_releases, self)
   end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -88,10 +88,6 @@ class App < ApplicationRecord
     releases.first.scheduled_at > 3.months.ago
   end
 
-  def deploy_action_enabled?
-    Flipper.enabled?(:deploy_action_enabled, self)
-  end
-
   def monitoring_disabled?
     Flipper.enabled?(:monitoring_disabled, self)
   end

--- a/app/models/bitbucket_integration.rb
+++ b/app/models/bitbucket_integration.rb
@@ -300,7 +300,7 @@ class BitbucketIntegration < ApplicationRecord
 
   def workflow_retriable_in_place? = false
 
-  def trigger_workflow_run!(ci_cd_channel, branch_name, inputs, commit_hash = nil, _deploy_action_enabled = false)
+  def trigger_workflow_run!(ci_cd_channel, branch_name, inputs, commit_hash = nil)
     with_api_retries do
       res = installation.trigger_pipeline!(code_repository_name, ci_cd_channel, branch_name, inputs, commit_hash, WORKFLOW_RUN_TRANSFORMATIONS)
       res.merge(ci_link: "https://bitbucket.org/#{code_repository_name}/pipelines/results/#{res[:number]}")

--- a/app/models/bitrise_integration.rb
+++ b/app/models/bitrise_integration.rb
@@ -114,7 +114,7 @@ class BitriseIntegration < ApplicationRecord
     end
   end
 
-  def trigger_workflow_run!(ci_cd_channel, branch_name, inputs, commit_hash = nil, _deploy_action_enabled = false)
+  def trigger_workflow_run!(ci_cd_channel, branch_name, inputs, commit_hash = nil)
     if custom_pipelines?
       installation.run_workflow!(project, nil, ci_cd_channel, branch_name, inputs, commit_hash, WORKFLOW_RUN_TRANSFORMATIONS)
     else

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -241,8 +241,8 @@ class GithubIntegration < ApplicationRecord
     end
   end
 
-  def trigger_workflow_run!(ci_cd_channel, branch_name, inputs, commit_hash = nil, deploy_action_enabled = false)
-    installation.run_workflow!(code_repository_name, ci_cd_channel, branch_name, inputs, commit_hash, deploy_action_enabled)
+  def trigger_workflow_run!(ci_cd_channel, branch_name, inputs, commit_hash = nil)
+    installation.run_workflow!(code_repository_name, ci_cd_channel, branch_name, inputs, commit_hash)
   end
 
   def cancel_workflow_run!(ci_ref)

--- a/app/models/gitlab_integration.rb
+++ b/app/models/gitlab_integration.rb
@@ -195,7 +195,7 @@ class GitlabIntegration < ApplicationRecord
     []
   end
 
-  def trigger_workflow_run!(ci_cd_channel, branch_name, inputs, commit_hash = nil, _deploy_action_enabled = false)
+  def trigger_workflow_run!(ci_cd_channel, branch_name, inputs, commit_hash = nil)
     with_api_retries do
       if ci_cd_channel.present? && ci_cd_channel != "default"
         installation.run_pipeline_with_job!(code_repository_name, branch_name, inputs, ci_cd_channel, commit_hash, WORKFLOW_RUN_TRANSFORMATIONS)

--- a/app/models/train.rb
+++ b/app/models/train.rb
@@ -181,10 +181,6 @@ class Train < ApplicationRecord
     Flipper.enabled?(:one_percent_beta_release, self)
   end
 
-  def deploy_action_enabled?
-    Flipper.enabled?(:deploy_action_enabled, self)
-  end
-
   def temporarily_allow_workflow_errors?
     Flipper.enabled?(:temporarily_allow_workflow_errors, self)
   end

--- a/app/models/workflow_run.rb
+++ b/app/models/workflow_run.rb
@@ -242,10 +242,8 @@ class WorkflowRun < ApplicationRecord
   end
 
   def trigger_external_run!
-    deploy_action_enabled = organization.deploy_action_enabled? || app.deploy_action_enabled? || train.deploy_action_enabled?
-
     ci_cd_provider
-      .trigger_workflow_run!(conf.identifier, release_branch, workflow_inputs, commit_hash, deploy_action_enabled)
+      .trigger_workflow_run!(conf.identifier, release_branch, workflow_inputs, commit_hash)
       .then { |external_workflow_run| check_external_data(external_workflow_run) }
       .then { |external_workflow_run| update_external_metadata!(external_workflow_run) }
   end


### PR DESCRIPTION
This deprecates the feature flag that checks if [deploy-action](https://github.com/tramlinehq/deploy-action) is set up for an app/org/train. Since all users have migrated to deploy-action on GH, this can be deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined workflow triggering by removing feature flag checks related to deploy actions.
  * Simplified input handling for workflow runs.
  * Cleaned up method signatures across integrations for consistency.
* **Chores**
  * Removed unused methods and parameters related to deploy action feature flags from various models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->