### PR TITLE
Add store status sync functionality

### DIFF
--- a/app/components/live_release/prod_release/rollout_component.html.erb
+++ b/app/components/live_release/prod_release/rollout_component.html.erb
@@ -79,11 +79,24 @@
           <%= render SectionComponent.new(title: "More actions", style: :titled, size: :micro) do %>
             <div class="flex flex-col justify-between items-center gap-2 md:flex-row">
               <div class="flex flex-wrap flex-row gap-2">
+                <% if syncable? %>
+                  <%= render ButtonComponent.new(label: "Sync store status",
+                                                 scheme: :light,
+                                                 type: :button,
+                                                 options: sync_store_rollout_path(id),
+                                                 html_options: html_opts(:patch, "Sync the current status from the store?"),
+                                                 size: :xxs) do |b|
+                        b.with_icon("arrow_path.svg", size: :md)
+                      end %>
+                <% end %>
                 <% more_actions.each do |action| %>
                   <%= render action %>
                 <% end %>
               </div>
               <div class="flex flex-row gap-2">
+                <% if last_sync_time.present? %>
+                  <span class="text-sm text-secondary">Last sync: <%= last_sync_time %></span>
+                <% end %>
                 <%= render ButtonComponent.new(label: "Store dashboard ↗",
                                                scheme: :link,
                                                type: :link_external,

--- a/app/components/live_release/prod_release/rollout_component.rb
+++ b/app/components/live_release/prod_release/rollout_component.rb
@@ -15,7 +15,8 @@ class LiveRelease::ProdRelease::RolloutComponent < BaseComponent
     completed: {text: "Completed", status: :success},
     halted: {text: "Halted", status: :inert},
     fully_released: {text: "Released to all users", status: :success},
-    paused: {text: "Paused phased release", status: :ongoing}
+    paused: {text: "Paused phased release", status: :ongoing},
+    syncing: {text: "Syncing...", status: :ongoing}
   }
 
   attr_reader :store_rollout
@@ -173,5 +174,21 @@ class LiveRelease::ProdRelease::RolloutComponent < BaseComponent
 
   def show_monitoring?
     @show_monitoring
+  end
+
+  def syncable?
+    store_rollout.syncable?
+  end
+
+  def last_sync_event
+    store_rollout.passports
+      .where(reason: [:sync_completed, :sync_no_changes, :sync_failed])
+      .order(created_at: :desc)
+      .first
+  end
+
+  def last_sync_time
+    return nil unless last_sync_event
+    time_ago_in_words(last_sync_event.event_timestamp) + " ago"
   end
 end

--- a/app/components/live_release/prod_release/submission_component.html.erb
+++ b/app/components/live_release/prod_release/submission_component.html.erb
@@ -147,6 +147,19 @@
     <% end %>
 
     <% card.with_action do %>
+      <% if syncable? %>
+        <%= render ButtonComponent.new(label: "Sync store status",
+                                       scheme: :light,
+                                       type: :button,
+                                       options: sync_store_submission_path(submission),
+                                       html_options: html_opts(:patch, "Sync the current status from the store?"),
+                                       size: :xxs) do |b| %>
+          <% b.with_icon("arrow_path.svg", size: :md) %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% card.with_action do %>
       <% if submission.retryable? %>
         <%= render ButtonComponent.new(label: "Retry sending to #{submission.provider.display}",
                                        auto_label_case: false,
@@ -229,6 +242,9 @@
               <% else %>
                 <%= NOT_AVAILABLE %>
               <% end %>
+            <% end %>
+            <% if last_sync_time.present? %>
+              <% component.with_data_set(title: "Last sync").with_content(last_sync_time) %>
             <% end %>
           <% end %>
         </div>

--- a/app/components/live_release/prod_release/submission_component.rb
+++ b/app/components/live_release/prod_release/submission_component.rb
@@ -15,7 +15,8 @@ class LiveRelease::ProdRelease::SubmissionComponent < BaseComponent
     failed: {text: "Submission failed", status: :failure},
     failed_with_action_required: {text: "Needs manual submission", status: :failure},
     cancelled: {text: "Removed from review", status: :inert},
-    finished: {text: "Ready to be released", status: :success}
+    finished: {text: "Ready to be released", status: :success},
+    syncing: {text: "Syncing...", status: :ongoing}
   }
 
   def initialize(submission, inactive: false, title: "Store Submission")
