### PR TITLE
Fix duplicate event/notification bug with iOS rollouts

### DIFF
--- a/app/models/store_rollout.rb
+++ b/app/models/store_rollout.rb
@@ -127,7 +127,7 @@ class StoreRollout < ApplicationRecord
 
     # otherwise
     if may_start?
-      # start the rollout and notify (if it can be started)
+      # start the rollout and stamp (if it can be started)
       start!
       event_stamp!(reason: :started, kind: :success, data: stamp_data)
     else

--- a/app/models/store_rollout.rb
+++ b/app/models/store_rollout.rb
@@ -115,28 +115,32 @@ class StoreRollout < ApplicationRecord
     last_rollout_percentage.to_f.equal_to?(100.0)
   end
 
+  def update_stage(stage, finish_rollout: false)
+    # do nothing if the new stage is the same as current and the rollout has not finished
+    return if stage == current_stage && !finish_rollout
+
+    # update the stage
+    update!(current_stage: stage)
+
+    # complete the release if the rollout has finished and we've reached the last stage
+    return complete! if finish_rollout && reached_last_stage?
+
+    # otherwise
+    if may_start?
+      # start the rollout and notify (if it can be started)
+      start!
+      event_stamp!(reason: :started, kind: :success, data: stamp_data)
+    else
+      # notify that the rollout has updated
+      event_stamp!(reason: :updated, kind: :notice, data: stamp_data)
+      notify!("Rollout has been updated", :production_rollout_updated, notification_params)
+    end
+  end
+
   protected
 
   def next_stage
     current_stage.blank? ? 0 : current_stage.succ
-  end
-
-  def update_stage(stage, finish_rollout: false)
-    return if stage == current_stage && !finish_rollout
-
-    update!(current_stage: stage)
-    if may_start?
-      start!
-      event_stamp!(reason: :started, kind: :success, data: stamp_data)
-    else
-      event_stamp!(reason: :updated, kind: :notice, data: stamp_data)
-      notify!("Rollout has been updated", :production_rollout_updated, notification_params)
-    end
-
-    if finish_rollout && reached_last_stage?
-      complete!
-      event_stamp!(reason: :completed, kind: :success, data: stamp_data)
-    end
   end
 
   def stamp_data

--- a/spec/models/app_store_rollout_spec.rb
+++ b/spec/models/app_store_rollout_spec.rb
@@ -255,4 +255,77 @@ describe AppStoreRollout do
       expect(rollout.errors?).to be(true)
     end
   end
+
+  describe "#track_live_release_status" do
+    let(:release_platform_run) { create(:release_platform_run) }
+    let(:production_release) { create(:production_release, release_platform_run:) }
+    let(:store_submission) { create(:app_store_submission, release_platform_run:, parent_release: production_release) }
+    let(:providable_dbl) { instance_double(AppStoreIntegration) }
+
+    before do
+      allow_any_instance_of(AppStoreSubmission).to receive(:provider).and_return(providable_dbl)
+      allow(providable_dbl).to receive(:public_icon_img)
+      allow(providable_dbl).to receive(:inflight_store_link)
+      allow(providable_dbl).to receive(:deliverable_store_link)
+    end
+
+    context "update_stage behavior during track_live_release_status" do
+      let(:release_info) {
+        AppStoreIntegration::AppStoreReleaseInfo.new(
+          {
+            external_id: "bd31faa6-6a9a-4958-82de-d271ddc639a8",
+            name: "1.2.0",
+            build_number: 9012,
+            added_at: 1.day.ago,
+            status: "READY_FOR_SALE",
+            phased_release_day: 2,
+            phased_release_status: "ACTIVE"
+          }
+        )
+      }
+
+      it "updates stage when release is live and staged" do
+        rollout = create(:store_rollout, :app_store, :started, release_platform_run:, store_submission:, current_stage: 0, config: [1, 50, 100])
+        allow(rollout).to receive(:provider).and_return(providable_dbl)
+        allow(providable_dbl).to receive(:find_live_release).and_return(GitHub::Result.new { release_info })
+        allow(rollout).to receive(:actionable?).and_return(true)
+        allow(release_info).to receive(:live?).with(rollout.build_number).and_return(true)
+        allow(release_info).to receive(:phased_release_complete?).and_return(false)
+        allow(release_info).to receive(:phased_release_stage).and_return(1)
+
+        expect { rollout.track_live_release_status }.to raise_error(AppStoreRollout::ReleaseNotFullyLive)
+
+        expect(rollout.reload.current_stage).to eq(1)
+        expect(rollout.started?).to be(true)
+      end
+
+      it "completes rollout when release is live and phased release complete" do
+        rollout = create(:store_rollout, :app_store, :started, release_platform_run:, store_submission:, current_stage: 2, config: [1, 50, 100])
+        allow(rollout).to receive(:provider).and_return(providable_dbl)
+        allow(providable_dbl).to receive(:find_live_release).and_return(GitHub::Result.new { release_info })
+        allow(rollout).to receive(:actionable?).and_return(true)
+        allow(release_info).to receive(:live?).with(rollout.build_number).and_return(true)
+        allow(release_info).to receive(:phased_release_complete?).and_return(true)
+        allow(release_info).to receive(:phased_release_stage).and_return(2)
+
+        rollout.track_live_release_status
+
+        expect(rollout.reload.current_stage).to eq(2)
+        expect(rollout.completed?).to be(true)
+      end
+
+      it "completes immediately for non-staged rollout when live" do
+        rollout = create(:store_rollout, :app_store, :started, release_platform_run:, store_submission:, is_staged_rollout: false)
+        allow(rollout).to receive(:provider).and_return(providable_dbl)
+        allow(providable_dbl).to receive(:find_live_release).and_return(GitHub::Result.new { release_info })
+        allow(rollout).to receive(:actionable?).and_return(true)
+        allow(release_info).to receive(:live?).with(rollout.build_number).and_return(true)
+
+        rollout.track_live_release_status
+
+        expect(rollout.completed?).to be(true)
+      end
+    end
+  end
+
 end

--- a/spec/models/play_store_rollout_spec.rb
+++ b/spec/models/play_store_rollout_spec.rb
@@ -163,8 +163,8 @@ describe PlayStoreRollout do
       expect(providable_dbl).to have_received(:rollout_release).with(anything, anything, anything, anything, anything, retry_on_review_fail: true, raise_on_lock_error: false).once
     end
 
-    context "update_stage behavior during move_to_next_stage!" do
-      it "updates stage and stays started when moving between stages" do
+    context "when it updates stage" do
+      it "updates stage to be started when moving between stages" do
         rollout = create(:store_rollout, :started, :play_store, release_platform_run:, store_submission:, config: [1, 80, 100], current_stage: 0)
         allow(providable_dbl).to receive(:rollout_release).and_return(GitHub::Result.new)
         allow(rollout).to receive(:provider).and_return(providable_dbl)
@@ -379,5 +379,4 @@ describe PlayStoreRollout do
       expect(providable_dbl).to have_received(:rollout_release).with(anything, anything, anything, anything, anything, retry_on_review_fail: true, raise_on_lock_error: false).once
     end
   end
-
 end


### PR DESCRIPTION
We accidentally send multiple complete-rollout notifications and sometimes send multiple update rollout notifications. This is happening because `update_stage` does not early exit when rollout finishes from the ASC side.

Rewrite all this logic to be clearer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and clarity of rollout stage updates and completion handling for App Store and Play Store rollouts.

* **Tests**
  * Added and expanded tests for rollout stage transitions, completion scenarios, and live-release status tracking to increase coverage and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->