### PR TITLE
fix(app_store): consume appVersionState from applelink

### DIFF
--- a/app/libs/concerns/sandboxable.rb
+++ b/app/libs/concerns/sandboxable.rb
@@ -85,7 +85,7 @@ module Sandboxable
 
   def mock_start_app_store_rollout!
     return unless sandbox_mode?
-    update_rollout(mocked_store_info("READY_FOR_SALE", "ACTIVE", 2))
+    update_rollout(mocked_store_info("READY_FOR_DISTRIBUTION", "ACTIVE", 2))
     event_stamp!(reason: :started, kind: :notice, data: stamp_data)
   end
 
@@ -157,7 +157,7 @@ module Sandboxable
 
   def mock_approve_for_app_store!
     return unless sandbox_mode?
-    update_store_info!(mocked_store_info("READY_FOR_SALE", "INACTIVE"))
+    update_store_info!(mocked_store_info("READY_FOR_DISTRIBUTION", "INACTIVE"))
     approve!
   end
 

--- a/app/models/app_store_integration.rb
+++ b/app/models/app_store_integration.rb
@@ -369,10 +369,12 @@ class AppStoreIntegration < ApplicationRecord
 
     attr_reader :release_info
 
-    READY_FOR_SALE = "READY_FOR_SALE"
+    # applelink now reports Apple's appVersionState (appStoreState was deprecated in
+    # App Store Connect API spec 3.3). READY_FOR_SALE -> READY_FOR_DISTRIBUTION, and
+    # the removed-from-sale states no longer exist as version states.
+    READY_FOR_DISTRIBUTION = "READY_FOR_DISTRIBUTION"
     PENDING_DEVELOPER_RELEASE = "PENDING_DEVELOPER_RELEASE"
     DEVELOPER_REJECTED = "DEVELOPER_REJECTED"
-    DEVELOPER_REMOVED_FROM_SALE = "DEVELOPER_REMOVED_FROM_SALE"
     REJECTED = "REJECTED"
     METADATA_REJECTED = "METADATA_REJECTED"
     INVALID_BINARY = "INVALID_BINARY"
@@ -407,7 +409,7 @@ class AppStoreIntegration < ApplicationRecord
     end
 
     def live?(build_number)
-      release_info[:build_number] == build_number && release_info[:status] == READY_FOR_SALE
+      release_info[:build_number] == build_number && release_info[:status] == READY_FOR_DISTRIBUTION
     end
 
     def valid?(build_number, version_name, staged_rollout_enabled)