@@ -183,6 +184,22 @@ class LiveRelease::ProdRelease::SubmissionComponent < BaseComponent
 
   def border_style
     :dashed if inflight?
+  end
+
+  def syncable?
+    submission.syncable?
+  end
+
+  def last_sync_event
+    submission.passports
+      .where(reason: [:sync_completed, :sync_no_changes, :sync_failed])
+      .order(created_at: :desc)
+      .first
+  end
+
+  def last_sync_time
+    return nil unless last_sync_event
+    time_ago_in_words(last_sync_event.event_timestamp) + " ago"
   end
 
   # ============== Sandbox actions ==============

--- a/app/jobs/store_rollouts/app_store/sync_store_status_job.rb
+++ b/app/jobs/store_rollouts/app_store/sync_store_status_job.rb
@@ -1,0 +1,128 @@
+class StoreRollouts::AppStore::SyncStoreStatusJob < ApplicationJob
+  sidekiq_options retry: 5
+
+  def perform(rollout_id, previous_status)
+    rollout = AppStoreRollout.find(rollout_id)
+    return unless rollout.syncing?
+
+    rollout.status_before_sync = previous_status
+
+    result = rollout.provider.find_live_release
+
+    unless result.ok?
+      handle_sync_error(rollout, result.error)
+      return
+    end
+
+    release_info = result.value!
+    old_status = previous_status
+    old_stage = rollout.current_stage
+    old_percentage = rollout.last_rollout_percentage
+
+    # Check if release is live with this build number
+    unless release_info.live?(rollout.build_number)
+      # Build not live yet, no changes
+      rollout.status_before_sync = previous_status
+      rollout.finish_sync!
+      rollout.event_stamp!(
+        reason: :sync_no_changes,
+        kind: :notice,
+        data: rollout.stamp_data.merge(
+          message: "Build not yet live in store"
+        )
+      )
+      return
+    end
+
+    # Update store info
+    rollout.update_store_info!(release_info)
+
+    # Determine new state
+    new_status = map_store_state_to_tramline_state(release_info, rollout)
+    new_stage = release_info.staged_rollout? ? release_info.phased_release_stage : nil
+    new_percentage = rollout.last_rollout_percentage
+
+    # Track changes
+    changes = detect_changes(old_status, new_status, old_stage, new_stage, old_percentage, new_percentage)
+
+    # Update stage if phased release
+    if release_info.staged_rollout? && new_stage != old_stage
+      rollout.update_stage(new_stage, finish_rollout: release_info.phased_release_complete?)
+    end
+
+    # Transition to new state if different
+    if new_status && new_status != previous_status
+      rollout.status_before_sync = new_status
+      rollout.finish_sync!
+      rollout.event_stamp!(
+        reason: :sync_completed,
+        kind: :success,
+        data: rollout.stamp_data.merge(
+          changes: changes,
+          previous_status: old_status,
+          new_status: new_status
+        )
+      )
+    elsif changes.present?
+      # Stage/percentage changed but not status
+      rollout.status_before_sync = previous_status
+      rollout.finish_sync!
+      rollout.event_stamp!(
+        reason: :sync_completed,
+        kind: :success,
+        data: rollout.stamp_data.merge(
+          changes: changes
+        )
+      )
+    else
+      # No changes detected
+      rollout.status_before_sync = previous_status
+      rollout.finish_sync!
+      rollout.event_stamp!(
+        reason: :sync_no_changes,
+        kind: :notice,
+        data: rollout.stamp_data.merge(
+          message: "No changes detected in store rollout"
+        )
+      )
+    end
+  rescue => e
+    handle_sync_error(rollout, e) if rollout
+    raise
+  end
+
+  private
+
+  def map_store_state_to_tramline_state(release_info, rollout)
+    return "halted" if release_info.halted?
+    return "paused" if release_info.paused?
+
+    if release_info.phased_release_complete? || !rollout.staged_rollout?
+      nil # Will be handled by completion logic
+    elsif release_info.live?(rollout.build_number)
+      "started"
+    else
+      nil
+    end
+  end
+
+  def detect_changes(old_status, new_status, old_stage, new_stage, old_percentage, new_percentage)
+    changes = []
+    changes << "Status: #{old_status} → #{new_status}" if new_status && old_status != new_status
+    changes << "Stage: #{old_stage} → #{new_stage}" if new_stage && old_stage != new_stage
+    changes << "Rollout: #{old_percentage}% → #{new_percentage}%" if old_percentage != new_percentage
+    changes.join(", ")
+  end
+
+  def handle_sync_error(rollout, error)
+    rollout.status_before_sync = rollout.aasm.from_state
+    rollout.finish_sync! if rollout.may_finish_sync?
+    rollout.event_stamp!(
+      reason: :sync_failed,
+      kind: :error,
+      data: rollout.stamp_data.merge(
+        error_message: error.respond_to?(:message) ? error.message : error.to_s
+      )
+    )
+  end
+end

