### PR TITLE
fix: keep submission settings saveable when CI returns no workflows

### DIFF
--- a/app/controllers/config/release_platforms_controller.rb
+++ b/app/controllers/config/release_platforms_controller.rb
@@ -81,7 +81,27 @@ class Config::ReleasePlatformsController < SignedInApplicationController
   end
 
   def set_ci_actions
-    @ci_actions = @train.workflows || []
+    @ci_actions = with_configured_workflows(@train.workflows || [])
+  end
+
+  # The CI provider can hand back an empty or stale workflow list (a transient API
+  # failure or a cached miss). When it does, the edit form would render the workflow
+  # dropdowns with no options - and since Rails 7.2 honours `required` on selects, that
+  # blocks saving any setting on the page. Worse, submitting then posts a blank
+  # identifier, which wipes the already-configured workflow (blank identifier / nil name
+  # both fail Config::Workflow validations). Always fold in the workflows already saved
+  # on the config so the current selection survives a flaky provider response.
+  def with_configured_workflows(ci_actions)
+    return ci_actions if @config.blank?
+
+    preserved = [@config.release_candidate_workflow, @config.internal_workflow].compact.filter_map do |workflow|
+      next if workflow.identifier.blank?
+      next if ci_actions.any? { |action| action[:id].to_s == workflow.identifier.to_s }
+
+      {id: workflow.identifier, name: workflow.name}
+    end
+
+    ci_actions + preserved
   end
 
   def set_submission_types

--- a/app/views/config/release_platforms/_form.html.erb
+++ b/app/views/config/release_platforms/_form.html.erb
@@ -22,7 +22,7 @@
           <%= rc_fields.hidden_field :id, value: rc_fields.object.id %>
           <%= rc_fields.labeled_select :identifier, "Release Candidate workflow",
                                        options_for_select(ci_actions.map { |c| [c[:name], c[:id]] }, platform_config.release_candidate_workflow.identifier),
-                                       {required: true},
+                                       {required: ci_actions.any?},
                                        data: {controller: "input-select"} %>
 
           <div class="text-xs text-secondary mt-1">

--- a/spec/controllers/config/release_platforms_controller_spec.rb
+++ b/spec/controllers/config/release_platforms_controller_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+describe Config::ReleasePlatformsController do
+  let(:train) { create(:train, :with_no_platforms) }
+  let(:app) { train.app }
+  let(:release_platform) { create(:release_platform, train:, platform: "android") }
+  let(:config) { release_platform.platform_config }
+  let(:rc_workflow) { config.release_candidate_workflow }
+  let(:user) { app.organization.owner }
+
+  before do
+    sign_in user.email_authentication
+    # Simulate the CI provider handing back an empty/stale workflow list (transient API
+    # failure or a cached miss). The configured workflows still exist on the config.
+    allow_any_instance_of(Train).to receive(:workflows).and_return([])
+    allow_any_instance_of(App).to receive(:ready?).and_return(true)
+  end
+
+  describe "GET #edit" do
+    it "renders successfully even when the provider returns no workflows" do
+      get :edit, params: {app_id: app.id, train_id: train.to_param, platform_id: release_platform.platform}
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH #update" do
+    let(:params) do
+      {
+        app_id: app.id,
+        train_id: train.to_param,
+        platform_id: release_platform.platform,
+        config_release_platform: {
+          production_release_enabled: "true",
+          release_candidate_workflow_attributes: {
+            id: rc_workflow.id,
+            identifier: rc_workflow.identifier
+          },
+          production_release_attributes: {
+            id: config.production_release.id,
+            submissions_attributes: {
+              "0" => {
+                id: config.production_release.submissions.first.id,
+                rollout_enabled: "true",
+                rollout_stages: "1, 5, 10, 50, 100"
+              }
+            }
+          }
+        }
+      }
+    end
+
+    context "when the CI provider returns no workflows" do
+      it "saves unrelated settings without wiping the configured RC workflow" do
+        patch :update, params: params
+
+        expect(flash[:error]).to be_blank
+        expect(flash[:notice]).to be_present
+      end
+
+      it "preserves the already-configured release candidate workflow" do
+        original_identifier = rc_workflow.identifier
+        original_name = rc_workflow.name
+
+        patch :update, params: params
+
+        config.reload
+        expect(config.release_candidate_workflow.identifier).to eq(original_identifier)
+        expect(config.release_candidate_workflow.name).to eq(original_name)
+      end
+
+      it "applies the edited rollout sequence" do
+        patch :update, params: params
+
+        config.reload
+        expect(config.production_release.submissions.first.rollout_stages).to eq([1.0, 5.0, 10.0, 50.0, 100.0])
+      end
+    end
+  end
+end