--- a/spec/fixtures/app_store_connect/live_release.json
+++ b/spec/fixtures/app_store_connect/live_release.json
@@ -1,7 +1,7 @@
 {
   "id": "bd31faa6-6a9a-4958-82de-d271ddc639a8",
   "version_name": "1.8.0",
-  "app_store_state": "READY_FOR_SALE",
+  "app_store_state": "READY_FOR_DISTRIBUTION",
   "release_type": "MANUAL",
   "earliest_release_date": null,
   "downloadable": true,

--- a/spec/fixtures/app_store_connect/release.json
+++ b/spec/fixtures/app_store_connect/release.json
@@ -1,7 +1,7 @@
 {
   "id": "bd31faa6-6a9a-4958-82de-d271ddc639a8",
   "version_name": "1.8.0",
-  "app_store_state": "READY_FOR_SALE",
+  "app_store_state": "READY_FOR_DISTRIBUTION",
   "release_type": "MANUAL",
   "earliest_release_date": null,
   "downloadable": true,

--- a/spec/libs/installations/apple/app_store_connect/api_spec.rb
+++ b/spec/libs/installations/apple/app_store_connect/api_spec.rb
@@ -33,7 +33,7 @@ describe Installations::Apple::AppStoreConnect::Api, type: :integration do
       request = stub_request(:get, url).to_return(body: File.read("spec/fixtures/app_store_connect/release.json"))
       expected_release = {
         external_id: "31aafef2-d5fb-45d4-9b02-f0ab5911c1b2",
-        status: "READY_FOR_SALE",
+        status: "READY_FOR_DISTRIBUTION",
         build_number: "33417",
         name: "1.8.0",
         added_at: "2023-02-26T03:02:46-08:00",
@@ -76,7 +76,7 @@ describe Installations::Apple::AppStoreConnect::Api, type: :integration do
       request = stub_request(:get, url).to_return(body: File.read("spec/fixtures/app_store_connect/release.json"))
       expected_release = {
         external_id: "31aafef2-d5fb-45d4-9b02-f0ab5911c1b2",
-        status: "READY_FOR_SALE",
+        status: "READY_FOR_DISTRIBUTION",
         build_number: "33417",
         name: "1.8.0",
         added_at: "2023-02-26T03:02:46-08:00",
@@ -133,7 +133,7 @@ describe Installations::Apple::AppStoreConnect::Api, type: :integration do
       payload = File.read("spec/fixtures/app_store_connect/release.json")
       expected_release = {
         external_id: "31aafef2-d5fb-45d4-9b02-f0ab5911c1b2",
-        status: "READY_FOR_SALE",
+        status: "READY_FOR_DISTRIBUTION",
         build_number: "33417",
         name: "1.8.0",
         added_at: "2023-02-26T03:02:46-08:00",
@@ -254,7 +254,7 @@ describe Installations::Apple::AppStoreConnect::Api, type: :integration do
 
       expected_release = {
         external_id: "31aafef2-d5fb-45d4-9b02-f0ab5911c1b2",
-        status: "READY_FOR_SALE",
+        status: "READY_FOR_DISTRIBUTION",
         build_number: "33417",
         name: "1.8.0",
         added_at: "2023-02-26T03:02:46-08:00",

--- a/spec/models/app_store_integration_spec.rb
+++ b/spec/models/app_store_integration_spec.rb
@@ -13,7 +13,7 @@ describe AppStoreIntegration do
     let(:live_release_response) {
       {
         external_id: "bd31faa6-6a9a-4958-82de-d271ddc639a8",
-        status: "READY_FOR_SALE",
+        status: "READY_FOR_DISTRIBUTION",
         build_number: "33417",
         name: "1.8.0",
         phased_release_day: 1,

--- a/spec/models/app_store_rollout_spec.rb
+++ b/spec/models/app_store_rollout_spec.rb
@@ -31,7 +31,7 @@ describe AppStoreRollout do
           name: "1.2.0",
           build_number: 9012,
           added_at: 1.day.ago,
-          status: "READY_FOR_SALE",
+          status: "READY_FOR_DISTRIBUTION",
           phased_release_day: 1,
           phased_release_status: "COMPLETE"
         }
@@ -111,7 +111,7 @@ describe AppStoreRollout do
           name: "1.2.0",
           build_number: 9012,
           added_at: 1.day.ago,
-          status: "READY_FOR_SALE",
+          status: "READY_FOR_DISTRIBUTION",
           phased_release_day: 1,
           phased_release_status: "INACTIVE"
         }
@@ -166,7 +166,7 @@ describe AppStoreRollout do
           name: "1.2.0",
           build_number: 9012,
           added_at: 1.day.ago,
-          status: "READY_FOR_SALE",
+          status: "READY_FOR_DISTRIBUTION",
           phased_release_day: 1,
           phased_release_status: "INACTIVE"
         }
@@ -208,7 +208,7 @@ describe AppStoreRollout do
           name: "1.2.0",
           build_number: 9012,
           added_at: 1.day.ago,
-          status: "READY_FOR_SALE",
+          status: "READY_FOR_DISTRIBUTION",
           phased_release_day: 2,
           phased_release_status: "ACTIVE"
         }
@@ -271,7 +271,7 @@ describe AppStoreRollout do
             name: "1.2.0",
             build_number: 9012,
             added_at: 1.day.ago,
-            status: "READY_FOR_SALE",
+            status: "READY_FOR_DISTRIBUTION",
             phased_release_day: 2,
             phased_release_status: "ACTIVE"
           }
@@ -364,7 +364,7 @@ describe AppStoreRollout do
             name: "1.2.0",
             build_number: 9012,
             added_at: 1.day.ago,
-            status: "READY_FOR_SALE",
+            status: "READY_FOR_DISTRIBUTION",
             phased_release_day: 1,
             phased_release_status: "ACTIVE"
           }
@@ -435,7 +435,7 @@ describe AppStoreRollout do
             name: "4.35.0",
             build_number: 15262,
             added_at: 1.day.ago,
-            status: "READY_FOR_SALE",
+            status: "READY_FOR_DISTRIBUTION",
             release_type: "MANUAL",
             phased_release_day: nil,
             phased_release_status: nil
@@ -479,7 +479,7 @@ describe AppStoreRollout do
               name: "1.2.0",
               build_number: 9012,
               added_at: 1.day.ago,
-              status: "READY_FOR_SALE",
+              status: "READY_FOR_DISTRIBUTION",
               phased_release_day: 2,
               phased_release_status: "ACTIVE"
             }
@@ -521,7 +521,7 @@ describe AppStoreRollout do
               name: "1.2.0",
               build_number: 9012,
               added_at: 1.day.ago,
-              status: "READY_FOR_SALE",
+              status: "READY_FOR_DISTRIBUTION",
               phased_release_day: 7,
               phased_release_status: "COMPLETE"
             }