--- a/app/jobs/store_rollouts/play_store/sync_store_status_job.rb
+++ b/app/jobs/store_rollouts/play_store/sync_store_status_job.rb
@@ -1,0 +1,153 @@
+class StoreRollouts::PlayStore::SyncStoreStatusJob < ApplicationJob
+  sidekiq_options retry: 5
+
+  def perform(rollout_id, previous_status)
+    rollout = PlayStoreRollout.find(rollout_id)
+    return unless rollout.syncing?
+
+    rollout.status_before_sync = previous_status
+
+    # Get current track info from Play Store
+    track_info = rollout.provider.find_build_in_track(
+      rollout.submission_channel_id,
+      rollout.build_number,
+      raise_on_lock_error: true
+    )
+
+    unless track_info
+      # Build not found in track
+      rollout.status_before_sync = previous_status
+      rollout.finish_sync!
+      rollout.event_stamp!(
+        reason: :sync_no_changes,
+        kind: :notice,
+        data: rollout.stamp_data.merge(
+          message: "Build not found in production track"
+        )
+      )
+      return
+    end
+
+    old_status = previous_status
+    old_stage = rollout.current_stage
+    old_percentage = rollout.last_rollout_percentage
+
+    # Determine state and percentage from store
+    store_status = track_info[:status] # "draft", "inProgress", "completed", "halted"
+    store_percentage = track_info[:user_fraction]&.*(100) || 100.0
+
+    # Map store state to Tramline state
+    new_status = map_store_state_to_tramline_state(store_status)
+
+    # Find closest stage for the percentage
+    new_stage = find_closest_stage(store_percentage, rollout.config) if rollout.staged_rollout?
+
+    # Track changes
+    changes = detect_changes(old_status, new_status, old_stage, new_stage, old_percentage, store_percentage)
+
+    # Update stage if changed and staged rollout
+    if rollout.staged_rollout? && new_stage && new_stage != old_stage
+      rollout.update_stage(new_stage, finish_rollout: store_percentage >= 100.0)
+    end
+
+    # Transition to new state if different
+    if new_status && new_status != previous_status
+      rollout.status_before_sync = new_status
+      rollout.finish_sync!
+
+      # If halted in store, halt in Tramline
+      rollout.halt! if new_status == "halted" && rollout.may_halt?
+
+      rollout.event_stamp!(
+        reason: :sync_completed,
+        kind: :success,
+        data: rollout.stamp_data.merge(
+          changes: changes,
+          previous_status: old_status,
+          new_status: new_status,
+          store_percentage: store_percentage
+        )
+      )
+    elsif changes.present?
+      # Stage/percentage changed but not status
+      rollout.status_before_sync = previous_status
+      rollout.finish_sync!
+      rollout.event_stamp!(
+        reason: :sync_completed,
+        kind: :success,
+        data: rollout.stamp_data.merge(
+          changes: changes,
+          store_percentage: store_percentage
+        )
+      )
+    else
+      # No changes detected
+      rollout.status_before_sync = previous_status
+      rollout.finish_sync!
+      rollout.event_stamp!(
+        reason: :sync_no_changes,
+        kind: :notice,
+        data: rollout.stamp_data.merge(
+          message: "No changes detected in store rollout"
+        )
+      )
+    end
+  rescue => e
+    handle_sync_error(rollout, e) if rollout
+    raise
+  end
+
+  private
+
+  def map_store_state_to_tramline_state(store_status)
+    case store_status
+    when "halted"
+      "halted"
+    when "inProgress"
+      "started"
+    when "completed"
+      nil # Keep current state or handle completion
+    when "draft"
+      "created"
+    else
+      nil
+    end
+  end
+
+  def find_closest_stage(percentage, config)
+    return nil if config.blank?
+
+    # Find the stage index where the config percentage is closest to the store percentage
+    config.each_with_index do |stage_percentage, index|
+      return index if stage_percentage >= percentage
+    end
+
+    # If we're beyond all configured stages, return the last stage
+    config.length - 1
+  end
+
+  def detect_changes(old_status, new_status, old_stage, new_stage, old_percentage, new_percentage)
+    changes = []
+    changes << "Status: #{old_status} → #{new_status}" if new_status && old_status != new_status
+    changes << "Stage: #{old_stage} → #{new_stage}" if new_stage && old_stage != new_stage
+
+    # Format percentages properly
+    old_perc_fmt = old_percentage.is_a?(Numeric) ? "#{old_percentage.round(2)}%" : old_percentage.to_s
+    new_perc_fmt = new_percentage.is_a?(Numeric) ? "#{new_percentage.round(2)}%" : new_percentage.to_s
+    changes << "Rollout: #{old_perc_fmt} → #{new_perc_fmt}" if old_percentage.to_f != new_percentage.to_f
+
+    changes.join(", ")
+  end
+
+  def handle_sync_error(rollout, error)
+    rollout.status_before_sync = rollout.aasm.from_state
+    rollout.finish_sync! if rollout.may_finish_sync?
+    rollout.event_stamp!(
+      reason: :sync_failed,
+      kind: :error,
+      data: rollout.stamp_data.merge(
+        error_message: error.respond_to?(:message) ? error.message : error.to_s
+      )
+    )
+  end
+end