--- a/spec/controllers/config/release_platforms_controller_spec.rb
+++ b/spec/controllers/config/release_platforms_controller_spec.rb
@@ -75,6 +75,29 @@ describe Config::ReleasePlatformsController do
         config.reload
         expect(config.production_release.submissions.first.rollout_stages).to eq([1.0, 5.0, 10.0, 50.0, 100.0])
       end
+
+      it "preserves the already-configured internal workflow" do
+        config.update!(
+          internal_workflow: Config::Workflow.new(kind: "internal", name: "Internal Build", identifier: "internal-123"),
+          internal_release: Config::ReleaseStep.new(kind: "internal")
+        )
+
+        patch :update, params: {
+          app_id: app.id,
+          train_id: train.to_param,
+          platform_id: release_platform.platform,
+          config_release_platform: {
+            internal_release_enabled: "true",
+            internal_workflow_attributes: {id: config.internal_workflow.id, identifier: "internal-123"},
+            internal_release_attributes: {id: config.internal_release.id}
+          }
+        }
+
+        expect(flash[:error]).to be_blank
+        config.reload
+        expect(config.internal_workflow.identifier).to eq("internal-123")
+        expect(config.internal_workflow.name).to eq("Internal Build")
+      end
     end
   end
 end


### PR DESCRIPTION
**Closes:** _link the bug issue here once filed_ — Rails 7.2 upgrade regression (no tracking issue linked yet)

## Why

On an app's **Submission Settings** page, editing any field — e.g. the **Rollout sequence** under *Configure Production Release* — and clicking **Save** can fail with a native browser validation bubble on the unrelated **Release Candidate workflow** dropdown: *"Please select an item in the list"* — even though that dropdown has no items to choose from.

This is a regression surfaced by the **Rails 7.1 → 7.2** upgrade. Rails 7.2's `Tags::SelectRenderer#select_content_tag` now promotes `:required`/`:multiple`/`:size` out of the `select` *options* hash into real HTML attributes:

```ruby
[:required, :multiple, :size].each do |prop|
  html_options[prop.to_s] = options.delete(prop) if options.key?(prop) && !html_options.key?(prop.to_s)
end
```

The RC workflow `labeled_select` has passed `{required: true}` in the *options* position for years — a no-op on 7.1, but a live `required` attribute on 7.2. When `@train.workflows` (the CI provider list) comes back empty/stale (a transient API failure or a cached miss), the dropdown renders `required` with no options, so the browser blocks the entire form — and submitting anyway posts a blank identifier that would wipe the configured workflow (`Config::Workflow`'s identifier/name presence validations fail; `WebHandlers::UpdateReleasePlatformConfig#add_workflow_name` also nulls the name when the identifier isn't in the list).

## This addresses

`Config::ReleasePlatformsController#set_ci_actions` now folds the already-configured workflows (RC + internal) into `@ci_actions` whenever the provider list doesn't already include them. The dropdown always keeps a valid selection, the current value round-trips on save, and `add_workflow_name` finds the name. The RC select is also only marked `required` when there is actually something to select (`ci_actions.any?`).

Files changed:
- `app/controllers/config/release_platforms_controller.rb` — `set_ci_actions` + new `with_configured_workflows` helper.
- `app/views/config/release_platforms/_form.html.erb` — `required: true` → `required: ci_actions.any?`.
- `spec/controllers/config/release_platforms_controller_spec.rb` — new regression spec.

## Scenarios tested

- [x] `GET #edit` renders when the CI provider returns no workflows.
- [x] `PATCH #update` saves an edited rollout sequence without wiping the configured RC workflow.
- [x] The already-configured RC workflow is preserved on save.
- [x] The already-configured internal workflow is preserved on save.
- [x] Red→green verified: with the fix reverted, `PATCH #update` fails with *"Release candidate workflow name can't be blank"* and the rollout edit is rolled back.
- [x] New controller spec: 5 examples, 0 failures. Existing `update_release_platform_config_spec`: 23 examples, 0 failures. `rubocop` + `erb_lint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)