--- a/spec/models/app_store_submission_spec.rb
+++ b/spec/models/app_store_submission_spec.rb
@@ -298,7 +298,7 @@ describe AppStoreSubmission do
     end
 
     it "marks submission as approved if release is live with matching build number" do
-      live_release_info = AppStoreIntegration::AppStoreReleaseInfo.new(base_release_info.merge(status: "READY_FOR_SALE", build_number: build.build_number))
+      live_release_info = AppStoreIntegration::AppStoreReleaseInfo.new(base_release_info.merge(status: "READY_FOR_DISTRIBUTION", build_number: build.build_number))
       allow(providable_dbl).to receive(:find_release).and_return(GitHub::Result.new { live_release_info })
 
       submission.update_external_release
@@ -307,7 +307,7 @@ describe AppStoreSubmission do
     end
 
     it "does not approve submission if release is live but build number does not match" do
-      live_mismatched_release_info = AppStoreIntegration::AppStoreReleaseInfo.new(base_release_info.merge(status: "READY_FOR_SALE", build_number: "mismatched_build"))
+      live_mismatched_release_info = AppStoreIntegration::AppStoreReleaseInfo.new(base_release_info.merge(status: "READY_FOR_DISTRIBUTION", build_number: "mismatched_build"))
       allow(providable_dbl).to receive(:find_release).and_return(GitHub::Result.new { live_mismatched_release_info })
 
       expect { submission.update_external_release }

--- a/spec/models/external_app_spec.rb
+++ b/spec/models/external_app_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe ExternalApp do
         {name: "production",
          releases: [
            {id: "62cdd0b0-19aa-4389-bd4b-4789ccf833f8",
-            status: "READY_FOR_SALE",
+            status: "READY_FOR_DISTRIBUTION",
             build_number: "471281164",
             release_date: "2024-10-15T23:44:11-07:00",
             localizations: [


### PR DESCRIPTION
## What

Lockstep counterpart to **tramlinehq/applelink#47**, which migrates applelink off Apple's deprecated `appStoreState` (ASC API spec 3.3) to [`appVersionState`](https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionstate). **Deploy together.**

The payload keys are unchanged (`status` / `app_store_state`); only the state *vocabulary* changed. For everything tramline consumes, the single meaningful rename is the live state:

`READY_FOR_SALE` → `READY_FOR_DISTRIBUTION`

Every other state we check (`PENDING_DEVELOPER_RELEASE`, `REJECTED`, `INVALID_BINARY`, `METADATA_REJECTED`, `IN_REVIEW`, `WAITING_FOR_REVIEW`, `DEVELOPER_REJECTED`) is identical in the new enum.

## Changes

- `AppStoreReleaseInfo#live?` now matches `READY_FOR_DISTRIBUTION`.
- Removed the dead `DEVELOPER_REMOVED_FROM_SALE` constant — removed-from-sale is no longer a version state; applelink now detects a halted release via app availability.
- Sandbox mocks (`sandboxable.rb`) and the affected specs + fixtures updated to the new value so sandbox mode mirrors production.

## Tests

108 examples across the app-store integration/rollout/submission/api specs pass; rubocop + erb_lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated App Store release status handling to use Apple’s current `READY_FOR_DISTRIBUTION` state.
  - Improved sandboxed App Store workflows to correctly recognize releases ready for distribution.
  - Ensured live-release detection, approvals, rollouts, and release tracking continue working with the updated status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->