--- a/app/jobs/store_submissions/app_store/sync_store_status_job.rb
+++ b/app/jobs/store_submissions/app_store/sync_store_status_job.rb
@@ -1,0 +1,97 @@
+class StoreSubmissions::AppStore::SyncStoreStatusJob < ApplicationJob
+  sidekiq_options retry: 5
+
+  def perform(submission_id, previous_status)
+    submission = AppStoreSubmission.find(submission_id)
+    return unless submission.syncing?
+
+    submission.status_before_sync = previous_status
+
+    result = submission.provider.find_release(submission.build_number)
+
+    unless result.ok?
+      handle_sync_error(submission, result.error)
+      return
+    end
+
+    release_info = result.value!
+    old_store_status = submission.store_status
+    old_status = previous_status
+
+    # Update store info
+    submission.update_store_info!(release_info)
+
+    # Determine new state based on store release info
+    new_status = map_store_state_to_tramline_state(release_info)
+
+    # Track changes
+    changes = detect_changes(old_status, new_status, old_store_status, submission.store_status)
+
+    # Transition to new state if different
+    if new_status != previous_status
+      submission.status_before_sync = new_status
+      submission.finish_sync!
+      submission.event_stamp!(
+        reason: :sync_completed,
+        kind: :success,
+        data: submission.stamp_data.merge(
+          changes: changes,
+          previous_status: old_status,
+          new_status: new_status
+        )
+      )
+    else
+      # No changes detected
+      submission.status_before_sync = previous_status
+      submission.finish_sync!
+      submission.event_stamp!(
+        reason: :sync_no_changes,
+        kind: :notice,
+        data: submission.stamp_data.merge(
+          message: "No changes detected in store status"
+        )
+      )
+    end
+  rescue => e
+    handle_sync_error(submission, e) if submission
+    raise
+  end
+
+  private
+
+  def map_store_state_to_tramline_state(release_info)
+    if release_info.success?
+      "approved"
+    elsif release_info.review_cancelled?
+      "cancelled"
+    elsif release_info.review_failed?
+      "review_failed"
+    elsif release_info.waiting_for_review?
+      "submitted_for_review"
+    elsif release_info.prepare_for_submission? || release_info.ready_for_review?
+      "prepared"
+    else
+      # Default to current state if uncertain
+      nil
+    end
+  end
+
+  def detect_changes(old_status, new_status, old_store_status, new_store_status)
+    changes = []
+    changes << "Status: #{old_status} → #{new_status}" if old_status != new_status
+    changes << "Store status: #{old_store_status} → #{new_store_status}" if old_store_status != new_store_status
+    changes.join(", ")
+  end
+
+  def handle_sync_error(submission, error)
+    submission.status_before_sync = submission.aasm.from_state
+    submission.finish_sync! if submission.may_finish_sync?
+    submission.event_stamp!(
+      reason: :sync_failed,
+      kind: :error,
+      data: submission.stamp_data.merge(
+        error_message: error.respond_to?(:message) ? error.message : error.to_s
+      )
+    )
+  end
+end

