### PR TITLE
feat: add rollout percentage input for PlayStore pre-prod submissions

### DIFF
--- a/app/components/live_release/pre_prod_release/submission_component.html.erb
+++ b/app/components/live_release/pre_prod_release/submission_component.html.erb
@@ -2,14 +2,56 @@
   <% if active? %>
     <% card.with_action do %>
       <% if submission.triggerable? %>
-        <%= render ButtonComponent.new(label: "Send to #{submission.display}",
-                                       auto_label_case: false,
-                                       scheme: :default,
-                                       type: :button,
-                                       options: trigger_store_submission_path(submission),
-                                       html_options: html_opts(:patch, "Are you sure you want to send this submission to #{submission.display}?"),
-                                       size: :xxs) do |b| %>
-          <% b.with_icon(submission_logo_bw, size: :md) %>
+        <% if show_rollout_percentage_modal? %>
+          <%= render ModalComponent.new(title: "Start rollout", subtitle: "Send to #{submission.display}", size: :xs) do |modal| %>
+            <% modal.with_button(label: "Send to #{submission.display}",
+                                 auto_label_case: false,
+                                 scheme: :default,
+                                 size: :xxs) do |b| %>
+              <% b.with_icon(submission_logo_bw, size: :md) %>
+            <% end %>
+            <% modal.with_body do %>
+              <%= form_with(url: trigger_store_submission_path(submission), method: :patch, class: "flex flex-col gap-4") do |form| %>
+                <div class="flex flex-col gap-2">
+                  <label for="rollout_percentage" class="text-sm font-medium">Rollout percentage</label>
+                  <div class="flex items-center gap-2">
+                    <%= form.number_field :rollout_percentage,
+                                          value: default_rollout_percentage,
+                                          min: 0.01,
+                                          max: 100,
+                                          step: 0.01,
+                                          class: "input-base w-24",
+                                          required: true %>
+                    <span class="text-secondary">%</span>
+                  </div>
+                  <p class="text-xs text-secondary-50">Enter the percentage of users to roll out to (0.01 - 100)</p>
+                </div>
+                <div class="flex justify-end gap-2">
+                  <%= render ButtonComponent.new(label: "Cancel",
+                                                 scheme: :light,
+                                                 type: :action,
+                                                 size: :xxs,
+                                                 html_options: {data: {action: "dialog#close"}}) %>
+                  <%= render ButtonComponent.new(label: "Start rollout",
+                                                 scheme: :default,
+                                                 type: :button,
+                                                 size: :xxs) do |b| %>
+                    <% b.with_icon(submission_logo_bw, size: :md) %>
+                  <% end %>
+                </div>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <%= render ButtonComponent.new(label: "Send to #{submission.display}",
+                                         auto_label_case: false,
+                                         scheme: :default,
+                                         type: :button,
+                                         options: trigger_store_submission_path(submission),
+                                         html_options: html_opts(:patch, "Are you sure you want to send this submission to #{submission.display}?"),
+                                         size: :xxs) do |b| %>
+            <% b.with_icon(submission_logo_bw, size: :md) %>
+          <% end %>
         <% end %>
       <% end %>
       <% if submission.retryable? %>

--- a/app/components/live_release/pre_prod_release/submission_component.rb
+++ b/app/components/live_release/pre_prod_release/submission_component.rb
@@ -81,4 +81,12 @@ class LiveRelease::PreProdRelease::SubmissionComponent < BaseComponent
       "upcoming submission"
     end
   end
+
+  def show_rollout_percentage_modal?
+    submission.is_a?(PlayStoreSubmission) && submission.staged_rollout?
+  end
+
+  def default_rollout_percentage
+    submission.conf.rollout_stages&.first || 100
+  end
 end

--- a/app/controllers/store_submissions_controller.rb
+++ b/app/controllers/store_submissions_controller.rb
@@ -18,7 +18,8 @@ class StoreSubmissionsController < SignedInApplicationController
 
   def trigger
     # return mock_trigger_submission if sandbox_mode?
-    if (result = Action.trigger_submission!(@submission)).ok?
+    rollout_percentage = params[:rollout_percentage].presence&.to_f
+    if (result = Action.trigger_submission!(@submission, rollout_percentage:)).ok?
       redirect_back fallback_location: fallback_path, notice: t(".success")
     else
       redirect_back fallback_location: fallback_path, flash: {error: t(".failure", errors: result.error.message)}

--- a/app/libs/coordinators.rb
+++ b/app/libs/coordinators.rb
@@ -197,10 +197,10 @@ module Coordinators
       end
     end
 
-    def self.trigger_submission!(submission)
+    def self.trigger_submission!(submission, rollout_percentage: nil)
       Res.new do
         raise "submission is not triggerable" unless submission.triggerable?
-        submission.trigger!
+        submission.trigger!(rollout_percentage:)
       end
     end
 


### PR DESCRIPTION
## Summary
- Adds a modal dialog for PlayStore pre-prod submissions with staged rollouts enabled
- Allows users to specify a custom rollout percentage when triggering submissions
- Stores the percentage in the submission config and uses it when starting the rollout

## Test plan
- [ ] Create a PlayStore pre-prod submission with staged rollouts enabled
- [ ] Click "Send to" button and verify modal appears with percentage input
- [ ] Enter a custom percentage and submit
- [ ] Verify the rollout starts with the specified percentage
- [ ] Test that non-PlayStore submissions still show the confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a rollout configuration modal that allows users to specify a rollout percentage before triggering a release
  * Enabled percentage-based staged rollout progression, intelligently mapping user-defined percentages to release stages
  * Added automatic error handling and validation for rollout percentages during staged releases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->