--- a/app/jobs/store_submissions/play_store/sync_store_status_job.rb
+++ b/app/jobs/store_submissions/play_store/sync_store_status_job.rb
@@ -1,0 +1,69 @@
+class StoreSubmissions::PlayStore::SyncStoreStatusJob < ApplicationJob
+  sidekiq_options retry: 5
+
+  def perform(submission_id, previous_status)
+    submission = PlayStoreSubmission.find(submission_id)
+    return unless submission.syncing?
+
+    submission.status_before_sync = previous_status
+
+    old_store_status = submission.store_status
+    old_status = previous_status
+
+    # Update store info (finds build in production track)
+    submission.update_store_info!
+
+    # Track changes
+    changes = detect_changes(old_status, submission.status, old_store_status, submission.store_status)
+
+    # For Play Store, the status generally stays as "prepared" once it's there
+    # But we sync the store_status which reflects the actual Play Store state
+    if changes.present?
+      submission.status_before_sync = previous_status
+      submission.finish_sync!
+      submission.event_stamp!(
+        reason: :sync_completed,
+        kind: :success,
+        data: submission.stamp_data.merge(
+          changes: changes,
+          store_status: submission.store_status
+        )
+      )
+    else
+      # No changes detected
+      submission.status_before_sync = previous_status
+      submission.finish_sync!
+      submission.event_stamp!(
+        reason: :sync_no_changes,
+        kind: :notice,
+        data: submission.stamp_data.merge(
+          message: "No changes detected in store status"
+        )
+      )
+    end
+  rescue => e
+    handle_sync_error(submission, e) if submission
+    raise
+  end
+
+  private
+
+  def detect_changes(old_status, new_status, old_store_status, new_store_status)
+    changes = []
+    changes << "Status: #{old_status} → #{new_status}" if old_status != new_status
+    changes << "Store status: #{old_store_status} → #{new_store_status}" if old_store_status != new_store_status
+    changes.join(", ")
+  end
+
+  def handle_sync_error(submission, error)
+    submission.status_before_sync = submission.aasm.from_state
+    submission.finish_sync! if submission.may_finish_sync?
+    submission.event_stamp!(
+      reason: :sync_failed,
+      kind: :error,
+      data: submission.stamp_data.merge(
+        error_message: error.respond_to?(:message) ? error.message : error.to_s
+      )
+    )
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,10 @@ en:
     fully_release_previous_rollout:
       success: "The previous rollout was fully released."
       failure: "Failed to release the previous rollout — %{errors}"
+    sync:
+      success: "Store status sync initiated successfully."
+      failure: "Failed to sync store status — %{errors}"
+      not_syncable: "This submission cannot be synced at the moment."
   store_rollouts:
     switcher:
       ios:
@@ -185,6 +189,10 @@ en:
     start:
       success: "Rollout was successfully started."
       failure: "Failed to start rollout — %{errors}"
+    sync:
+      success: "Store rollout sync initiated successfully."
+      failure: "Failed to sync store rollout — %{errors}"
+      not_syncable: "This rollout cannot be synced at the moment."
     rollout_not_controllable: "Rollout is not controllable."
     rollout_not_automatic: "Rollout is not automatic."
     rollout_not_moveable: "Rollout is not moveable."

--- a/config/locales/passport/en.yml
+++ b/config/locales/passport/en.yml
@@ -60,6 +60,10 @@ en:
       review_rejected_html: 'Play Store submission for <span class="emphasize">%{version} (%{build_number})</span> was rejected'
       failed_html: 'Failed to create a release for <span class="emphasize">%{version} (%{build_number})</span> to the Play Store track <span class="emphasize">%{track}</span>. Error – <span class="emphasize">%{failure_reason}</span>'
       finished_manually_html: 'Marked the release for <span class="emphasize">%{version} (%{build_number})</span> as finished manually'
+      sync_initiated_html: 'Started syncing store status for <span class="emphasize">%{version} (%{build_number})</span> from Play Store'
+      sync_completed_html: 'Synced store status for <span class="emphasize">%{version} (%{build_number})</span> from Play Store<span class="ml-1 text-xs">(%{changes})</span>'
+      sync_no_changes_html: 'Synced store status for <span class="emphasize">%{version} (%{build_number})</span> – no changes detected'
+      sync_failed_html: 'Failed to sync store status for <span class="emphasize">%{version} (%{build_number})</span> from Play Store. Error – <span class="emphasize">%{error_message}</span>'
     app_store_submission:
       triggered_html: 'Triggered a new store release for <span class="emphasize">%{version} (%{build_number})</span> in the App Store'
       prepared_html: 'Created a new store release for <span class="emphasize">%{version} (%{build_number})</span> in the App Store'
@@ -72,6 +76,10 @@ en:
       cancelling_html: 'Cancelling release submission to the App Store for <span class="emphasize">%{version} (%{build_number})</span>'
       cancelled_html: 'Release submission to the App Store for <span class="emphasize">%{version} (%{build_number})</span> was cancelled'
       failed_html: 'Failed to create an inflight store version for <span class="emphasize">%{version} (%{build_number})</span> in the App Store. Error – <span class="emphasize">%{failure_reason}</span>'
+      sync_initiated_html: 'Started syncing store status for <span class="emphasize">%{version} (%{build_number})</span> from App Store'
+      sync_completed_html: 'Synced store status for <span class="emphasize">%{version} (%{build_number})</span> from App Store<span class="ml-1 text-xs">(%{changes})</span>'
+      sync_no_changes_html: 'Synced store status for <span class="emphasize">%{version} (%{build_number})</span> – no changes detected'
+      sync_failed_html: 'Failed to sync store status for <span class="emphasize">%{version} (%{build_number})</span> from App Store. Error – <span class="emphasize">%{error_message}</span>'
     play_store_rollout:
       started_html: 'Started rollout of <span class="emphasize">%{version} (%{build_number})</span> to Play Store <span class="emphasize">%{track}</span> track at <span class="emphasize">%{rollout_percentage}%</span>'
       updated_html: 'Updated the rollout of <span class="emphasize">%{version} (%{build_number})</span> to Play Store <span class="emphasize">%{track}</span> track to <span class="emphasize">%{rollout_percentage}%</span>'
@@ -81,6 +89,10 @@ en:
       fully_released_html: 'Fully released <span class="emphasize">%{version} (%{build_number})</span> to Play Store <span class="emphasize">%{track}</span> track from <span class="emphasize">%{rollout_percentage}%</span>'
       finished_manually_html: 'Marked the rollout of <span class="emphasize">%{version} (%{build_number})</span> to Play Store <span class="emphasize">%{track}</span> track as finished manually'
       failed_html: 'Failed to rollout <span class="emphasize">%{version} (%{build_number})</span> to Play Store <span class="emphasize">%{track}</span> track'
+      sync_initiated_html: 'Started syncing rollout status for <span class="emphasize">%{version} (%{build_number})</span> from Play Store'
+      sync_completed_html: 'Synced rollout status for <span class="emphasize">%{version} (%{build_number})</span> from Play Store<span class="ml-1 text-xs">(%{changes})</span>'
+      sync_no_changes_html: 'Synced rollout status for <span class="emphasize">%{version} (%{build_number})</span> – no changes detected'
+      sync_failed_html: 'Failed to sync rollout status for <span class="emphasize">%{version} (%{build_number})</span> from Play Store. Error – <span class="emphasize">%{error_message}</span>'
     app_store_rollout:
       started_html: 'Started rollout of <span class="emphasize">%{version} (%{build_number})</span> to App Store at phase <span class="emphasize">%{current_stage} (%{rollout_percentage}%)</span>'
       updated_html: 'Rollout of <span class="emphasize">%{version} (%{build_number})</span> to App Store is at phase <span class="emphasize">%{current_stage} (%{rollout_percentage}%)</span>'
@@ -89,6 +101,10 @@ en:
       fully_released_html: 'Fully released <span class="emphasize">%{version} (%{build_number})</span> to App Store from phase <span class="emphasize">%{current_stage} (%{rollout_percentage}%)</span>'
       paused_html: 'Paused the rollout of <span class="emphasize">%{version} (%{build_number})</span> to App Store at phase <span class="emphasize">%{current_stage} (%{rollout_percentage}%)</span>'
       resumed_html: 'Resumed the rollout of <span class="emphasize">%{version} (%{build_number})</span> to App Store at phase <span class="emphasize">%{current_stage} (%{rollout_percentage}%)</span>'
+      sync_initiated_html: 'Started syncing rollout status for <span class="emphasize">%{version} (%{build_number})</span> from App Store'
+      sync_completed_html: 'Synced rollout status for <span class="emphasize">%{version} (%{build_number})</span> from App Store<span class="ml-1 text-xs">(%{changes})</span>'
+      sync_no_changes_html: 'Synced rollout status for <span class="emphasize">%{version} (%{build_number})</span> – no changes detected'
+      sync_failed_html: 'Failed to sync rollout status for <span class="emphasize">%{version} (%{build_number})</span> from App Store. Error – <span class="emphasize">%{error_message}</span>'
     store_rollout:
       reasons:
         started: 'Rollout started'
@@ -99,3 +115,7 @@ en:
         paused: 'Rollout paused'
         resumed: 'Rollout resumed'
         increased: 'Rollout increased'
+        sync_initiated: 'Sync initiated'
+        sync_completed: 'Sync completed'
+        sync_no_changes: 'Sync completed (no changes)'
+        sync_failed: 'Sync failed'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,7 @@ Rails.application.routes.draw do
       patch :resume
       patch :halt
       patch :fully_release
+      patch :sync
     end
   end
 
@@ -268,6 +269,7 @@ Rails.application.routes.draw do
       patch :cancel
       patch :remove_from_review
       patch :fully_release_previous_rollout
+      patch :sync
     end
   end
 


### PR DESCRIPTION
This change adds the ability for users to manually sync store status from Play Store and App Store while in the middle of a release. The sync feature allows users to pull the current state from the stores and automatically update Tramline's internal state to match.

Key features:
- Sync button available in submission and rollout components for non-terminal states
- Async job processing for store status synchronization
- Automatic state mapping from store states to Tramline states
- For Play Store rollouts: maps percentages to closest configured stage
- For App Store rollouts: syncs phased release status and stages
- Passport events track sync operations with detailed change logs
- Shows last sync timestamp in UI components
- Write access required to trigger sync

Technical changes:
- Add 'syncing' state to StoreSubmission and StoreRollout state machines
- Implement sync jobs for both App Store and Play Store
- Add sync controller actions with permission checks
- Update UI components to show sync button and last sync time
- Add i18n translations for sync events and controller messages
- Create passport events for sync operations (initiated, completed, no_changes, failed)

Resolves the need for manual store status synchronization during releases.

**Closes:** https://github.com/tramlinehq/site/issues/<number>

## Why

Enter the reason/premise for raising this PR.

## This addresses

Enter the details of what all this covers, include screenshots, demos, thought processes etc.

## Scenarios tested

- [ ] List the scenarios this is tested against.
